### PR TITLE
Maintain JSON formatting for situation in Python block

### DIFF
--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -37,7 +37,21 @@ function PythonCodeBlock({ lines }) {
         {lines.map((line, i) => {
           if (line === "") {
             return <div key={i} style={{ paddingTop: 15 }} />;
-          } else {
+          } else if (line.includes("situation = {")) {
+            return (
+              <pre 
+                key={i} 
+                style={{
+                  color: style.colors.WHITE, 
+                  fontFamily: "monospace", 
+                  margin: 0, 
+                  paddingTop: 5,}}
+              >
+                {line}
+              </pre>
+            );
+          }
+          else {
             return (
               <p
                 key={i}


### PR DESCRIPTION
Fixes #167.

The JSON formatting that `householdJson` already has from being returned from `JSON.stringify()` was being reformatted by the browser. By using `<pre>`, the `JSON` styling (e.g. the new lines and white space) is kept when being displayed on the browser. 

Note, this causes the python block to be larger than before. 

![JSON Formatted Situation](https://user-images.githubusercontent.com/69769431/227087391-c7a9a0ea-bc94-4af0-9d69-652d7ef5051a.png)
