### PR TITLE
Fix issue 342: Cliff shading height

### DIFF
--- a/src/pages/household/output/EarningsVariation/cliffs.jsx
+++ b/src/pages/household/output/EarningsVariation/cliffs.jsx
@@ -1,5 +1,7 @@
 import style from "../../../../style";
 
+const ROUNDING_FACTOR = 100000;
+
 export function getCliffs(netIncomeArray, earningsArray, isReform = false) {
   // Return a list of [(start, end), ...] where the net income does not increase
   if (!netIncomeArray || !earningsArray) return [];
@@ -22,10 +24,13 @@ export function getCliffs(netIncomeArray, earningsArray, isReform = false) {
     }
   }
 
+  const maxNetIncome = Math.max(...netIncomeArray);
+  const maxCliffShadingHeight = Math.ceil(maxNetIncome / ROUNDING_FACTOR) * ROUNDING_FACTOR; 
+
   return cliffs.map((points, i) => {
     return {
       x: [points[0], points[0], points[1], points[1], points[0]],
-      y: [0, 200_000, 200_000, 0, 0],
+      y: [0, maxCliffShadingHeight, maxCliffShadingHeight, 0, 0],
       fill: "toself",
       mode: "lines",
       fillcolor: style.colors.DARK_GRAY,


### PR DESCRIPTION
Fixes #342.

Previously, the height of the cliff shading was hardcoded to go up to `200,000`. This PR updates the max shading height to be the ceiling of the net income array rounded up to the nearest `100,000`.

![household=16193](https://user-images.githubusercontent.com/69769431/226448342-868878de-3c11-46a4-8884-adab467ad52b.png)
