### PR TITLE
Prevent hover cards from displaying when data points are unhovered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ yarn-error.log*
 /requirements.txt
 **/__pycache__
 .env
+
+.idea

--- a/src/layout/HoverCard.jsx
+++ b/src/layout/HoverCard.jsx
@@ -12,6 +12,8 @@ export default function HoverCard(props) {
       body: "",
     };
   }
+  const notEmpty = content.title.length !== 0 || content.body.length !== 0;
+
   const [visible, setVisible] = useState(false);
 
   const hoverCardElement = (
@@ -50,7 +52,7 @@ export default function HoverCard(props) {
 
   return (
     <>
-      <AnimatePresence>{visible && hoverCardElement}</AnimatePresence>
+      <AnimatePresence>{visible && notEmpty && hoverCardElement}</AnimatePresence>
       <div
         onMouseEnter={() => {
           setVisible(true);

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -227,6 +227,9 @@ function BaselineAndReformTogetherChart(props) {
           })
         }
       }}
+      onUnhover={() => {
+        setHoverCard(null);
+      }}
     />
   );
 
@@ -317,6 +320,9 @@ function BaselineReformDeltaChart(props) {
             body: message,
           });
         }
+      }}
+      onUnhover={() => {
+        setHoverCard(null);
       }}
     />
   );

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -137,6 +137,9 @@ export default function BaselineOnlyChart(props) {
             })
           }
         }}
+        onUnhover={() => {
+          setHoverCard(null);
+        }}
       />
     </FadeIn>
   );

--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -88,6 +88,9 @@ export default function AverageImpactByDecile(props) {
           body: message,
         });
       }}
+      onUnhover={() => {
+        setHoverCard(null);
+      }}
     />
   );
 

--- a/src/pages/policy/output/AverageImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByWealthDecile.jsx
@@ -88,6 +88,9 @@ export default function AverageImpactByWealthDecile(props) {
           body: message,
         });
       }}
+      onUnhover={() => {
+        setHoverCard(null);
+      }}
     />
   );
 

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -135,6 +135,9 @@ export default function BudgetaryImpact(props) {
           body: body,
         });
       }}
+      onUnhover={() => {
+        setHoverCard(null);
+      }}
     />
   );
 

--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -174,6 +174,9 @@ export default function CliffImpact(props) {
           body: message,
         });
       }}
+      onUnhover={() => {
+        setHovercard(null);
+      }}
     />
   );
 

--- a/src/pages/policy/output/DeepPovertyImpact.jsx
+++ b/src/pages/policy/output/DeepPovertyImpact.jsx
@@ -115,6 +115,9 @@ export default function DeepPovertyImpact(props) {
           body: message,
         });
       }}
+      onUnhover={() => {
+        setHoverCard(null);
+      }}
     />
   );
 

--- a/src/pages/policy/output/DeepPovertyImpactByGender.jsx
+++ b/src/pages/policy/output/DeepPovertyImpactByGender.jsx
@@ -110,6 +110,9 @@ export default function DeepPovertyImpactByGender(props) {
           body: message,
         });
       }}
+      onUnhover={() => {
+        setHoverCard(null);
+      }}
     />
   );
 

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -126,6 +126,9 @@ export default function InequalityImpact(props) {
           body: body,
         });
       }}
+      onUnhover={() => {
+          setHoverCard(null);
+      }}
     />
   );
 

--- a/src/pages/policy/output/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/IntraDecileImpact.jsx
@@ -277,6 +277,9 @@ export default function IntraDecileImpact(props) {
           body: message,
         });
       }}
+      onUnhover={() => {
+        setHovercard(null);
+      }}
     />
   );
 

--- a/src/pages/policy/output/IntraWealthDecileImpact.jsx
+++ b/src/pages/policy/output/IntraWealthDecileImpact.jsx
@@ -277,6 +277,9 @@ export default function IntraWealthDecileImpact(props) {
           body: message,
         });
       }}
+      onUnhover={() => {
+        setHovercard(null);
+      }}
     />
   );
 

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -112,6 +112,9 @@ export default function PovertyImpact(props) {
           body: message,
         });
       }}
+      onUnhover={() => {
+        setHoverCard(null);
+      }}
     />
   );
 

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -110,6 +110,9 @@ export default function PovertyImpactByGender(props) {
           body: message,
         });
       }}
+      onUnhover={() => {
+        setHoverCard(null);
+      }}
     />
   );
 

--- a/src/pages/policy/output/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByDecile.jsx
@@ -84,6 +84,9 @@ export default function RelativeImpactByDecile(props) {
           body: message,
         });
       }}
+      onUnhover={() => {
+        setHoverCard(null);
+      }}
     />
   );
 

--- a/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
@@ -84,6 +84,9 @@ export default function RelativeImpactByWealthDecile(props) {
           body: message,
         });
       }}
+      onUnhover={() => {
+        setHoverCard(null);
+      }}
     />
   );
 


### PR DESCRIPTION
Fixes issue #125 

Every plot that uses HoverCard did not clear the content of the hover card when the mouse was moved away from data points, hence the hover card was always displaying the last data point the mouse was hovered over. Now this is fixed.

HoverCard component kept rendering the hover card even though the content was empty. Now a check is added to the rendering logic so that the hover card will not appear whenever the content is empty.