### PR TITLE
Drop modify_parameters and reform if no reform

### DIFF
--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -69,7 +69,8 @@ export function getReformDefinitionCode(metadata, policy) {
   ];
 
   if (Object.keys(policy.reform.data).length === 0) {
-    lines.push("    pass");
+    lines.pop();
+    return lines;
   }
 
   for (const [parameterName, parameter] of Object.entries(policy.reform.data)) {


### PR DESCRIPTION
Fix #115.

If no reform is provided, this change removes the `modify_parameters(parameters)` line from the Python block and returns the function before adding the strings for `class reform(Reform)`. 

![image](https://user-images.githubusercontent.com/69769431/225826000-224ac136-94b0-450c-a802-b0bfc1021f8b.png)

