### PR TITLE
add target="_blank" to <a> tags

### DIFF
--- a/src/pages/household/output/PolicyImpactPopup.jsx
+++ b/src/pages/household/output/PolicyImpactPopup.jsx
@@ -17,7 +17,7 @@ export default function PolicyImpactPopup(props) {
           <p>
             PolicyEngine estimates reform impacts using a static microsimulation
             over the 2021 Current Population Survey March Supplement.{" "}
-            <a href="/us/blog/2022-12-28-enhancing-the-current-population-survey-for-policy-analysis">
+            <a href="/us/blog/2022-12-28-enhancing-the-current-population-survey-for-policy-analysis" target="_blank">
               Read our caveats and data enhancement plan.
             </a>
           </p>

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -408,7 +408,7 @@ export default function PolicyOutput(props) {
         PolicyEngine US v{selectedVersion} estimates reform impacts using a
         static microsimulation over the 2021 Current Population Survey March
         Supplement.{" "}
-        <a href="/us/blog/2022-12-28-enhancing-the-current-population-survey-for-policy-analysis">
+        <a href="/us/blog/2022-12-28-enhancing-the-current-population-survey-for-policy-analysis" target="_blank">
           Read our caveats and data enhancement plan.
         </a>
       </p>


### PR DESCRIPTION
Fixed #191

This PR adds `target="_blank"` to the `<a>` tags in `PolicyImpactPopus.jsx` and `PolicyOutput.jsx` which tells the browser to open the links in a new tab.


https://user-images.githubusercontent.com/68708484/231616067-ff9ae463-c35f-4eb0-b155-7b76ea7efb82.mov