### PR TITLE
Issue #249: Extend 404 to policyengine.org/{us,uk}/[bad-url]

### DIFF
--- a/src/PolicyEngine.jsx
+++ b/src/PolicyEngine.jsx
@@ -21,7 +21,7 @@ export default function PolicyEngine() {
         <Route path="/us/*" element={<PolicyEngineCountry countryId="us" />} />
         <Route path="/ca/*" element={<PolicyEngineCountry countryId="ca" />} />
         <Route path="/ng/*" element={<PolicyEngineCountry countryId="ng" />} />
-        <Route exact path="/" element={<Navigate to={`/${countryId}`} />} />
+        <Route path="/*" element={<Navigate to={`/${countryId}`} />} />
       </Routes>
     </Router>
   );

--- a/src/PolicyEngineCountry.jsx
+++ b/src/PolicyEngineCountry.jsx
@@ -6,6 +6,7 @@ import HomePage from "./pages/HomePage";
 import LoadingCentered from "./layout/LoadingCentered";
 import ErrorPage from "./layout/Error";
 import Footer from "./layout/Footer";
+import FOF from "./pages/FOF";
 
 const HouseholdPage = lazy(() => import("./pages/HouseholdPage"));
 const PolicyPage = lazy(() => import("./pages/PolicyPage"));
@@ -143,7 +144,7 @@ export default function PolicyEngineCountry(props) {
 
   let mainPage = (
     <Routes>
-      <Route path="/" element={homePage} />
+      <Route exact path="/" element={homePage} />
       <Route
         path="/household/*"
         element={metadata ? householdPage : error ? errorPage : loadingPage}
@@ -158,6 +159,7 @@ export default function PolicyEngineCountry(props) {
       <Route path="/cec" element={
         <CEC />
       } />
+      <Route path="/*" element={<FOF />} />
     </Routes>
   );
 

--- a/src/pages/FOF.jsx
+++ b/src/pages/FOF.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+/*
+* A 404 page for bad urls.
+*/
+export default function FOF() {
+    return (
+        <div style={{ height: "100%" }}>
+            <p style={{ 
+                marginTop: 180,
+                fontSize: "2em",
+                textAlign: "center"
+            }}>
+                Sorry, we can't find the page you're looking for.
+            </p>
+        </div>
+    )
+}


### PR DESCRIPTION
# New feature/Improvement/Bug fix: Adds 404 redirect for country pages
 
When the user enters a bad url for a country page like `policyengine.org/uk/nonsense`, they will now be redirected to a 404 page. If the user tries to navigate to a non-existent country page, like `policyengine.org/flatland`, they will be redirected to the UK page by default. I used [this PR](https://github.com/PolicyEngine/policyengine/pull/932) from the PolicyEngine repo as a reference. 

Prior to this submission, if you entered a bad country like `policyengine.org/flatland` you would see a blank page with no feedback as to what the user did wrong. I redirect to the UK page because it's simpler then showing the FOF 404 page, given that I would need to either add a header that is conditionally displayed (so `policyengine.org/uk/nonsense` doesn't show 2 headers), or move the header in the country pages up a level.

### Status
* [x]  Cosmetic change
   
* [x]  Screenshots attached
![PolicyEngine](https://user-images.githubusercontent.com/117248915/219034846-d4dc3e39-9cb0-49e8-858e-0a6011077dc6.png)
The url I used here was "policyengine.org/uk/nonsense"

* [ ]  Back-end change
* [ ]  Unintuitive logic commented
* [ ]  Version change   
  * [ ]  Major
  * [ ]  Minor
  * [ ]  Patch
 
### Issues fixed
Closes #249