### PR TITLE
Fix Issue 341: Display changes to MTR when there are changes

### DIFF
--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -526,3 +526,21 @@ export function optimiseHousehold(household, metadata, removeEmpty = false) {
   }
   return newHousehold;
 }
+
+export function findEarningsIndex(earningsArray, currentEarnings) {
+  let left = 0;
+  let right = earningsArray.length - 1;
+
+  while (left <= right) {
+    let middle = Math.floor(left + right) / 2;
+    if (earningsArray[middle] === currentEarnings) {
+      return middle;
+    }
+    if (earningsArray[middle] > currentEarnings) {
+      right = middle - 1;
+    } else {
+      left = middle + 1;
+    }
+  }
+  return 0;
+}

--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -526,21 +526,3 @@ export function optimiseHousehold(household, metadata, removeEmpty = false) {
   }
   return newHousehold;
 }
-
-export function findEarningsIndex(earningsArray, currentEarnings) {
-  let left = 0;
-  let right = earningsArray.length - 1;
-
-  while (left <= right) {
-    let middle = Math.floor((left + right) / 2);
-    if (earningsArray[middle] === currentEarnings) {
-      return middle;
-    }
-    if (earningsArray[middle] > currentEarnings) {
-      right = middle - 1;
-    } else {
-      left = middle + 1;
-    }
-  }
-  return -1;
-}

--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -532,7 +532,7 @@ export function findEarningsIndex(earningsArray, currentEarnings) {
   let right = earningsArray.length - 1;
 
   while (left <= right) {
-    let middle = Math.floor(left + right) / 2;
+    let middle = Math.floor((left + right) / 2);
     if (earningsArray[middle] === currentEarnings) {
       return middle;
     }
@@ -542,5 +542,5 @@ export function findEarningsIndex(earningsArray, currentEarnings) {
       left = middle + 1;
     }
   }
-  return 0;
+  return -1;
 }

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import Plot from "react-plotly.js";
 import { apiCall } from "../../../api/call";
 import {
-  findEarningsIndex,
   formatVariableValue,
   getPlotlyAxisFormat,
   getValueFromHousehold,
@@ -198,7 +197,7 @@ export default function MarginalTaxRates(props) {
       metadata
     );
 
-    const currEarningsIdx = findEarningsIndex(earningsArray, currentEarnings);
+    const currEarningsIdx = earningsArray.indexOf(currentEarnings)
     const reformMtrValue = reformMtrArray[currEarningsIdx]
     
     if (currentMtr !== reformMtrValue) {

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import Plot from "react-plotly.js";
 import { apiCall } from "../../../api/call";
 import {
+  findEarningsIndex,
   formatVariableValue,
   getPlotlyAxisFormat,
   getValueFromHousehold,
@@ -203,14 +204,18 @@ export default function MarginalTaxRates(props) {
       householdBaseline,
       metadata
     );
-    if (currentMtr !== baselineMtrValue) {
+
+    const currEarningsIdx = findEarningsIndex(earningsArray, currentEarnings);
+    const reformMtrValue = reformMtrArray[currEarningsIdx]
+    
+    if (currentMtr !== reformMtrValue) {
       title = `${policyLabel} ${
-        currentMtr > baselineMtrValue ? "increases" : "decreases"
+        reformMtrValue > currentMtr ? "increases" : "decreases"
       } your marginal tax rate from ${formatVariableValue(
         { unit: "/1" },
-        baselineMtrValue,
+        currentMtr,
         0
-      )} to ${formatVariableValue({ unit: "/1" }, currentMtr, 0)}`;
+      )} to ${formatVariableValue({ unit: "/1" }, reformMtrValue, 0)}`;
     } else {
       title = `${policyLabel} doesn't change your marginal tax rate`;
     }

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -197,13 +197,6 @@ export default function MarginalTaxRates(props) {
       reformMtr,
       metadata
     );
-    const baselineMtrValue = getValueFromHousehold(
-      "marginal_tax_rate",
-      "2023",
-      "you",
-      householdBaseline,
-      metadata
-    );
 
     const currEarningsIdx = findEarningsIndex(earningsArray, currentEarnings);
     const reformMtrValue = reformMtrArray[currEarningsIdx]
@@ -237,7 +230,7 @@ export default function MarginalTaxRates(props) {
         },
         {
           x: [currentEarnings, currentEarnings],
-          y: [0, currentMtr - baselineMtrValue],
+          y: [0, reformMtrValue - currentMtr],
           type: "line",
           name: "Your current MTR difference",
           line: {


### PR DESCRIPTION
Fixes #341.

Previously the comparison made to determine if a reform impacted MTR was made using `baselineMtrValue` and `currentMtr`. This caused a disconnect between what the charts show for the effects of a reform on MTR and what the descriptions of the impact on the page. 

With this PR, the comparison made is with the reform MTR value that corresponds to the current earnings amount. 

![MTR chart](https://user-images.githubusercontent.com/69769431/226780029-3f730559-4961-489e-bc6c-32ae977b6528.png)

![MTR difference](https://user-images.githubusercontent.com/69769431/226780132-65505efd-d02c-4a30-acdf-c04a17248f51.png)

