### PR TITLE
Fix social card issue

### DIFF
--- a/gcp/main.py
+++ b/gcp/main.py
@@ -10,7 +10,7 @@ app = Flask(__name__, static_folder="build")
 
 @app.before_request
 def before_request():
-    if request.url.startswith("httpa://"):
+    if request.url.startswith("http://"):
         url = request.url.replace("http://", "https://", 1)
         code = 301
         return redirect(url, code=code)

--- a/gcp/social_card_tags.py
+++ b/gcp/social_card_tags.py
@@ -35,6 +35,7 @@ def get_title(path: str, query_params: dict):
 
 
 def get_image(path: str, query_params: dict, social_cards: dict = {}):
+    print(f"Getting image for {path}")
     # Replace all /, ? and = from the path and query string combined with -
 
     country = path.split("/")[1].upper()
@@ -64,7 +65,11 @@ def get_image(path: str, query_params: dict, social_cards: dict = {}):
         image_folder = Path("./build/static/media")
         image_files = list(image_folder.glob(f"{filename}.*"))
         if len(image_files) > 0:
-            filename = image_files[0].name
+            # In order of preference: file ending with .png, then jpeg, then jpg
+            for extension in [".png", ".jpeg", ".jpg"]:
+                for image_file in image_files:
+                    if image_file.name.endswith(extension):
+                        return f"https://policyengine.org/static/media/{image_file.name}"
             return f"https://policyengine.org/static/media/{filename}"
 
     # Check if there is a filename in the social_cards dict whose non-extension part matches the path


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c392790</samp>

### Summary
🐛🖨️🖼️

<!--
1.  🐛 for fixing a bug in the `before_request` function.
2.  🖨️ for adding a print statement to `get_title` for debugging purposes.
3.  🖼️ for improving the image generation logic in `get_image`.
-->
This pull request enhances the social card image generation and fixes a security issue with the request url. It adds a print statement to `get_title` in `gcp/social_card_tags.py` and corrects the file extension logic in `get_image`. It also removes an extra `a` from the `startswith` argument in `gcp/main.py` to enable the redirection from `http://` to `https://`.

> _We fix the typo of doom, no more `http://`_
> _We redirect the fools to the secure path_
> _We generate the social cards with skill and grace_
> _We print the title and we check the file extension_

### Walkthrough
* Fix typo in url redirection logic ([link](https://github.com/PolicyEngine/policyengine-app/pull/520/files?diff=unified&w=0#diff-9587992a2d42c54bfca816a0842881adbff62f5cba34c6f09b8a0ff6a7941a55L13-R13))
* Improve social card image selection by prioritizing file extensions ([link](https://github.com/PolicyEngine/policyengine-app/pull/520/files?diff=unified&w=0#diff-ae0dd35c4814ef458813c7a57b98943aee67f68f6d496f094b7543b37a786c66L67-R72))
* Add print statement for debugging and logging title generation ([link](https://github.com/PolicyEngine/policyengine-app/pull/520/files?diff=unified&w=0#diff-ae0dd35c4814ef458813c7a57b98943aee67f68f6d496f094b7543b37a786c66R38))



Fixes #516 - the issue was that the social card was erroneously returning the URL of the MD file, not the PNG file.