### PR TITLE
ChartLogo overlap fix

### DIFF
--- a/src/api/charts.js
+++ b/src/api/charts.js
@@ -1,17 +1,17 @@
 import PolicyEngineLogoBlue from "../images/logos/policyengine/blue.png";
 
-export const ChartLogo = {
+export const ChartLogo = (x, y) => ({
   images: [
     {
       source: PolicyEngineLogoBlue,
       xref: "paper",
       yref: "paper",
-      x: 0.97,
-      y: -0.15,
+      x: x,
+      y: y,
       sizex: 0.15,
       sizey: 0.15,
       xanchor: "right",
       yanchor: "bottom",
     },
   ],
-};
+});

--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -50,7 +50,7 @@ export default function AverageImpactByDecile(props) {
           mode: "hide",
           minsize: mobile ? 4 : 8,
         },
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 80,

--- a/src/pages/policy/output/AverageImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByWealthDecile.jsx
@@ -50,7 +50,7 @@ export default function AverageImpactByWealthDecile(props) {
           mode: "hide",
           minsize: mobile ? 4 : 8,
         },
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 80,

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -94,7 +94,7 @@ export default function BudgetaryImpact(props) {
           mode: "hide",
           minsize: 12,
         },
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 100,

--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -130,7 +130,7 @@ export default function CliffImpact(props) {
           mode: "hide",
           minsize: 8,
         },
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 80,

--- a/src/pages/policy/output/DeepPovertyImpact.jsx
+++ b/src/pages/policy/output/DeepPovertyImpact.jsx
@@ -77,7 +77,7 @@ export default function DeepPovertyImpact(props) {
           mode: "hide",
           minsize: 8,
         },
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 100,

--- a/src/pages/policy/output/DeepPovertyImpactByGender.jsx
+++ b/src/pages/policy/output/DeepPovertyImpactByGender.jsx
@@ -71,7 +71,7 @@ export default function DeepPovertyImpactByGender(props) {
           mode: "hide",
           minsize: 8,
         },
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 100,

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -58,7 +58,7 @@ export default function InequalityImpact(props) {
           mode: "hide",
           minsize: 12,
         },
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 100,

--- a/src/pages/policy/output/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/IntraDecileImpact.jsx
@@ -246,7 +246,7 @@ export default function IntraDecileImpact(props) {
           minsize: mobile ? 7 : 10,
         },
         showlegend: false,
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 80,

--- a/src/pages/policy/output/IntraWealthDecileImpact.jsx
+++ b/src/pages/policy/output/IntraWealthDecileImpact.jsx
@@ -246,7 +246,7 @@ export default function IntraWealthDecileImpact(props) {
           minsize: mobile ? 7 : 10,
         },
         showlegend: false,
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 80,

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -75,7 +75,7 @@ export default function PovertyImpact(props) {
           mode: "hide",
           minsize: 8,
         },
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 100,

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -69,7 +69,7 @@ export default function PovertyImpactByGender(props) {
           mode: "hide",
           minsize: 8,
         },
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 100,

--- a/src/pages/policy/output/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/PovertyImpactByRace.jsx
@@ -82,7 +82,7 @@ export default function PovertyImpactByRace(props) {
           mode: "hide",
           minsize: 8,
         },
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 100,

--- a/src/pages/policy/output/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByDecile.jsx
@@ -50,7 +50,7 @@ export default function RelativeImpactByDecile(props) {
           minsize: 8,
         },
         showlegend: false,
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 80,

--- a/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
@@ -50,7 +50,7 @@ export default function RelativeImpactByWealthDecile(props) {
           minsize: 8,
         },
         showlegend: false,
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
         margin: {
           t: 0,
           b: 80,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 82e8ac6</samp>

### Summary
📱📊🔧

<!--
1.  📱 - This emoji represents the mobile device condition that affects the logo position.
2.  📊 - This emoji represents the charts that were modified to invoke the `ChartLogo` function with the appropriate arguments.
3.  🔧 - This emoji represents the refactoring of the `ChartLogo` function to make it more flexible and reusable.
-->
Refactored `ChartLogo` to be a function that accepts position arguments, and applied it to all output charts. This improves the logo placement and responsiveness on different devices and screen sizes.

> _`ChartLogo` adapts_
> _to mobile or desktop views_
> _autumn leaves falling_

### Walkthrough
*  Convert `ChartLogo` object to a function that takes `x` and `y` parameters for logo position ([link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-fd1e93b85e76819144371e1181bdf0d1a97cb142ab45e6d4c7ecd520107c299cL3-R3), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-fd1e93b85e76819144371e1181bdf0d1a97cb142ab45e6d4c7ecd520107c299cL9-R10), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-fd1e93b85e76819144371e1181bdf0d1a97cb142ab45e6d4c7ecd520107c299cL17-R17))
*  Invoke `ChartLogo` function with appropriate `x` and `y` values for each chart component, depending on `mobile` variable ([link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L53-R53), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aL53-R53), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L97-R97), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L133-R133), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8L80-R80), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cL74-R74), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L61-R61), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-71b88b3f4ac09980a01bd897cb30749591d957adfb78c6de0b91e8010b71072aL249-R249), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-d41e88c8038a48564a3b9efe556677354d37e1fc69a77bd612f33d5aa98cda85L249-R249), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L78-R78), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-04e2d157bf184eb210182f434c2f34a470a711a29e5aa61e626d0cabb949526fL72-R72), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-666b4a2954e170f5d63c511ffebea4d88b6f3ef1c2d7e836d4cfc6b6fe268bcbL85-R85), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-2b5717cbee57bbbc685fbb5310eb4f84ee1f0b60fc6215373dd876f733f47fb4L53-R53), [link](https://github.com/PolicyEngine/policyengine-app/pull/548/files?diff=unified&w=0#diff-3479abe14967df8c0649d35cc8a385878b52956281431d871039601f975a133cL53-R53))


