### PR TITLE
Ensure baseline net income table shows all components

### DIFF
--- a/src/pages/household/output/NetIncomeBreakdown.jsx
+++ b/src/pages/household/output/NetIncomeBreakdown.jsx
@@ -180,7 +180,7 @@ function VariableArithmetic(props) {
     const parameter = metadata.parameters[subtracts];
     subtracts = getParameterAtInstant(parameter, "2023-01-01");
   }
-  const expandable = doesIncomeChange && adds.length + subtracts.length > 0;
+  const expandable = (!hasReform || doesIncomeChange) && adds.length + subtracts.length > 0;
   const childAddNodes = adds.filter(shouldShowVariable).map((variable) => (
     <VariableArithmetic
       variableName={variable}


### PR DESCRIPTION
There was a minor bug that meant baseline-only household outputs didn't break down the net income tree.