### PR TITLE
Fix Issue 314: Reproduce in Python doesn't capture US state

### DIFF
--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -509,7 +509,7 @@ export function optimiseHousehold(household, metadata, removeEmpty = false) {
           household[entityPlural][entityName][variable]
         )) {
           let variableData = newHousehold[entityPlural][entityName][variable];
-          if (variable === "members") {
+          if (variable === "members" || variable === "state_name") {
             continue;
           }
           let defaultValue = metadata.variables[variable].defaultValue;

--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -509,7 +509,7 @@ export function optimiseHousehold(household, metadata, removeEmpty = false) {
           household[entityPlural][entityName][variable]
         )) {
           let variableData = newHousehold[entityPlural][entityName][variable];
-          if (variable === "members" || variable === "state_name") {
+          if (variable === "members" || metadata.basicInputs.includes(variable)) {
             continue;
           }
           let defaultValue = metadata.variables[variable].defaultValue;


### PR DESCRIPTION
Fixes #314.

The `optimiseHousehold` function removes extraneous object keys that already exist in the metadata, allowing for the `Reproduce in Python` page to only have the unique inputs required to replicate the results. 

However, the `state_name` property in the metadata has a `defaultValue` value of `CA` and an `isInputVariable` value of `false`. This caused the `optimiseHousehold` function to remove `state_name` from the final returned object. To avoid this without any major changes to the function inputs, I made a change similar to how the `members` variable is handled. 

```
if (variable === "members" || variable === "state_name")
```

With this change, the `state_name` property is included as a value in the `households` key.
```
//...
situation = {
  //...
  "households": {
    "your household": {
      "members": [
        "you"
      ],
      "state_name": {
        "2023": "AK"
      }
    }
  }
}
//...
```
