### PR TITLE
Fix date styling in blog post previews

### DIFF
--- a/src/layout/BlogPostHolder.jsx
+++ b/src/layout/BlogPostHolder.jsx
@@ -47,7 +47,8 @@ export function BlogPostPreviewRegular(props) {
         src={imageSrc}
         style={{
           width: width || 300,
-          height: imageHeight || 200,
+          height: imageHeight || 180,
+          maxHeight: 180,
           // Fit inside without stretching
           objectFit: "cover",
         }}

--- a/src/layout/BlogPostHolder.jsx
+++ b/src/layout/BlogPostHolder.jsx
@@ -70,7 +70,6 @@ export function BlogPostPreviewRegular(props) {
           style={{
             marginLeft: "auto",
             marginBottom: 5,
-            color: style.colors.DARK_GRAY,
           }}
         >
           {dateString}


### PR DESCRIPTION
### **Scope of change**
- The issue with the blog card where the date was not visible on hover has been fixed by removing the inline style of  paragraph tag enclosing the date.
- the issue where the date was moving to the bottom of the card when the image height was larger has also been fixed. To address this issue, the height is changed to `180px` and a maxHeight of `180px` was added to provide a static height ceiling for all images.

### **Screenshots**
<img width="1280" alt="Screenshot 2023-04-27 at 6 14 52 PM" src="https://user-images.githubusercontent.com/87971509/234867168-ac66e5d5-9210-443f-bbd9-1756d26bbe5b.png">

### Note
This fixes #497  