### PR TITLE
Fix input field bug

### DIFF
--- a/src/controls/InputField.jsx
+++ b/src/controls/InputField.jsx
@@ -63,7 +63,7 @@ export default function InputField(props) {
               e.target.value.length - 1
             );
           }
-        }else{
+        } else if (pattern === "number") {
           if (value !== '' && !re.test(value)) {
             const val = value.replace(/[^\d.]+/g, '');
             e.target.value = val.includes('.') ? parseFloat(val) : val;


### PR DESCRIPTION
I noticed the policy labeller wasn't accepting any inputs, so I just added a quick fix that enables strings by default unless the pattern is specified as `number`. Sorry @DeepthiSRao this might have affected the non-percentage inputs with the feature you added, would you mind taking a look at how we can have both the policy labeller and the non-pct numeric inputs both filtering respective inputs? Thanks- and happy to debug stuff too!