### PR TITLE
Fix issue #501: distinguish State vs federal budgetary impacts

### DIFF
--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -19,30 +19,25 @@ export default function BudgetaryImpact(props) {
 
   const urlParams = new URLSearchParams(window.location.search);
   const region = urlParams.get("region");
-  const desktopLabels = [
+
+  let desktopLabels = [
     "Federal tax revenues",
     "State tax revenues",
     "Benefit spending",
     "Net impact",
   ];
-  const mobileLabels = ["Federal taxes", "State taxes", "Benefits", "Net"];
-  let valuesBeforeFilter, labelsBeforeFilter;
-  if (region === "us") {
-    valuesBeforeFilter = [
-      taxImpact / 1e9,
-      stateTaxImpact / 1e9,
-      -spendingImpact / 1e9,
-      budgetaryImpact / 1e9,
-    ];
-    labelsBeforeFilter = mobile ? mobileLabels : desktopLabels
-  } else {
-    valuesBeforeFilter = [
-      taxImpact / 1e9,
-      stateTaxImpact / 1e9,
-      -spendingImpact / 1e9,
-    ];
-    labelsBeforeFilter = mobile ? ["Federal taxes", "State taxes", "Benefits"] : ["Federal tax revenues", "State tax revenues", "Benefit spending"];
+  let mobileLabels = ["Federal taxes", "State taxes", "Benefits", "Net"];
+  if (region !== "us" && region !== "ca") {
+    desktopLabels[0] = "Tax revenues";
+    mobileLabels[0] = "Taxes";
   }
+  const labelsBeforeFilter = mobile ? mobileLabels : desktopLabels;
+  const valuesBeforeFilter = [
+    taxImpact / 1e9,
+    stateTaxImpact / 1e9,
+    -spendingImpact / 1e9,
+    budgetaryImpact / 1e9,
+  ];
   const values = valuesBeforeFilter.filter((value) => value !== 0);
   // Only include labels for which there is a value
   const labels = labelsBeforeFilter.filter(

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -16,6 +16,9 @@ export default function BudgetaryImpact(props) {
   const spendingImpact = impact.budget.benefit_spending_impact;
   const stateTaxImpact = impact.budget.state_tax_revenue_impact;
   const taxImpact = impact.budget.tax_revenue_impact - stateTaxImpact;
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const region = urlParams.get("region");
   const desktopLabels = [
     "Federal tax revenues",
     "State tax revenues",
@@ -23,13 +26,23 @@ export default function BudgetaryImpact(props) {
     "Net impact",
   ];
   const mobileLabels = ["Federal taxes", "State taxes", "Benefits", "Net"];
-  const labelsBeforeFilter = mobile ? mobileLabels : desktopLabels;
-  const valuesBeforeFilter = [
-    taxImpact / 1e9,
-    stateTaxImpact / 1e9,
-    -spendingImpact / 1e9,
-    budgetaryImpact / 1e9,
-  ];
+  let valuesBeforeFilter, labelsBeforeFilter;
+  if (region === "us") {
+    valuesBeforeFilter = [
+      taxImpact / 1e9,
+      stateTaxImpact / 1e9,
+      -spendingImpact / 1e9,
+      budgetaryImpact / 1e9,
+    ];
+    labelsBeforeFilter = mobile ? mobileLabels : desktopLabels
+  } else {
+    valuesBeforeFilter = [
+      taxImpact / 1e9,
+      stateTaxImpact / 1e9,
+      -spendingImpact / 1e9,
+    ];
+    labelsBeforeFilter = mobile ? ["Federal taxes", "State taxes", "Benefits"] : ["Federal tax revenues", "State tax revenues", "Benefit spending"];
+  }
   const values = valuesBeforeFilter.filter((value) => value !== 0);
   // Only include labels for which there is a value
   const labels = labelsBeforeFilter.filter(
@@ -138,8 +151,6 @@ export default function BudgetaryImpact(props) {
       }}
     />
   );
-  const urlParams = new URLSearchParams(window.location.search);
-  const region = urlParams.get("region");
 
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ddb7bfd</samp>

### Summary
🌎💰📊

<!--
1.  🌎 - This emoji represents the global or regional aspect of the changes, as the component now supports different regions for the policy simulation.
2.  💰 - This emoji represents the budgetary impact aspect of the changes, as the component displays the fiscal effects of the policy simulation on the selected region.
3.  📊 - This emoji represents the chart or data visualization aspect of the changes, as the component uses a chart to show the budgetary impact of the policy simulation.
-->
This pull request enhances the `BudgetaryImpact` component to support regional policy simulations. It uses the URL parameter to fetch and display the appropriate budgetary impact data for each region.

> _To simulate policies in regions_
> _We updated the `BudgetaryImpact` legions_
> _We got the param from the URL_
> _And tweaked the chart to show it well_
> _And also removed some code redundancies_

### Walkthrough
*  Add code to get the region parameter from the URL query string in `BudgetaryImpact.jsx` ([link](https://github.com/PolicyEngine/policyengine-app/pull/542/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3R19-R21))
*  Modify the values and labels for the budgetary impact chart based on the region parameter in `BudgetaryImpact.jsx` ([link](https://github.com/PolicyEngine/policyengine-app/pull/542/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L26-R45))
*  Remove the redundant code to get the region parameter in the `BudgetaryImpactChart` component in `BudgetaryImpact.jsx` ([link](https://github.com/PolicyEngine/policyengine-app/pull/542/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L141-L142))


