### PR TITLE
Remove antd.css import

### DIFF
--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Radio } from 'antd';
-import "antd/dist/antd.css";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../../api/charts";
 import { capitalize } from "../../../../api/language";


### PR DESCRIPTION
Just noticed that #327's new radio buttons look very nice, but included a reference to an antd CSS file that unintentionally shrank the dropdown menus (example below). Fixed by removing the CSS reference. We could add a test for this in future - merging now to tackle it quickly.

<img width="547" alt="image" src="https://user-images.githubusercontent.com/35577657/227077287-fa679fd7-9e34-448e-894e-256dcb6e0395.png">
