### PR TITLE
Add State budgetary impacts and better loading UX

### DIFF
--- a/src/api/call.js
+++ b/src/api/call.js
@@ -3,13 +3,19 @@ import { buildVariableTree, getTreeLeavesInOrder } from "./variables";
 
 const POLICYENGINE_API = "https://api.policyengine.org";
 
-export function apiCall(path, body, method) {
+export function apiCall(path, body, method, secondAttempt = false) {
   return fetch(POLICYENGINE_API + path, {
     method: method || (body ? "POST" : "GET"),
     headers: {
       "Content-Type": "application/json",
     },
     body: body ? JSON.stringify(body) : null,
+  }).then((response) => {
+    // If the response is a 500, try again once.
+    if (response.status === 500 && !secondAttempt) {
+      return apiCall(path, body, method, true);
+    }
+    return response;
   });
 }
 

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -17,7 +17,7 @@ import CliffImpact from "./CliffImpact";
 import BottomCarousel from "../../../layout/BottomCarousel";
 import getPolicyOutputTree from "./tree";
 import InequalityImpact from "./InequalityImpact";
-import { Result, Steps } from "antd";
+import { Result, Steps, Progress } from "antd";
 import { CheckCircleFilled, CloseCircleFilled } from "@ant-design/icons";
 import useMobile from "../../../layout/Responsive";
 import PolicyImpactPopup from "../../household/output/PolicyImpactPopup";
@@ -31,13 +31,12 @@ import {
   LinkedinFilled,
   LinkOutlined,
 } from "@ant-design/icons";
-import React from 'react';
-import {message} from 'antd';
+import React from "react";
+import { message } from "antd";
 import Analysis from "./Analysis";
 import style from "../../../style";
 
-import { useScreenshot } from 'use-react-screenshot'
-
+import { useScreenshot } from "use-react-screenshot";
 
 export function RegionSelector(props) {
   const { metadata } = props;
@@ -94,40 +93,47 @@ export default function PolicyOutput(props) {
   const baselinePolicyId = searchParams.get("baseline");
   const [impact, setImpact] = useState(null);
   const [error, setError] = useState(null);
-  const imageRef = useRef(null)
-  const [preparingForScreenshot, setPreparingForScreenshot] = useState(false)
+  const imageRef = useRef(null);
+  const [preparingForScreenshot, setPreparingForScreenshot] = useState(false);
   const [, takeScreenShot] = useScreenshot();
+  const [impactTimeStats, setImpactTimeStats] = useState(null);
 
   const handleScreenshot = () => {
-    console.log(imageRef.current)
+    console.log(imageRef.current);
     setPreparingForScreenshot(true);
-  }
+  };
 
   useEffect(() => {
     if (preparingForScreenshot) {
       setTimeout(() => {
-        takeScreenShot(imageRef.current).then(img => {
-            setPreparingForScreenshot(false);
-            // send a request to /image with the image
-            // The filename should be the current path (including query strings), but with /, &, ? etc. replaced with _
-            const filename = (window.location.pathname + window.location.search).replaceAll("/", "_").replaceAll("&", "_").replaceAll("?", "_").replaceAll("=", "_").replaceAll(".", "_") + ".png";
-            fetch('/image', {
-              method: 'POST',
-              body: JSON.stringify({
-                filename,
-                image: img,
-              }),
-              headers: {
-                'Content-Type': 'application/json'
-              }
-            }).then((response) => {
-              if (response.ok) {
-                return response.json();
-              } else {
-                throw new Error('Something went wrong');
-              }
-            });
+        takeScreenShot(imageRef.current).then((img) => {
+          setPreparingForScreenshot(false);
+          // send a request to /image with the image
+          // The filename should be the current path (including query strings), but with /, &, ? etc. replaced with _
+          const filename =
+            (window.location.pathname + window.location.search)
+              .replaceAll("/", "_")
+              .replaceAll("&", "_")
+              .replaceAll("?", "_")
+              .replaceAll("=", "_")
+              .replaceAll(".", "_") + ".png";
+          fetch("/image", {
+            method: "POST",
+            body: JSON.stringify({
+              filename,
+              image: img,
+            }),
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }).then((response) => {
+            if (response.ok) {
+              return response.json();
+            } else {
+              throw new Error("Something went wrong");
+            }
           });
+        });
       }, 1000);
     }
   }, [preparingForScreenshot, takeScreenShot]);
@@ -152,7 +158,10 @@ export default function PolicyOutput(props) {
       const url = `/${metadata.countryId}/economy/${reformPolicyId}/over/${baselinePolicyId}?region=${region}&time_period=${timePeriod}&version=${selectedVersion}`;
       setImpact(null);
       setError(null);
-      asyncApiCall(url, null, 1_000)
+      asyncApiCall(url, null, 1_000, 1_000, (intermediateData) => {
+        console.log(intermediateData);
+        setImpactTimeStats(intermediateData);
+      })
         .then((data) => {
           if (data.status === "error") {
             if (!data.result.baseline_economy) {
@@ -270,7 +279,7 @@ export default function PolicyOutput(props) {
   if (!reformPolicyId) {
     return (
       <ResultsPanel
-        style={{paddingTop: 50}}
+        style={{ paddingTop: 50 }}
         title="Your policy is empty"
         description="You haven't added any reforms to your policy yet. Change policy parameters and see the results here."
       />
@@ -291,7 +300,26 @@ export default function PolicyOutput(props) {
   ).skipImpacts;
 
   if (!impact & !skipImpacts) {
-    pane = <LoadingCentered message="Simulating your policy" />;
+    // Show a Progress bar that fills up over time, taking 100 seconds to fill.
+    pane = (
+      <div style={{ textAlign: "center", paddingTop: 50 }}>
+        <LoadingCentered message="Simulating the impact of your policy..." />
+        <Progress
+          showInfo={false}
+          percent={
+            impactTimeStats
+              ? Math.min(
+                  90,
+                  (impactTimeStats.time_elapsed /
+                    impactTimeStats.average_time) *
+                    100
+                )
+              : 0
+          }
+          strokeColor={style.colors.BLUE}
+        />
+      </div>
+    );
   } else if (focus === "policyOutput.netIncome") {
     pane = (
       <BudgetaryImpact
@@ -431,17 +459,19 @@ export default function PolicyOutput(props) {
   const url = encodeURIComponent(window.location.href);
   const link = (
     // eslint-disable-next-line
-    <a onClick={() => {
-      handleScreenshot();
-      navigator.clipboard.writeText(window.location.href);
-      message.info('Link copied to clipboard');
-    }}>
+    <a
+      onClick={() => {
+        handleScreenshot();
+        navigator.clipboard.writeText(window.location.href);
+        message.info("Link copied to clipboard");
+      }}
+    >
       <LinkOutlined style={{ fontSize: 23 }} />
     </a>
   );
   const encodedPolicyLabel = encodeURIComponent(policyLabel);
   const twitter = (
-    <a 
+    <a
       onClick={() => {
         handleScreenshot();
       }}
@@ -453,19 +483,27 @@ export default function PolicyOutput(props) {
     </a>
   );
   const facebook = (
-    <a href={`https://www.facebook.com/sharer/sharer.php?u=${url}`} target="_blank" rel="noreferrer">
+    <a
+      href={`https://www.facebook.com/sharer/sharer.php?u=${url}`}
+      target="_blank"
+      rel="noreferrer"
+    >
       <FacebookFilled style={{ fontSize: 23 }} />
     </a>
   );
   const linkedIn = (
-    <a href={`https://www.linkedin.com/sharing/share-offsite/?url=${(url)}`} target="_blank" rel="noreferrer">
+    <a
+      href={`https://www.linkedin.com/sharing/share-offsite/?url=${url}`}
+      target="_blank"
+      rel="noreferrer"
+    >
       <LinkedinFilled style={{ fontSize: 23 }} />
     </a>
   );
   const commonStyle = {
-    border: "1px solid #ccc", 
-    borderRadius: "0px", 
-    padding: "6px", 
+    border: "1px solid #ccc",
+    borderRadius: "0px",
+    padding: "6px",
     marginRight: "-1px",
   };
   const shareItems = [link, twitter, facebook, linkedIn];
@@ -478,14 +516,19 @@ export default function PolicyOutput(props) {
   const bottomElements =
     mobile & !embed ? null : metadata.countryId === "us" ? (
       <p>
-        PolicyEngine US v{selectedVersion} estimates reform impacts using microsimulation.{" "}
-        <a href="/us/blog/2022-12-28-enhancing-the-current-population-survey-for-policy-analysis" target="_blank">
+        PolicyEngine US v{selectedVersion} estimates reform impacts using
+        microsimulation.{" "}
+        <a
+          href="/us/blog/2022-12-28-enhancing-the-current-population-survey-for-policy-analysis"
+          target="_blank"
+        >
           Learn more
         </a>
       </p>
     ) : (
       <p>
-        PolicyEngine UK v{selectedVersion} estimates reform impacts using microsimulation.{" "}
+        PolicyEngine UK v{selectedVersion} estimates reform impacts using
+        microsimulation.{" "}
         <a href="/uk/blog/2022-03-07-how-machine-learning-tools-make-policyengine-more-accurate">
           Learn more
         </a>
@@ -510,7 +553,7 @@ export default function PolicyOutput(props) {
             paddingBottom: 100,
           }}
         >
-            {pane}
+          {pane}
         </div>
         <div
           style={{
@@ -529,32 +572,48 @@ export default function PolicyOutput(props) {
 
   pane = (
     <>
-      <div style={{ display: "flex", flexDirection: "row", backgroundColor: style.colors.WHITE,
-      justifyContent: "center", alignItems: "center", paddingBottom: 20,
-     }}>
-      {!preparingForScreenshot && <h6 style={{
-        margin: 0,
-        paddingRight: 20,
-      }}><b>Share this result</b></h6>}
-     <div 
-      style={{ 
-        display: "flex", 
-        flexDirection: "row",
-      }}>
-      {!preparingForScreenshot && shareDivs}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          backgroundColor: style.colors.WHITE,
+          justifyContent: "center",
+          alignItems: "center",
+          paddingBottom: 20,
+        }}
+      >
+        {!preparingForScreenshot && (
+          <h6
+            style={{
+              margin: 0,
+              paddingRight: 20,
+            }}
+          >
+            <b>Share this result</b>
+          </h6>
+        )}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+          }}
+        >
+          {!preparingForScreenshot && shareDivs}
+        </div>
       </div>
-    </div>
       <PolicyImpactPopup
         metadata={metadata}
         hasShownPopulationImpactPopup={hasShownPopulationImpactPopup}
         setHasShownPopulationImpactPopup={setHasShownPopulationImpactPopup}
       />
       {pane}
-      {!preparingForScreenshot && <BottomCarousel
-        selected={focus}
-        options={POLICY_OUTPUT_TREE[0].children}
-        bottomText={bottomElements}
-      />}
+      {!preparingForScreenshot && (
+        <BottomCarousel
+          selected={focus}
+          options={POLICY_OUTPUT_TREE[0].children}
+          bottomText={bottomElements}
+        />
+      )}
     </>
   );
 
@@ -562,5 +621,5 @@ export default function PolicyOutput(props) {
     <div>
       <ResultsPanel ref={imageRef}>{pane}</ResultsPanel>
     </div>
-  )
+  );
 }

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -96,7 +96,7 @@ export default function PolicyOutput(props) {
   const imageRef = useRef(null);
   const [preparingForScreenshot, setPreparingForScreenshot] = useState(false);
   const [, takeScreenShot] = useScreenshot();
-  const [impactTimeStats, setImpactTimeStats] = useState(null);
+  const [averageImpactTime, setAverageImpactTime] = useState(100);
   const [secondsElapsed, setSecondsElapsed] = useState(0);
 
   const handleScreenshot = () => {
@@ -164,7 +164,9 @@ export default function PolicyOutput(props) {
         setSecondsElapsed((secondsElapsed) => secondsElapsed + 1);
       }, 1000);
       asyncApiCall(url, null, 1_000, 1_000, (intermediateData) => {
-        setImpactTimeStats(intermediateData);
+        if(averageImpactTime === 100) {
+          setAverageImpactTime(intermediateData.average_time);
+        }
       })
         .then((data) => {
           if (data.status === "error") {
@@ -184,14 +186,17 @@ export default function PolicyOutput(props) {
               data.result.message = data.message;
             }
             setError(data.result);
+            setSecondsElapsed(0);
             clearInterval(interval);
           } else {
             setImpact(data.result);
+            setSecondsElapsed(0);
             clearInterval(interval);
           }
         })
         .catch((err) => {
           setError(err);
+          setSecondsElapsed(0);
           clearInterval(interval);
         });
     } else {
@@ -314,17 +319,19 @@ export default function PolicyOutput(props) {
         <Progress
           showInfo={false}
           percent={
-            impactTimeStats
+            averageImpactTime
               ? Math.min(
                   90,
-                  (secondsElapsed /
-                    impactTimeStats.average_time) *
-                    100
+                  (secondsElapsed / averageImpactTime) * 100
                 )
               : 0
           }
           strokeColor={style.colors.BLUE}
         />
+        <p>
+          This usually takes around{" "}
+          {Math.round(averageImpactTime / 5) * 5} seconds, but may take longer.
+        </p>
       </div>
     );
   } else if (focus === "policyOutput.netIncome") {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 529bfeb</samp>

### Summary
🔄🇺🇸⏱️

<!--
1.  🔄 for the `apiCall` function modification, since it adds a retry mechanism to the fetch request.
2. 🇺🇸 for the `BudgetaryImpact` component update, since it adds support for US state tax revenues.
3. ⏱️ for the `PolicyOutput` component update, since it adds a progress bar for the simulation time.
-->
This pull request improves the user interface and the error handling of the policy simulation app. It adds a retry mechanism for server errors in `call.js`, a progress bar for the simulation time in `PolicyOutput.jsx`, and a better visualization of the budgetary impact for the US in `BudgetaryImpact.jsx`. It also fixes some minor formatting issues in the code.

> _We face the doom of server errors, we won't give up the fight_
> _We call the API once again, with `secondAttempt` in sight_
> _We show the impact of our policies, with state tax revenues and charts_
> _We add a progress bar to the output, and fix the `import` parts_

### Walkthrough
*  Add a retry mechanism for API calls in case of server errors ([link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-21944af492c6c9ee9158a5bc0a089aef67b9e83c6b6a9c1cce3dae2df054f259L6-R6),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-21944af492c6c9ee9158a5bc0a089aef67b9e83c6b6a9c1cce3dae2df054f259R13-R18))
*  Display a progress bar for the simulation time in the `PolicyOutput` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL20-R20),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL97-R136),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL155-R164),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL294-R322))
*  Handle state tax revenue impact for the US in the `BudgetaryImpact` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L13-R26),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L26-R37),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L84-R103),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L155-R129))
*  Refactor the hovercard logic for the waterfall chart in the `BudgetaryImpact` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L84-R103))
*  Fix the formatting of the import statements, style props, and link elements in the `PolicyOutput` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL34-R40),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL273-R282),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL434-R468),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL444-R474),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL456-R506),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL481-R524),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL488-R531),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL513-R556),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL532-R603),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL553-R616),[link](https://github.com/PolicyEngine/policyengine-app/pull/508/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL565-R624))



Adds State budgetary impacts (only shown if nonzero), and also keeps track of average economic impact times and runs through a slider. Video below (cc @MaxGhenis)

https://user-images.githubusercontent.com/35577657/235360207-ff6b4ccb-022f-4c9b-82f6-0496322f52f2.mov

