### PR TITLE
Testimonial Carousel Speed - 10 seconds

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -502,7 +502,7 @@ function Collaborations(props) {
             paddingRight: mobile ? 30 : 300,
           }}
         >
-          <Carousel autoplay>{quoteBlocks}</Carousel>
+          <Carousel autoplay autoplaySpeed={10000}>{quoteBlocks}</Carousel>
         </Row>
         <Row style={{ justifyContent: "center", alignItems: "center" }}>
           {Object.values(orgData[countryId] || {}).map((org) => (


### PR DESCRIPTION
Fixes #194

Because ANTD is based on React Slick, we can use the same properties. 

I currently have the timer set to 10 seconds, but we can extend or shorten it.

https://watch.screencastify.com/v/5IWPs5tEUcj9im5xUhgV