### PR TITLE
Fix issue #486 update hover card in Outcomes by income decile page

### DIFF
--- a/src/pages/policy/output/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/IntraDecileImpact.jsx
@@ -268,11 +268,12 @@ export default function IntraDecileImpact(props) {
         const title = group === "All" ? "All households" : `Decile ${group}`;
         const category = data.points[0].data.name;
         const value = data.points[0].x;
-        const message = `${percent(value)} of ${
+        const message = `Of ${
           group === "All"
             ? "all households"
             : `households in the ${cardinal(group)} decile`
-        } ${category.toLowerCase()}.`;
+        }, ${policyLabel} would cause ${percent(value)} of people to
+        ${category.toLowerCase()} of their net income.`;
         setHovercard({
           title: title,
           body: message,


### PR DESCRIPTION
This is the current message format:
<img width="1512" alt="Screen Shot 2023-05-03 at 2 48 12 PM" src="https://user-images.githubusercontent.com/59995724/235850496-58ee6fe0-e942-4638-a7c6-93d4852d210a.png">

