### PR TITLE
Styling fixes

### DIFF
--- a/src/layout/BottomCarousel.jsx
+++ b/src/layout/BottomCarousel.jsx
@@ -24,6 +24,7 @@ export default function BottomCarousel(props) {
         backgroundColor: style.colors.WHITE,
         padding: 5,
         justifyContent: mobile ? "center" : "right",
+        borderTop: "1px solid black"
       }}
     >
       {!mobile && (

--- a/src/layout/ResultsPanel.jsx
+++ b/src/layout/ResultsPanel.jsx
@@ -17,7 +17,7 @@ const ResultsPanel = forwardRef((props, ref) => {
     >
       <h2>{props.title}</h2>
       <h5 style={{ marginBottom: mobile ? 5 : 20 }}>{props.description}</h5>
-      <div ref={ref} style={{ paddingTop: 0, paddingBottom: 20 }}>{props.children}</div>
+      <div ref={ref} style={{ paddingTop: 0, paddingBottom: 50 }}>{props.children}</div>
       {/* <div style={{ paddingTop: 0, paddingBottom: 150 }}>{props.children}</div> */}
     </div>
   );

--- a/src/pages/household/output/PolicyImpactPopup.jsx
+++ b/src/pages/household/output/PolicyImpactPopup.jsx
@@ -15,18 +15,16 @@ export default function PolicyImpactPopup(props) {
       <div>
         {metadata.countryId === "us" ? (
           <p>
-            PolicyEngine estimates reform impacts using a static microsimulation
-            over the 2021 Current Population Survey March Supplement.{" "}
+            PolicyEngine estimates reform impacts using microsimulation.{" "}
             <a href="/us/blog/2022-12-28-enhancing-the-current-population-survey-for-policy-analysis" target="_blank">
-              Read our caveats and data enhancement plan.
+              Learn more
             </a>
           </p>
         ) : (
           <p>
-            PolicyEngine estimates reform impacts using a static microsimulation
-            over{" "}
+            PolicyEngine estimates reform impacts using microsimulation.{" "}
             <a href="/uk/blog/2022-03-07-how-machine-learning-tools-make-policyengine-more-accurate">
-              an enhanced version of the 2019 Family Resources Survey
+              Learn more
             </a>
           </p>
         )}

--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -10,7 +10,7 @@ import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function AverageImpactByDecile(props) {
-  const { impact, policyLabel, metadata } = props;
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
   // Decile bar chart. Bars are grey if negative, green if positive.
   const [hovercard, setHoverCard] = useState(null);
   const mobile = useMobile();
@@ -134,7 +134,7 @@ export default function AverageImpactByDecile(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container"> 
           {!mobile &&
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={data}
               filename="absoluteImpactByIncomeDecile.csv"
               style={downloadButtonStyle}

--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -132,6 +132,7 @@ export default function AverageImpactByDecile(props) {
           )}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container"> 
           {!mobile &&
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -141,7 +142,6 @@ export default function AverageImpactByDecile(props) {
             />
           }
         </div>
-      </Screenshottable>
       <p>
         The chart above shows the relative change in income for each income
         decile. Households are sorted into ten equally-populated groups

--- a/src/pages/policy/output/AverageImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByWealthDecile.jsx
@@ -132,6 +132,7 @@ export default function AverageImpactByWealthDecile(props) {
           )}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container"> 
           {!mobile &&
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -141,7 +142,6 @@ export default function AverageImpactByWealthDecile(props) {
             />
           }
         </div>
-      </Screenshottable>
       <p>
         The chart above shows the relative change in income for each wealth
         decile. Households are sorted into ten equally-populated groups

--- a/src/pages/policy/output/AverageImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByWealthDecile.jsx
@@ -10,7 +10,7 @@ import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function AverageImpactByWealthDecile(props) {
-  const { impact, policyLabel, metadata } = props;
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
   // Decile bar chart. Bars are grey if negative, green if positive.
   const [hovercard, setHoverCard] = useState(null);
   const mobile = useMobile();
@@ -134,7 +134,7 @@ export default function AverageImpactByWealthDecile(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container"> 
           {!mobile &&
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={data}
               filename="absoluteImpactByWealthDecile.csv"
               style={downloadButtonStyle}

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -9,7 +9,7 @@ import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function BudgetaryImpact(props) {
-  const { impact, policyLabel, metadata } = props;
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
 
   const budgetaryImpact = impact.budget.budgetary_impact;
   const taxImpact = impact.budget.tax_revenue_impact;
@@ -172,7 +172,7 @@ export default function BudgetaryImpact(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container"> 
           {!mobile &&
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={data}
               filename="budgetaryImpact.csv"
               className="download-button"

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -170,6 +170,7 @@ export default function BudgetaryImpact(props) {
           {label}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container"> 
           {!mobile &&
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -179,7 +180,6 @@ export default function BudgetaryImpact(props) {
             />
           }
         </div>
-      </Screenshottable>
     </>
   );
   

--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -21,7 +21,7 @@ export default function CliffImpact(props) {
   const baselinePolicyId = searchParams.get("baseline");
   const [impact, setImpact] = useState(null);
   const [error, setError] = useState(null);
-  const { metadata, policyLabel } = props;
+  const { metadata, policyLabel, preparingForScreenshot } = props;
   const [hovercard, setHovercard] = useState(null);
   const mobile = useMobile();
   useEffect(() => {
@@ -232,7 +232,7 @@ export default function CliffImpact(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container">
           {!mobile && 
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={data}
               filename="cliffImpact.csv"
               style={downloadButtonStyle}

--- a/src/pages/policy/output/DeepPovertyImpact.jsx
+++ b/src/pages/policy/output/DeepPovertyImpact.jsx
@@ -9,7 +9,7 @@ import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function DeepPovertyImpact(props) {
-  const { impact, policyLabel, metadata } = props;
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
   const childPovertyChange =
     impact.poverty.deep_poverty.child.reform /
       impact.poverty.deep_poverty.child.baseline -
@@ -167,7 +167,7 @@ export default function DeepPovertyImpact(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container">
           {!mobile && (
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={data}
               filename="deeppPovertyImpactByAge.csv"
               className="download-button"

--- a/src/pages/policy/output/DeepPovertyImpact.jsx
+++ b/src/pages/policy/output/DeepPovertyImpact.jsx
@@ -165,6 +165,7 @@ export default function DeepPovertyImpact(props) {
             : `wouldn't change the deep poverty rate ${label}`}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container">
           {!mobile && (
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -174,7 +175,6 @@ export default function DeepPovertyImpact(props) {
             />
           )}
         </div>
-      </Screenshottable>
       <p>
         The chart above shows the relative change in the deep poverty rate for
         each age group.

--- a/src/pages/policy/output/DeepPovertyImpactByGender.jsx
+++ b/src/pages/policy/output/DeepPovertyImpactByGender.jsx
@@ -172,6 +172,7 @@ export default function DeepPovertyImpactByGender(props) {
             : `wouldn't change the deep poverty rate ${label}`}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container">
           {!mobile && (
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -181,7 +182,6 @@ export default function DeepPovertyImpactByGender(props) {
             />
           )}
         </div>
-      </Screenshottable>
       <p>
         The chart above shows the relative change in the deep poverty rate for
         each sex.

--- a/src/pages/policy/output/DeepPovertyImpactByGender.jsx
+++ b/src/pages/policy/output/DeepPovertyImpactByGender.jsx
@@ -9,7 +9,7 @@ import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function DeepPovertyImpactByGender(props) {
-  const { impact, policyLabel, metadata } = props;
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
   const malePovertyChange =
     impact.poverty_by_gender.deep_poverty.male.reform /
       impact.poverty_by_gender.deep_poverty.male.baseline -
@@ -90,11 +90,11 @@ export default function DeepPovertyImpactByGender(props) {
         const group = data.points[0].x;
         const change = data.points[0].y;
         const baseline =
-          group == "All"
+          group === "All"
             ? impact.poverty.deep_poverty[labelToKey[group]].baseline
             : impact.poverty_by_gender.deep_poverty[labelToKey[group]].baseline;
         const reform =
-          group == "All"
+          group === "All"
             ? impact.poverty.deep_poverty[labelToKey[group]].reform
             : impact.poverty_by_gender.deep_poverty[labelToKey[group]].reform;
         const message = `The percentage of ${
@@ -174,7 +174,7 @@ export default function DeepPovertyImpactByGender(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container">
           {!mobile && (
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={data}
               filename="deepPovertyImpactBySex.csv"
               className="download-button"

--- a/src/pages/policy/output/DownloadCsvButton.jsx
+++ b/src/pages/policy/output/DownloadCsvButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const DownloadCsvButton = ({ content, filename, className, style }) => {
+const DownloadCsvButton = ({ content, filename, className, style, preparingForScreenshot }) => {
   const downloadCSV = (event) => {
     event.preventDefault();
 
@@ -20,6 +20,10 @@ const DownloadCsvButton = ({ content, filename, className, style }) => {
     URL.revokeObjectURL(url);
   };
 
+  if (preparingForScreenshot) {
+    return null;
+  }
+
   const downloadButtonStyle = {
     display: "inline-block",
     backgroundColor: "#F2F2F2",
@@ -35,6 +39,7 @@ const DownloadCsvButton = ({ content, filename, className, style }) => {
   };
 
   return (
+    // eslint-disable-next-line
     <a
       href="#"
       onClick={downloadCSV}

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -186,6 +186,7 @@ export default function InequalityImpact(props) {
             : ` would have an ambiguous effect on inequality ${label}` }
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container">
           {!mobile && (
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -195,7 +196,6 @@ export default function InequalityImpact(props) {
             />
           )}
         </div>
-      </Screenshottable>
       <p>
         The chart above shows how this policy reform affects different measures
         of income inequality.

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -9,7 +9,7 @@ import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function InequalityImpact(props) {
-  const { impact, policyLabel, metadata } = props;
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
 
   const metricChanges = [
     impact.inequality.gini.reform / impact.inequality.gini.baseline - 1,
@@ -188,7 +188,7 @@ export default function InequalityImpact(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container">
           {!mobile && (
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={data}
               filename="incomeInequilityImpact.csv"
               className="download-button"

--- a/src/pages/policy/output/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/IntraDecileImpact.jsx
@@ -10,7 +10,7 @@ import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function IntraDecileImpact(props) {
-  const { impact, policyLabel, metadata } = props;
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
   const deciles = impact.intra_decile.deciles;
   const decileNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   const all = impact.intra_decile.all;
@@ -339,7 +339,7 @@ export default function IntraDecileImpact(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container">
           {!mobile && (
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={csvData}
               filename="intraDecileImpact.csv"
               style={downloadButtonStyle}

--- a/src/pages/policy/output/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/IntraDecileImpact.jsx
@@ -337,6 +337,7 @@ export default function IntraDecileImpact(props) {
           {formatVariableValue({ unit: "/1" }, totalAhead, 0)}{label}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container">
           {!mobile && (
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -346,7 +347,6 @@ export default function IntraDecileImpact(props) {
             />
           )}
         </div>
-      </Screenshottable>
       <p>
         The chart above shows percentage of of people in each household income
         decile who experience different outcomes. Households are sorted into ten

--- a/src/pages/policy/output/IntraWealthDecileImpact.jsx
+++ b/src/pages/policy/output/IntraWealthDecileImpact.jsx
@@ -10,7 +10,7 @@ import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function IntraWealthDecileImpact(props) {
-  const { impact, policyLabel, metadata } = props;
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
   const deciles = impact.intra_wealth_decile.deciles;
   const decileNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   const all = impact.intra_wealth_decile.all;
@@ -339,7 +339,7 @@ export default function IntraWealthDecileImpact(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container">
           {!mobile && (
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={csvData}
               filename="intraWealthDecileImpact.csv"
               style={downloadButtonStyle}

--- a/src/pages/policy/output/IntraWealthDecileImpact.jsx
+++ b/src/pages/policy/output/IntraWealthDecileImpact.jsx
@@ -337,6 +337,7 @@ export default function IntraWealthDecileImpact(props) {
           {formatVariableValue({ unit: "/1" }, totalAhead, 0)}{label}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container">
           {!mobile && (
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -346,7 +347,6 @@ export default function IntraWealthDecileImpact(props) {
             />
           )}
         </div>
-      </Screenshottable>
       <p>
         The chart above shows percentage of of people in each household wealth
         decile who experience different outcomes. Households are sorted into ten

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -96,9 +96,7 @@ export default function PolicyOutput(props) {
   const [error, setError] = useState(null);
   const imageRef = useRef(null)
   const [preparingForScreenshot, setPreparingForScreenshot] = useState(false)
-  const [image, takeScreenShot] = useScreenshot();
-  image;
-  setPreparingForScreenshot;
+  const [, takeScreenShot] = useScreenshot();
 
   const handleScreenshot = () => {
     console.log(imageRef.current)
@@ -132,7 +130,7 @@ export default function PolicyOutput(props) {
           });
       }, 1000);
     }
-  }, [preparingForScreenshot])
+  }, [preparingForScreenshot, takeScreenShot]);
 
   const {
     metadata,
@@ -297,6 +295,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.netIncome") {
     pane = (
       <BudgetaryImpact
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -305,6 +304,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.decileRelativeImpact") {
     pane = (
       <RelativeImpactByDecile
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -313,6 +313,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.decileAverageImpact") {
     pane = (
       <AverageImpactByDecile
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -321,6 +322,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.intraDecileImpact") {
     pane = (
       <IntraDecileImpact
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -329,6 +331,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.povertyImpact") {
     pane = (
       <PovertyImpact
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -337,6 +340,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.deepPovertyImpact") {
     pane = (
       <DeepPovertyImpact
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -345,6 +349,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.genderPovertyImpact") {
     pane = (
       <PovertyImpactByGender
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -353,6 +358,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.genderDeepPovertyImpact") {
     pane = (
       <DeepPovertyImpactByGender
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -361,6 +367,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.racialPovertyImpact") {
     pane = (
       <PovertyImpactByRace
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -369,6 +376,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.inequalityImpact") {
     pane = (
       <InequalityImpact
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -377,6 +385,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.wealthDecileAverageImpact") {
     pane = (
       <AverageImpactByWealthDecile
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -385,6 +394,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.wealthDecileRelativeImpact") {
     pane = (
       <RelativeImpactByWealthDecile
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -393,6 +403,7 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.intraWealthDecileImpact") {
     pane = (
       <IntraWealthDecileImpact
+        preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}
         policyLabel={policyLabel}
@@ -419,6 +430,7 @@ export default function PolicyOutput(props) {
 
   const url = encodeURIComponent(window.location.href);
   const link = (
+    // eslint-disable-next-line
     <a onClick={() => {
       handleScreenshot();
       navigator.clipboard.writeText(window.location.href);
@@ -466,19 +478,16 @@ export default function PolicyOutput(props) {
   const bottomElements =
     mobile & !embed ? null : metadata.countryId === "us" ? (
       <p>
-        PolicyEngine US v{selectedVersion} estimates reform impacts using a
-        static microsimulation over the 2021 Current Population Survey March
-        Supplement.{" "}
+        PolicyEngine US v{selectedVersion} estimates reform impacts using microsimulation.{" "}
         <a href="/us/blog/2022-12-28-enhancing-the-current-population-survey-for-policy-analysis" target="_blank">
-          Read our caveats and data enhancement plan.
+          Learn more
         </a>
       </p>
     ) : (
       <p>
-        PolicyEngine UK v{selectedVersion} estimates reform impacts using a
-        static microsimulation over{" "}
+        PolicyEngine UK v{selectedVersion} estimates reform impacts using microsimulation.{" "}
         <a href="/uk/blog/2022-03-07-how-machine-learning-tools-make-policyengine-more-accurate">
-          an enhanced version of the 2019 Family Resources Survey
+          Learn more
         </a>
       </p>
     );

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -160,6 +160,7 @@ export default function PovertyImpact(props) {
             : `wouldn't change the poverty rate ${label}`}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container">
           {!mobile && (
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -169,7 +170,6 @@ export default function PovertyImpact(props) {
             />
           )}
         </div>
-      </Screenshottable>
       <p>
         The chart above shows the relative change in the poverty rate for each
         age group.

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -9,7 +9,7 @@ import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function PovertyImpact(props) {
-  const { impact, policyLabel, metadata } = props;
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
   const childPovertyChange =
     impact.poverty.poverty.child.reform /
       impact.poverty.poverty.child.baseline -
@@ -162,7 +162,7 @@ export default function PovertyImpact(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container">
           {!mobile && (
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={data}
               filename="povertyImpactByAge.csv"
               className="download-button"

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -166,6 +166,7 @@ export default function PovertyImpactByGender(props) {
             : `wouldn't change the poverty rate ${label}`}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container">
           {!mobile && (
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -175,7 +176,6 @@ export default function PovertyImpactByGender(props) {
             />
           )}
         </div>
-      </Screenshottable>
       <p>
         The chart above shows the relative change in the poverty rate for each
         sex.

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -9,7 +9,7 @@ import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function PovertyImpactByGender(props) {
-  const { impact, policyLabel, metadata} = props;
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
   const malePovertyChange =
     impact.poverty_by_gender.poverty.male.reform /
       impact.poverty_by_gender.poverty.male.baseline -
@@ -88,11 +88,11 @@ export default function PovertyImpactByGender(props) {
         const group = data.points[0].x;
         const change = data.points[0].y;
         const baseline =
-          group == "All"
+          group === "All"
             ? impact.poverty.poverty[labelToKey[group]].baseline
             : impact.poverty_by_gender.poverty[labelToKey[group]].baseline;
         const reform =
-          group == "All"
+          group === "All"
             ? impact.poverty.poverty[labelToKey[group]].reform
             : impact.poverty_by_gender.poverty[labelToKey[group]].reform;
         const message = `The percentage of ${
@@ -168,7 +168,7 @@ export default function PovertyImpactByGender(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container">
           {!mobile && (
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={data}
               filename="povertyImpactByGender.csv"
               className="download-button"

--- a/src/pages/policy/output/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/PovertyImpactByRace.jsx
@@ -9,8 +9,7 @@ import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function PovertyImpactByRace(props) {
-  const { impact, policyLabel, metadata} = props;
-  console.log(impact)
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
   // white, black, hispanic, other
   const whitePovertyChange =
     impact.poverty_by_race.poverty.white.reform /
@@ -102,11 +101,11 @@ export default function PovertyImpactByRace(props) {
         const group = data.points[0].x;
         const change = data.points[0].y;
         const baseline =
-          group == "All"
+          group === "All"
             ? impact.poverty.poverty[labelToKey[group]].baseline
             : impact.poverty_by_race.poverty[labelToKey[group]].baseline;
         const reform =
-          group == "All"
+          group === "All"
             ? impact.poverty.poverty[labelToKey[group]].reform
             : impact.poverty_by_race.poverty[labelToKey[group]].reform;
         const message = `The percentage of ${
@@ -192,7 +191,7 @@ export default function PovertyImpactByRace(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container">
           {!mobile && (
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={data}
               filename="povertyImpactByRace.csv"
               style={downloadButtonStyle}

--- a/src/pages/policy/output/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/PovertyImpactByRace.jsx
@@ -189,6 +189,7 @@ export default function PovertyImpactByRace(props) {
             : `wouldn't change the poverty rate ${label}`}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container">
           {!mobile && (
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -198,7 +199,6 @@ export default function PovertyImpactByRace(props) {
             />
           )}
         </div>
-      </Screenshottable>
       <p>
         The chart above shows the relative change in the poverty rate for each
         top-level racial and ethnic group.

--- a/src/pages/policy/output/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByDecile.jsx
@@ -10,7 +10,7 @@ import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function RelativeImpactByDecile(props) {
-  const { impact, policyLabel, metadata} = props;
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
   const [hovercard, setHoverCard] = useState(null);
   const mobile = useMobile();
   // Decile bar chart. Bars are grey if negative, green if positive.
@@ -129,7 +129,7 @@ export default function RelativeImpactByDecile(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container">
           {!mobile && (
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={data}
               filename="relativeImpactByDecile.csv"
               style={downloadButtonStyle}

--- a/src/pages/policy/output/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByDecile.jsx
@@ -127,6 +127,7 @@ export default function RelativeImpactByDecile(props) {
           {formatVariableValue({ unit: "/1" }, Math.abs(averageRelChange), 1)}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container">
           {!mobile && (
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -136,7 +137,6 @@ export default function RelativeImpactByDecile(props) {
             />
           )}
         </div>
-      </Screenshottable>
       <p>
         The chart above shows the relative change in income for each income
         decile. Households are sorted into ten equally-populated groups

--- a/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
@@ -126,6 +126,7 @@ export default function RelativeImpactByWealthDecile(props) {
           {formatVariableValue({ unit: "/1" }, Math.abs(averageRelChange), 1)}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
+      </Screenshottable>
         <div className="chart-container">
           {!mobile && (
             <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
@@ -135,7 +136,6 @@ export default function RelativeImpactByWealthDecile(props) {
             />
           )}
         </div>
-      </Screenshottable>
       <p>
         The chart above shows the relative change in income for each wealth
         decile. Households are sorted into ten equally-populated groups

--- a/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
@@ -10,7 +10,7 @@ import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
 
 export default function RelativeImpactByWealthDecile(props) {
-  const { impact, policyLabel, metadata} = props;
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
   const [hovercard, setHoverCard] = useState(null);
   const mobile = useMobile();
   // Decile bar chart. Bars are grey if negative, green if positive.
@@ -128,7 +128,7 @@ export default function RelativeImpactByWealthDecile(props) {
         <HoverCard content={hovercard}>{chart}</HoverCard>
         <div className="chart-container">
           {!mobile && (
-            <DownloadCsvButton
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
               content={data}
               filename="relativeImpactByWealthDecile.csv"
               style={downloadButtonStyle}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fa7f1bb</samp>

### Summary
📸📊🛠️

<!--
1.  📸 - This emoji represents the screenshot feature that is added to many of the chart components and the bottom carousel. It conveys the idea of capturing an image of the policy impact analysis.
2.  📊 - This emoji represents the charts and tables that are displayed in the bottom carousel and the policy impact popup. It conveys the idea of visualizing and summarizing the data and the results of the policy reform.
3.  🛠️ - This emoji represents the code quality and style improvements that are made to some of the components, such as using the strict equality operator, removing unused code, and fixing linting errors. It conveys the idea of fixing and enhancing the code.
-->
This pull request adds a feature that allows the user to download a screenshot of the bottom carousel, which shows various charts of the policy impact analysis. It also improves the layout, the text, and the code quality of some components. It mainly adds a `preparingForScreenshot` prop to the chart and button components, which controls the rendering of some elements for the screenshot. It also modifies the `BottomCarousel`, `ResultsPanel`, and `PolicyImpactPopup` components to enhance the style, the spacing, and the information.

> _To download a screenshot with ease_
> _We added a prop to some charts and `DownloadCsvButton`s_
> _This prop lets us hide some parts_
> _That clutter the image of the policy impacts_
> _And makes the bottom carousel look more pleasing_

### Walkthrough
*  Add a new prop called `preparingForScreenshot` to various chart components and pass it to the `DownloadCsvButton` component to hide the button when taking a screenshot ([link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L13-R13), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L137-R137), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aL13-R13), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aL137-R137), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L12-R12), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L175-R175), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L24-R24), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L235-R235), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8L12-R12), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8L170-R170), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cL12-R12), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cL177-R177), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-53e00af386370e2583bc217d2dc3a9b8192fbc7396679cb55663ecfd7d21c56eL3-R3), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-53e00af386370e2583bc217d2dc3a9b8192fbc7396679cb55663ecfd7d21c56eR23-R26), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L12-R12), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L191-R191), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-71b88b3f4ac09980a01bd897cb30749591d957adfb78c6de0b91e8010b71072aL13-R13), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-71b88b3f4ac09980a01bd897cb30749591d957adfb78c6de0b91e8010b71072aL342-R342), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-d41e88c8038a48564a3b9efe556677354d37e1fc69a77bd612f33d5aa98cda85L13-R13), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-d41e88c8038a48564a3b9efe556677354d37e1fc69a77bd612f33d5aa98cda85L342-R342), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L12-R12), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L165-R165), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-04e2d157bf184eb210182f434c2f34a470a711a29e5aa61e626d0cabb949526fL12-R12), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-04e2d157bf184eb210182f434c2f34a470a711a29e5aa61e626d0cabb949526fL171-R171), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-666b4a2954e170f5d63c511ffebea4d88b6f3ef1c2d7e836d4cfc6b6fe268bcbL12-R12), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-666b4a2954e170f5d63c511ffebea4d88b6f3ef1c2d7e836d4cfc6b6fe268bcbL195-R194), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-2b5717cbee57bbbc685fbb5310eb4f84ee1f0b60fc6215373dd876f733f47fb4L13-R13), )
*  Pass the `preparingForScreenshot` prop to the chart components from the `PolicyOutput` component, which is the main component that renders the bottom carousel and its contents ([link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR298), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR307), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR316), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR325), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR334), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR343), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR352), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR361), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR370), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR379), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR388), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR397), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR406))
*  Add a border-top style to the bottom carousel component to improve the visual separation between the bottom carousel and the rest of the page ([link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-d99942e8e6aaa680cdaadf6901d6c242ca56c822ddff67b256ee98d692494a8eR27))
*  Reduce the padding-bottom style of the `ResultsPanel` component to make the layout more compact and consistent across different panels ([link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-81eca4ebc9235127e803c4dfa8d48afb99b24d5c7a75051db308bfdf9cc22fd1L20-R20))
*  Simplify the text and update the link that appear at the bottom of the `PolicyImpactPopup` and `PolicyOutput` components to make the text more concise and clear, and to direct the user to the most relevant information source ([link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-6aa7b1f04dab1ee09975a2a88651cde58b71f8f1d2b67785870f39488c151940L18-R27), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL469-R490))
*  Replace the == operator with the === operator in the logic for accessing the baseline and reform values for each gender and race group from the impact object to improve the code quality and avoid potential bugs ([link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cL93-R97), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-04e2d157bf184eb210182f434c2f34a470a711a29e5aa61e626d0cabb949526fL91-R95), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-666b4a2954e170f5d63c511ffebea4d88b6f3ef1c2d7e836d4cfc6b6fe268bcbL105-R108))
*  Remove the unused variables `image` and `setPreparingForScreenshot` from the destructuring assignment of the `useScreenshot` hook and add comments to disable the eslint warning for the unused variables `image` and `imageRef` to avoid the linting error and keep the code consistent ([link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-53e00af386370e2583bc217d2dc3a9b8192fbc7396679cb55663ecfd7d21c56eR42), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL99-R99), [link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR433))
*  Add the `takeScreenShot` function to the dependency array of the `useEffect` hook to ensure that the hook has access to the latest version of the function and avoid potential bugs ([link](https://github.com/PolicyEngine/policyengine-app/pull/499/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL135-R133))



Fixes #498 
