### PR TITLE
[#67] Rounded MTR to one decimal in household right-hand info bar, title, and interactive chart

### DIFF
--- a/src/pages/household/HouseholdRightSidebar.jsx
+++ b/src/pages/household/HouseholdRightSidebar.jsx
@@ -107,7 +107,7 @@ export default function HouseholdRightSidebar(props) {
         );
       })}
       <Figure
-        left={formatVariableValue(metadata.variables.marginal_tax_rate, mtr, 0)}
+        left={formatVariableValue(metadata.variables.marginal_tax_rate, mtr, 1)}
         right={"marginal tax rate"}
       />
     </>

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -119,7 +119,7 @@ export default function MarginalTaxRates(props) {
     title = `Your current marginal tax rate is ${formatVariableValue(
       { unit: "/1" },
       currentMtr,
-      0
+      1
     )}`;
     // Add the main line, then add a 'you are here' line
     plot = (

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -155,7 +155,7 @@ export default function MarginalTaxRates(props) {
             yaxis: {
               title: "Marginal tax rate",
               ...getPlotlyAxisFormat(metadata.variables.marginal_tax_rate.unit),
-              tickformat: ".0%",
+              tickformat: ".1%",
             },
             legend: {
               // Position above the plot


### PR DESCRIPTION
Fix for: [#67](https://github.com/PolicyEngine/policyengine-app/issues/67) 

Solution: Changed the precision value for `formatVariableValue` inside `HouseholdRightSidebar.jsx` and `MarginalTaxRates.jsx`