### PR TITLE
Fix some input numbers being formatted as $012000 instead of $12,000 in net income table

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -163,6 +163,7 @@ function HouseholdVariableEntityInput(props) {
     setEdited,
   } = props;
   const submitValue = (value) => {
+    value = Number.isNaN(+value) ? value : +value
     let newHousehold = JSON.parse(JSON.stringify(householdInput));
     newHousehold[entityPlural][entityName][variable.name][timePeriod] = value;
     setHouseholdInput(newHousehold);


### PR DESCRIPTION
Fixes #129.

Previously, inputs for income were being submitted as a type `string`. By changing the submitted value to a valid type `number`, this enables the Net Income output page to properly display the income amounts as a converted currency string. 

![image](https://user-images.githubusercontent.com/69769431/224222427-c727f064-e763-4e3f-bef8-beab500749c3.png)


