### PR TITLE
Resolve zooming issue in household charts

### DIFF
--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -169,6 +169,7 @@ function BaselineAndReformTogetherChart(props) {
           title: "Employment income",
           ...getPlotlyAxisFormat(metadata.variables.employment_income.unit, 0),
           tickformat: ",.0f",
+          uirevision: metadata.variables.employment_income.unit,
         },
         yaxis: {
           title: capitalize(variableLabel),
@@ -177,6 +178,7 @@ function BaselineAndReformTogetherChart(props) {
             0
           ),
           tickformat: ",.0f",
+          uirevision: metadata.variables.household_net_income.unit,
         },
         legend: {
           // Position above the plot
@@ -261,6 +263,7 @@ function BaselineReformDeltaChart(props) {
           title: "Employment income",
           ...getPlotlyAxisFormat(metadata.variables.employment_income.unit, 0),
           tickformat: ",.0f",
+          uirevision: metadata.variables.employment_income.unit,
         },
         yaxis: {
           title: `Change in ${variableLabel}`,
@@ -271,6 +274,7 @@ function BaselineReformDeltaChart(props) {
             metadata.variables[variable].valueType
           ),
           tickformat: ",.0f",
+          uirevision: metadata.variables[variable].unit,
         },
         legend: {
           // Position above the plot

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -87,6 +87,7 @@ export default function BaselineOnlyChart(props) {
             title: "Employment income",
             ...getPlotlyAxisFormat(metadata.variables.employment_income.unit),
             tickformat: ",.0f",
+            uirevision: metadata.variables.employment_income.unit,
           },
           yaxis: {
             title: {
@@ -99,6 +100,7 @@ export default function BaselineOnlyChart(props) {
               metadata.variables[variable].valueType
             ),
             tickformat: ",.0f",
+            uirevision: metadata.variables[variable].unit,
           },
           legend: {
             // Position above the plot


### PR DESCRIPTION
Fixes issue #297.

Previously, zooming into a chart and hovering over the line caused the entire Plot component to re-render, resetting the  view back to the default zoom. By utilizing `uirevision` based on this [SO discusion](https://stackoverflow.com/questions/63519850/plotly-react-keep-zoom-and-rotation-between-re-rendering), the charts are able to keep their zoomed in view while hovering over the plot lines. 

![Screen Recording 2023-03-07 at 1 40 44 PM](https://user-images.githubusercontent.com/69769431/223559655-28bc4782-4e1a-46ef-8f96-212340c0339b.gif)
