### PR TITLE
Issue 324: DISABLE_ESLINT_PLUGIN in package.json for Windows users

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react", "react-hooks", "jest"],
+  "plugins": ["react", "react-hooks", "jest", "jsx-a11y"],
   "rules": {
     // suppress errors for missing 'import React' in files
     "react/react-in-jsx-scope": "off",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "workbox-streams": "^6.5.4"
   },
   "scripts": {
-    "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",
-    "build": "DISABLE_ESLINT_PLUGIN=true react-scripts build",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "node_modules/.bin/eslint src/**/*.js src/**/*.jsx"

--- a/src/pages/household/input/CountChildren.jsx
+++ b/src/pages/household/input/CountChildren.jsx
@@ -197,7 +197,8 @@ export default function CountChildren(props) {
       title={`How many ${
         metadata.countryId !== "us" ? "children" : "dependents"
       } do you have?`}
-      children={radioButtonComponent}
-    />
+    >
+      {radioButtonComponent}
+    </CenteredMiddleColumn>
   );
 }

--- a/src/pages/household/input/MaritalStatus.jsx
+++ b/src/pages/household/input/MaritalStatus.jsx
@@ -146,14 +146,11 @@ export default function MaritalStatus(props) {
     />
   );
   return (
-    <CenteredMiddleColumn
-      title="What is your marital status?"
-      children={
-        <>
-          {radioButtonComponent}
-          <NavigationButton text="Enter" focus="input.household.children" />
-        </>
-      }
-    />
+    <CenteredMiddleColumn title="What is your marital status?">
+      <>
+        {radioButtonComponent}
+        <NavigationButton text="Enter" focus="input.household.children" />
+      </>
+    </CenteredMiddleColumn>
   );
 }

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -84,8 +84,8 @@ export default function VariableEditor(props) {
         </h4>
         {isSimulated && (
           <p style={{ textAlign: "center" }}>
-            This variable is calculated from other variables you've entered.
-            Editing it will override the simulated value.
+            This variable is calculated from other variables you&apos;ve
+            entered. Editing it will override the simulated value.
           </p>
         )}
         {entityInputs}
@@ -163,7 +163,7 @@ function HouseholdVariableEntityInput(props) {
     setEdited,
   } = props;
   const submitValue = (value) => {
-    value = Number.isNaN(+value) ? value : +value
+    value = Number.isNaN(+value) ? value : +value;
     let newHousehold = JSON.parse(JSON.stringify(householdInput));
     newHousehold[entityPlural][entityName][variable.name][timePeriod] = value;
     setHouseholdInput(newHousehold);

--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -100,7 +100,7 @@ export default function AverageImpactByDecile(props) {
         <h2>
           {policyLabel}{" "}
           {averageChange >= 0 ? "would increase" : "would decrease"} the average
-          household's net income by{" "}
+          household&apos;s net income by{" "}
           {formatVariableValue(
             metadata.variables.household_net_income,
             Math.abs(averageChange),

--- a/src/pages/policy/output/AverageImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByWealthDecile.jsx
@@ -100,7 +100,7 @@ export default function AverageImpactByWealthDecile(props) {
         <h2>
           {policyLabel}{" "}
           {averageChange >= 0 ? "would increase" : "would decrease"} the average
-          household's net income by{" "}
+          household&apos;s net income by{" "}
           {formatVariableValue(
             metadata.variables.household_net_income,
             Math.abs(averageChange),

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -16,7 +16,7 @@ import CliffImpact from "./CliffImpact";
 import BottomCarousel from "../../../layout/BottomCarousel";
 import getPolicyOutputTree from "./tree";
 import InequalityImpact from "./InequalityImpact";
-import { Dropdown, Result, Select, Steps } from "antd";
+import { Result, Steps } from "antd";
 import { CheckCircleFilled, CloseCircleFilled } from "@ant-design/icons";
 import useMobile from "../../../layout/Responsive";
 import PolicyImpactPopup from "../../household/output/PolicyImpactPopup";
@@ -342,15 +342,16 @@ export default function PolicyOutput(props) {
 
   const bottomElements = mobile ? null : metadata.countryId === "us" ? (
     <p>
-      PolicyEngine US v{selectedVersion} estimates reform impacts using a static microsimulation over
-      the 2021 Current Population Survey March Supplement.{" "}
+      PolicyEngine US v{selectedVersion} estimates reform impacts using a static
+      microsimulation over the 2021 Current Population Survey March Supplement.{" "}
       <a href="/us/blog/2022-12-28-enhancing-the-current-population-survey-for-policy-analysis">
         Read our caveats and data enhancement plan.
       </a>
     </p>
   ) : (
     <p>
-      PolicyEngine UK v{selectedVersion} estimates reform impacts using a static microsimulation over{" "}
+      PolicyEngine UK v{selectedVersion} estimates reform impacts using a static
+      microsimulation over{" "}
       <a href="/uk/blog/2022-03-07-how-machine-learning-tools-make-policyengine-more-accurate">
         an enhanced version of the 2019 Family Resources Survey
       </a>

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -34,10 +34,11 @@ function PythonCodeBlock({ lines }) {
       >
         {lines.map((line, i) => {
           if (line === "") {
-            return <div style={{ paddingTop: 15 }} />;
+            return <div key={i} style={{ paddingTop: 15 }} />;
           } else {
             return (
               <p
+                key={i}
                 style={{
                   color: style.colors.WHITE,
                   fontFamily: "monospace",

--- a/src/pages/policy/output/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByDecile.jsx
@@ -96,7 +96,7 @@ export default function RelativeImpactByDecile(props) {
         <h2>
           {policyLabel}{" "}
           {averageRelChange >= 0 ? "would increase" : "would decrease"} the
-          average household's net income by{" "}
+          average household&apos;s net income by{" "}
           {formatVariableValue({ unit: "/1" }, Math.abs(averageRelChange), 1)}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>

--- a/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
@@ -96,7 +96,7 @@ export default function RelativeImpactByWealthDecile(props) {
         <h2>
           {policyLabel}{" "}
           {averageRelChange >= 0 ? "would increase" : "would decrease"} the
-          average household's net income by{" "}
+          average household&apos;s net income by{" "}
           {formatVariableValue({ unit: "/1" }, Math.abs(averageRelChange), 1)}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>


### PR DESCRIPTION
Fixes #324 

### What does `DISABLE_ESLINT_PLUGIN` do anyway?
This variable stops the linter from running when executing an npm command. When I initially added this variable in PR #290, the project wasn't completely linted and there were too many errors to tackle everything in one go. The linter would run `npm run build` on CI and fail.

### Fixing the remaining linter errors
This submission cleans up the remaining linter errors in the project, so I can remove the `DISABLE_ESLINT_PLUGIN` and have the linter successfully run on CI.