### PR TITLE
Compare use of hovertemplate instead of custom Hovercard

### DIFF
--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -137,7 +137,10 @@ function BaselineAndReformTogetherChart(props) {
       line: {
         color: style.colors.MEDIUM_DARK_GRAY,
       },
-      hoverinfo:"none",
+      // hoverinfo:"none",
+      hovertemplate: `<b>Baseline ${variableLabel}</b><br><br>` +
+                      `If you earn %{x}, your` +
+                      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
     },
     {
       x: earningsArray,
@@ -147,7 +150,10 @@ function BaselineAndReformTogetherChart(props) {
       line: {
         color: style.colors.BLUE,
       },
-      hoverinfo:"none",
+      // hoverinfo:"none",
+      hovertemplate: `<b>Reform ${variableLabel}</b><br><br>` +
+                      `If you earn %{x}, your` +
+                      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
     },
     {
       x: [currentEarnings, currentEarnings],
@@ -157,7 +163,10 @@ function BaselineAndReformTogetherChart(props) {
       line: {
         color: style.colors.MEDIUM_DARK_GRAY,
       },
-      hoverinfo:"none",
+      // hoverinfo:"none",
+      hovertemplate: `<b>Your current ${variableLabel}</b><br><br>` +
+                      `If you earn %{x}, your` +
+                      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
     },
   ];
   const plotObject = (
@@ -180,6 +189,7 @@ function BaselineAndReformTogetherChart(props) {
           tickformat: ",.0f",
           uirevision: metadata.variables.household_net_income.unit,
         },
+        hoverlabel: { bgcolor: "#FFF", font: {size: "16"} },
         legend: {
           // Position above the plot
           y: 1.2,
@@ -215,8 +225,8 @@ function BaselineAndReformTogetherChart(props) {
       }}
     />
   );
-
-  return <HoverCard content={hovercard}><FadeIn>{plotObject}</FadeIn></HoverCard>;
+  return plotObject
+  // return <HoverCard content={hovercard}><FadeIn>{plotObject}</FadeIn></HoverCard>;
 }
 
 function BaselineReformDeltaChart(props) {
@@ -241,7 +251,10 @@ function BaselineReformDeltaChart(props) {
       line: {
         color: style.colors.BLUE,
       },
-      hoverinfo:"none",
+      // hoverinfo:"none",
+      hovertemplate: `<b>Change in ${variableLabel}</b><br><br>` +
+      `If you earn %{x}, your` +
+      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
     },
     {
       x: [currentEarnings, currentEarnings],
@@ -251,7 +264,10 @@ function BaselineReformDeltaChart(props) {
       line: {
         color: style.colors.MEDIUM_DARK_GRAY,
       },
-      hoverinfo:"none",
+      // hoverinfo:"none",
+      hovertemplate: `<b>Your current ${variableLabel}</b><br><br>` +
+      `If you earn %{x}, your` +
+      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
     },
   ];
   const plotObject = (
@@ -276,6 +292,7 @@ function BaselineReformDeltaChart(props) {
           tickformat: ",.0f",
           uirevision: metadata.variables[variable].unit,
         },
+        hoverlabel: { bgcolor: "#FFF", font: {size: "16"} },
         legend: {
           // Position above the plot
           y: 1.2,
@@ -306,5 +323,6 @@ function BaselineReformDeltaChart(props) {
     />
   );
 
-  return <HoverCard content={hovercard}><FadeIn>{plotObject}</FadeIn></HoverCard>;
+  return plotObject
+  // return <HoverCard content={hovercard}><FadeIn>{plotObject}</FadeIn></HoverCard>;
 }

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -172,7 +172,6 @@ function BaselineAndReformTogetherChart(props) {
           title: "Employment income",
           ...getPlotlyAxisFormat(metadata.variables.employment_income.unit, 0),
           tickformat: ",.0f",
-          uirevision: metadata.variables.employment_income.unit,
         },
         yaxis: {
           title: capitalize(variableLabel),
@@ -181,7 +180,6 @@ function BaselineAndReformTogetherChart(props) {
             0
           ),
           tickformat: ",.0f",
-          uirevision: metadata.variables.household_net_income.unit,
         },
         hoverlabel: { bgcolor: "#FFF", font: {size: "16"} },
         legend: {
@@ -250,7 +248,6 @@ function BaselineReformDeltaChart(props) {
           title: "Employment income",
           ...getPlotlyAxisFormat(metadata.variables.employment_income.unit, 0),
           tickformat: ",.0f",
-          uirevision: metadata.variables.employment_income.unit,
         },
         yaxis: {
           title: `Change in ${variableLabel}`,
@@ -261,7 +258,6 @@ function BaselineReformDeltaChart(props) {
             metadata.variables[variable].valueType
           ),
           tickformat: ",.0f",
-          uirevision: metadata.variables[variable].unit,
         },
         hoverlabel: { bgcolor: "#FFF", font: {size: "16"} },
         legend: {

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -136,7 +136,7 @@ function BaselineAndReformTogetherChart(props) {
       },
       hovertemplate: `<b>Baseline ${variableLabel}</b><br><br>` +
                       `If you earn %{x}, your` +
-                      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
+                      `<br>${variableLabel} will be %{y}.<extra></extra>`
     },
     {
       x: earningsArray,
@@ -148,7 +148,7 @@ function BaselineAndReformTogetherChart(props) {
       },
       hovertemplate: `<b>Reform ${variableLabel}</b><br><br>` +
                       `If you earn %{x}, your` +
-                      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
+                      `<br>${variableLabel} will be %{y}.<extra></extra>`
     },
     {
       x: [currentEarnings, currentEarnings],
@@ -160,7 +160,7 @@ function BaselineAndReformTogetherChart(props) {
       },
       hovertemplate: `<b>Your current ${variableLabel}</b><br><br>` +
                       `If you earn %{x}, your` +
-                      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
+                      `<br>${variableLabel} will be %{y}.<extra></extra>`
     },
   ];
   const plotObject = (
@@ -224,7 +224,7 @@ function BaselineReformDeltaChart(props) {
       },
       hovertemplate: `<b>Change in ${variableLabel}</b><br><br>` +
                       `If you earn %{x}, your` +
-                      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
+                      `<br>${variableLabel} will be %{y}.<extra></extra>`
     },
     {
       x: [currentEarnings, currentEarnings],
@@ -236,7 +236,7 @@ function BaselineReformDeltaChart(props) {
       },
       hovertemplate: `<b>Your current ${variableLabel}</b><br><br>` +
                       `If you earn %{x}, your` +
-                      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
+                      `<br>${variableLabel} will be %{y}.<extra></extra>`
     },
   ];
   const plotObject = (

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -10,8 +10,6 @@ import {
 import FadeIn from "../../../../layout/FadeIn";
 import style from "../../../../style";
 import { getCliffs } from "./cliffs";
-import HoverCard from "../../../../layout/HoverCard";
-import { convertToCurrencyString } from "./convertToCurrencyString";
 
 export default function BaselineAndReformChart(props) {
   const {
@@ -121,7 +119,6 @@ function BaselineAndReformTogetherChart(props) {
     metadata,
     variable,
   } = props;
-  const [hovercard, setHoverCard] = useState(null);
   let data = [
     ...(variable === "household_net_income"
       ? getCliffs(baselineArray, earningsArray)
@@ -137,7 +134,6 @@ function BaselineAndReformTogetherChart(props) {
       line: {
         color: style.colors.MEDIUM_DARK_GRAY,
       },
-      // hoverinfo:"none",
       hovertemplate: `<b>Baseline ${variableLabel}</b><br><br>` +
                       `If you earn %{x}, your` +
                       `<br>${variableLabel} will be %{y}.</br><extra></extra>`
@@ -150,7 +146,6 @@ function BaselineAndReformTogetherChart(props) {
       line: {
         color: style.colors.BLUE,
       },
-      // hoverinfo:"none",
       hovertemplate: `<b>Reform ${variableLabel}</b><br><br>` +
                       `If you earn %{x}, your` +
                       `<br>${variableLabel} will be %{y}.</br><extra></extra>`
@@ -163,7 +158,6 @@ function BaselineAndReformTogetherChart(props) {
       line: {
         color: style.colors.MEDIUM_DARK_GRAY,
       },
-      // hoverinfo:"none",
       hovertemplate: `<b>Your current ${variableLabel}</b><br><br>` +
                       `If you earn %{x}, your` +
                       `<br>${variableLabel} will be %{y}.</br><extra></extra>`
@@ -204,29 +198,9 @@ function BaselineAndReformTogetherChart(props) {
       style={{
         width: "100%",
       }}
-      onHover={(data) => {
-        if (data.points[0].x !== undefined && data.points[0].y !== undefined) {
-          const variableLabelAmount = convertToCurrencyString(metadata.currency, data.points[0].y)
-          const employmentIncome = convertToCurrencyString(metadata.currency, data.points[0].x)
-          const message = `If you earn ${employmentIncome}, your reform ${variableLabel} will be ${variableLabelAmount}.`
-          setHoverCard({
-            title: data.points[0].data.name,
-            body: message,
-          });
-        } else {
-          setHoverCard({ 
-            title: data.points[0].data.name,
-            body: `Your net income falls after earning 
-              ${convertToCurrencyString(metadata.currency, Math.min(...data.points[0].data.x))} until earning 
-              ${convertToCurrencyString(metadata.currency, Math.max(...data.points[0].data.x))} in the 
-              ${data.points[0].data.name.includes('reform') ? 'reform' : 'baseline'} scenario.`
-          })
-        }
-      }}
     />
   );
-  return plotObject
-  // return <HoverCard content={hovercard}><FadeIn>{plotObject}</FadeIn></HoverCard>;
+  return <FadeIn>{plotObject}</FadeIn>;
 }
 
 function BaselineReformDeltaChart(props) {
@@ -241,7 +215,6 @@ function BaselineReformDeltaChart(props) {
     metadata,
     variable,
   } = props;
-  const [hovercard, setHoverCard] = useState(null);
   let data = [
     {
       x: earningsArray,
@@ -251,10 +224,9 @@ function BaselineReformDeltaChart(props) {
       line: {
         color: style.colors.BLUE,
       },
-      // hoverinfo:"none",
       hovertemplate: `<b>Change in ${variableLabel}</b><br><br>` +
-      `If you earn %{x}, your` +
-      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
+                      `If you earn %{x}, your` +
+                      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
     },
     {
       x: [currentEarnings, currentEarnings],
@@ -264,10 +236,9 @@ function BaselineReformDeltaChart(props) {
       line: {
         color: style.colors.MEDIUM_DARK_GRAY,
       },
-      // hoverinfo:"none",
       hovertemplate: `<b>Your current ${variableLabel}</b><br><br>` +
-      `If you earn %{x}, your` +
-      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
+                      `If you earn %{x}, your` +
+                      `<br>${variableLabel} will be %{y}.</br><extra></extra>`
     },
   ];
   const plotObject = (
@@ -309,20 +280,8 @@ function BaselineReformDeltaChart(props) {
       style={{
         width: "100%",
       }}
-      onHover={(data) => {
-        if (data.points[0].x !== undefined && data.points[0].y !== undefined) {
-          const variableLabelAmount = convertToCurrencyString(metadata.currency, data.points[0].y)
-          const employmentIncome = convertToCurrencyString(metadata.currency, data.points[0].x)
-          const message = `If you earn ${employmentIncome}, your change in ${variableLabel} will be ${variableLabelAmount}.`
-          setHoverCard({
-            title: data.points[0].data.name,
-            body: message,
-          });
-        }
-      }}
     />
   );
 
-  return plotObject
-  // return <HoverCard content={hovercard}><FadeIn>{plotObject}</FadeIn></HoverCard>;
+  return <FadeIn>{plotObject}</FadeIn>;
 }

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -86,7 +86,6 @@ export default function BaselineOnlyChart(props) {
             title: "Employment income",
             ...getPlotlyAxisFormat(metadata.variables.employment_income.unit),
             tickformat: ",.0f",
-            uirevision: metadata.variables.employment_income.unit,
           },
           yaxis: {
             title: {
@@ -99,7 +98,6 @@ export default function BaselineOnlyChart(props) {
               metadata.variables[variable].valueType
             ),
             tickformat: ",.0f",
-            uirevision: metadata.variables[variable].unit,
           },
           hoverlabel: { bgcolor: "#FFF", font: {size: "16"} },
           legend: {

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../../api/charts";
 import { capitalize } from "../../../../api/language";
@@ -9,9 +8,6 @@ import {
 import FadeIn from "../../../../layout/FadeIn";
 import style from "../../../../style";
 import { getCliffs } from "./cliffs";
-import HoverCard from "../../../../layout/HoverCard";
-
-import { convertToCurrencyString } from "./convertToCurrencyString";
 
 export default function BaselineOnlyChart(props) {
   const {
@@ -21,7 +17,6 @@ export default function BaselineOnlyChart(props) {
     variable,
     variableLabel,
   } = props;
-  const [hovercard, setHoverCard] = useState(null);
 
   const earningsArray = getValueFromHousehold(
     "employment_income",
@@ -69,7 +64,6 @@ export default function BaselineOnlyChart(props) {
             line: {
               color: style.colors.BLUE,
             },
-            // hoverinfo: "none",
             hovertemplate: `<b>${capitalize(variableLabel)}</b><br><br>` +
                             `If you earn %{x}, your` +
                             `<br>${variableLabel} will be %{y}.</br><extra></extra>`
@@ -82,7 +76,6 @@ export default function BaselineOnlyChart(props) {
             line: {
               color: style.colors.MEDIUM_DARK_GRAY,
             },
-            // hoverinfo: "none",
             hovertemplate: `<b>Your current ${variableLabel}</b><br><br>` +
                             `If you earn %{x}, your` +
                             `<br>${variableLabel} will be %{y}.</br><extra></extra>`
@@ -126,27 +119,10 @@ export default function BaselineOnlyChart(props) {
         style={{
           width: "100%",
         }}
-        onHover={(data) => {
-          if (data.points[0].x !== undefined && data.points[0].y !== undefined) {
-            const variableLabelAmount = convertToCurrencyString(metadata.currency, data.points[0].y)
-            const employmentIncome = convertToCurrencyString(metadata.currency, data.points[0].x)
-            const message = `If you earn ${employmentIncome}, your ${variableLabel} will be ${variableLabelAmount}.`
-            setHoverCard({
-              title: data.points[0].data.name,
-              body: message,
-            });
-          } else {
-            setHoverCard({ 
-              title: data.points[0].data.name,
-              body: `Your net income falls after earning 
-                ${convertToCurrencyString(metadata.currency, Math.min(...data.points[0].data.x))} until earning 
-                ${convertToCurrencyString(metadata.currency, Math.max(...data.points[0].data.x))}.`
-            })
-          }
-        }}
       />
     </FadeIn>
   );
+  
   return plot
-  // return <HoverCard content={hovercard}>{plot}</HoverCard>
+
 }

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -66,7 +66,7 @@ export default function BaselineOnlyChart(props) {
             },
             hovertemplate: `<b>${capitalize(variableLabel)}</b><br><br>` +
                             `If you earn %{x}, your` +
-                            `<br>${variableLabel} will be %{y}.</br><extra></extra>`
+                            `<br>${variableLabel} will be %{y}.<extra></extra>`
           },
           {
             x: [currentEarnings, currentEarnings],
@@ -78,7 +78,7 @@ export default function BaselineOnlyChart(props) {
             },
             hovertemplate: `<b>Your current ${variableLabel}</b><br><br>` +
                             `If you earn %{x}, your` +
-                            `<br>${variableLabel} will be %{y}.</br><extra></extra>`
+                            `<br>${variableLabel} will be %{y}.<extra></extra>`
           },
         ]}
         layout={{

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -70,6 +70,9 @@ export default function BaselineOnlyChart(props) {
               color: style.colors.BLUE,
             },
             hoverinfo: "none",
+            // hovertemplate: `<b>${capitalize(variableLabel)}</b><br><br>` +
+            //                 `If you earn %{x}, your` +
+            //                 `<br>${variableLabel} will be %{y}.</br><extra></extra>`
           },
           {
             x: [currentEarnings, currentEarnings],
@@ -80,6 +83,9 @@ export default function BaselineOnlyChart(props) {
               color: style.colors.MEDIUM_DARK_GRAY,
             },
             hoverinfo: "none",
+            // hovertemplate: `<b>Your current ${variableLabel}</b><br><br>` +
+            //                 `If you earn %{x}, your` +
+            //                 `<br>${variableLabel} will be %{y}.</br><extra></extra>`
           },
         ]}
         layout={{
@@ -102,6 +108,7 @@ export default function BaselineOnlyChart(props) {
             tickformat: ",.0f",
             uirevision: metadata.variables[variable].unit,
           },
+          hoverlabel: { bgcolor: "#FFF", font: {size: "16"} },
           legend: {
             // Position above the plot
             y: 1.2,
@@ -140,5 +147,6 @@ export default function BaselineOnlyChart(props) {
       />
     </FadeIn>
   );
+  // return plot
   return <HoverCard content={hovercard}>{plot}</HoverCard>
 }

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -69,10 +69,10 @@ export default function BaselineOnlyChart(props) {
             line: {
               color: style.colors.BLUE,
             },
-            hoverinfo: "none",
-            // hovertemplate: `<b>${capitalize(variableLabel)}</b><br><br>` +
-            //                 `If you earn %{x}, your` +
-            //                 `<br>${variableLabel} will be %{y}.</br><extra></extra>`
+            // hoverinfo: "none",
+            hovertemplate: `<b>${capitalize(variableLabel)}</b><br><br>` +
+                            `If you earn %{x}, your` +
+                            `<br>${variableLabel} will be %{y}.</br><extra></extra>`
           },
           {
             x: [currentEarnings, currentEarnings],
@@ -82,10 +82,10 @@ export default function BaselineOnlyChart(props) {
             line: {
               color: style.colors.MEDIUM_DARK_GRAY,
             },
-            hoverinfo: "none",
-            // hovertemplate: `<b>Your current ${variableLabel}</b><br><br>` +
-            //                 `If you earn %{x}, your` +
-            //                 `<br>${variableLabel} will be %{y}.</br><extra></extra>`
+            // hoverinfo: "none",
+            hovertemplate: `<b>Your current ${variableLabel}</b><br><br>` +
+                            `If you earn %{x}, your` +
+                            `<br>${variableLabel} will be %{y}.</br><extra></extra>`
           },
         ]}
         layout={{
@@ -147,6 +147,6 @@ export default function BaselineOnlyChart(props) {
       />
     </FadeIn>
   );
-  // return plot
-  return <HoverCard content={hovercard}>{plot}</HoverCard>
+  return plot
+  // return <HoverCard content={hovercard}>{plot}</HoverCard>
 }

--- a/src/pages/household/output/EarningsVariation/cliffs.jsx
+++ b/src/pages/household/output/EarningsVariation/cliffs.jsx
@@ -1,6 +1,7 @@
 import style from "../../../../style";
+import { convertToCurrencyString } from "./convertToCurrencyString";
 
-export function getCliffs(netIncomeArray, earningsArray, isReform = false) {
+export function getCliffs(netIncomeArray, earningsArray, isReform = false, currency = "$") {
   // Return a list of [(start, end), ...] where the net income does not increase
   if (!netIncomeArray || !earningsArray) return [];
   let cliffs = [];
@@ -30,7 +31,11 @@ export function getCliffs(netIncomeArray, earningsArray, isReform = false) {
       mode: "lines",
       fillcolor: style.colors.DARK_GRAY,
       name: `Cliff ${i + 1}${isReform ? " (reform)" : ""}`,
-      text: "",
+      text: `<b>Cliff ${i + 1}${isReform ? " (reform)" : ""}</b><br><br>` +
+            `Your net income falls after earning ` + 
+            `${convertToCurrencyString(currency, points[0])}<br>` +
+            `until earning ${convertToCurrencyString(currency, points[1])} ` +
+            `in the ${isReform ? "reform" : "baseline"} scenario.`,
       opacity: 0.1,
       line_width: 0,
       showlegend: true,
@@ -38,7 +43,8 @@ export function getCliffs(netIncomeArray, earningsArray, isReform = false) {
       line: {
         color: style.colors.DARK_GRAY,
       },
-      hoverinfo: "none"
+      hoverinfo: "text",
+      // hoverinfo: "none",
     };
   });
 }

--- a/src/pages/household/output/EarningsVariation/cliffs.jsx
+++ b/src/pages/household/output/EarningsVariation/cliffs.jsx
@@ -44,7 +44,6 @@ export function getCliffs(netIncomeArray, earningsArray, isReform = false, curre
         color: style.colors.DARK_GRAY,
       },
       hoverinfo: "text",
-      // hoverinfo: "none",
     };
   });
 }


### PR DESCRIPTION
Explored the use of plotly's `hovertemplate` property for creating custom hover labels on the Household charts.

![Hovertemplate hover labels](https://user-images.githubusercontent.com/69769431/223966683-363457b3-b0f8-4dd4-b2db-b3a2d227648e.gif)

One drawback to using `hovertemplate` is that the [styling options](https://plotly.com/javascript/reference/layout/#layout-hoverlabel) are more limited.