### PR TITLE
Use bold instead of arrows to indicate active element of left menus

### DIFF
--- a/src/layout/Menu.jsx
+++ b/src/layout/Menu.jsx
@@ -20,10 +20,10 @@ function MenuItem(props) {
       <motion.h5
         style={{ fontSize: 18 }}
         initial={{ x: 0 }}
-        whileHover={{ x: 5 }}
+        whileHover={{ color: "black", fontWeight: "bold" }}
       >
-        {selected === name && <span style={{ marginRight: 10 }}>&#8594;</span>}
-        {label || name.split(".").pop()}
+        {selected === name && <span style={{ marginRight: 10, color: "black", fontWeight: "bold", textShadow: "0 0 .2px #000" }}>{label}</span>}
+        {selected === name ? "" : label || name.split(".").pop()}
       </motion.h5>
     </motion.div>
   );
@@ -119,12 +119,11 @@ function MenuItemGroup(props) {
       <motion.h5
         onClick={toggleExpanded}
         initial={{ x: 0 }}
-        whileHover={{ x: 5 }}
-        transition={{ duration: 0.25 }}
+        whileHover={{ color: "black", fontWeight: "bold" }}
         style={{ fontSize: 18 }}
       >
-        {selected === name && <span style={{ marginRight: 10 }}>&#8594;</span>}
-        {label || name.split(".").pop()}
+        {selected === name && <span style={{ marginRight: 10, color: "black", fontWeight: "bold", textShadow: "0 0 .2px #000" }}>{label}</span>}
+        {selected === name ? "" : label || name.split(".").pop()}
       </motion.h5>
       {expandedComponentSpace}
     </motion.div>


### PR DESCRIPTION
Fixes #170

1) Parent tabs are now consistently in line with one another.
2) Arrows are removed.
3) Current tabs are now bolded.
4) Hovered tabs are given a light bolding; however, they are not as dark as the current tab.

<img width="316" alt="Screen Shot 2023-01-20 at 4 13 43 PM" src="https://user-images.githubusercontent.com/88756231/213828298-3e7cf6b8-900d-43ff-87bc-89694f89d29f.png">
