### PR TITLE
Update wording of "average" for average impact by docile and relative…

### DIFF
--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -125,14 +125,14 @@ export default function AverageImpactByDecile(props) {
     <>
       <Screenshottable>
         <h2>
-          {policyLabel}{" "}
-          {averageChange >= 0 ? "would increase" : "would decrease"} the average
-          household&apos;s net income {label} by{" "}
+        {policyLabel}&nbsp;
+          {averageChange >= 0 ? "would increase" : "would decrease"} the
+          net income of households {label} by&nbsp;
           {formatVariableValue(
             metadata.variables.household_net_income,
             Math.abs(averageChange),
             0
-          )}
+          )} on average
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
       </Screenshottable>

--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -125,7 +125,7 @@ export default function AverageImpactByDecile(props) {
     <>
       <Screenshottable>
         <h2>
-        {policyLabel}&nbsp;
+          {policyLabel}&nbsp;
           {averageChange >= 0 ? "would increase" : "would decrease"} the
           net income of households {label} by&nbsp;
           {formatVariableValue(

--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -8,6 +8,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { avgChangeDirection} from './utils';
 
 export default function AverageImpactByDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -125,14 +126,12 @@ export default function AverageImpactByDecile(props) {
     <>
       <Screenshottable>
         <h2>
-          {policyLabel}&nbsp;
-          {averageChange >= 0 ? "would increase" : "would decrease"} the
-          net income of households {label} by&nbsp;
-          {formatVariableValue(
+          {`${policyLabel} ${avgChangeDirection(averageChange)} the net income of households ${label} by ${
+          formatVariableValue(
             metadata.variables.household_net_income,
             Math.abs(averageChange),
             0
-          )} on average
+          )} on average`}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
       </Screenshottable>

--- a/src/pages/policy/output/AverageImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByWealthDecile.jsx
@@ -8,6 +8,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { avgChangeDirection} from './utils';
 
 export default function AverageImpactByWealthDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -125,14 +126,12 @@ export default function AverageImpactByWealthDecile(props) {
     <>
       <Screenshottable>
         <h2>
-          {policyLabel}{" "}
-          {averageChange >= 0 ? "would increase" : "would decrease"} the average
-          household&apos;s net income {label} by{" "}
-          {formatVariableValue(
+          {`${policyLabel} ${avgChangeDirection(averageChange)} the net income of households ${label} by ${
+            formatVariableValue(
             metadata.variables.household_net_income,
             Math.abs(averageChange),
             0
-          )}
+          )} on average`}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
       </Screenshottable>

--- a/src/pages/policy/output/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByDecile.jsx
@@ -8,6 +8,7 @@ import { cardinal, percent } from "../../../api/language";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
+import { avgChangeDirection} from './utils';
 
 export default function RelativeImpactByDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -124,10 +125,8 @@ export default function RelativeImpactByDecile(props) {
     <>
       <Screenshottable>
         <h2>
-          {policyLabel}&nbsp;
-          {averageRelChange >= 0 ? "would increase" : "would decrease"} the
-          net income of households {label} by&nbsp;
-          {formatVariableValue({ unit: "/1" }, Math.abs(averageRelChange), 1)} on average
+          {`${policyLabel} ${avgChangeDirection(averageRelChange)} the net income of households ${label} by ${
+            formatVariableValue({ unit: "/1" }, Math.abs(averageRelChange), 1)} on average`}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
       </Screenshottable>

--- a/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
@@ -8,6 +8,7 @@ import { cardinal, percent } from "../../../api/language";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
+import { avgChangeDirection} from './utils';
 
 export default function RelativeImpactByWealthDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -123,10 +124,8 @@ export default function RelativeImpactByWealthDecile(props) {
     <>
       <Screenshottable>
         <h2>
-          {policyLabel}&nbsp;
-          {averageRelChange >= 0 ? "would increase" : "would decrease"} the
-          net income of households {label} by&nbsp;
-          {formatVariableValue({ unit: "/1" }, Math.abs(averageRelChange), 1)} on average
+          {`${policyLabel} ${avgChangeDirection(averageRelChange)} the net income of households ${label} by ${
+            formatVariableValue({ unit: "/1" }, Math.abs(averageRelChange), 1)} on average`}
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
       </Screenshottable>

--- a/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
@@ -123,10 +123,10 @@ export default function RelativeImpactByWealthDecile(props) {
     <>
       <Screenshottable>
         <h2>
-          {policyLabel}{" "}
+          {policyLabel}&nbsp;
           {averageRelChange >= 0 ? "would increase" : "would decrease"} the
-          average household&apos;s net income {label} by{" "}
-          {formatVariableValue({ unit: "/1" }, Math.abs(averageRelChange), 1)}
+          net income of households {label} by&nbsp;
+          {formatVariableValue({ unit: "/1" }, Math.abs(averageRelChange), 1)} on average
         </h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
       </Screenshottable>

--- a/src/pages/policy/output/utils.js
+++ b/src/pages/policy/output/utils.js
@@ -1,0 +1,1 @@
+export const avgChangeDirection = change => change >= 0 ? "would increase" : "would decrease";


### PR DESCRIPTION
… impact by wealth docile

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a7c0f62</samp>

### Summary
📝🚚♻️

<!--
1.  📝 This emoji represents the change in wording for the heading, as it is a minor edit or correction to the text.
2.  🚚 This emoji represents the change in code location for the relative impact by wealth decile chart, as it is a move or rename of files or folders.
3.  ♻️ This emoji represents the change in code structure for the relative impact by decile chart, as it is a refactoring or improvement of the code.
-->
This pull request refactors the code for the output charts of the policy simulation, moving the relative impact by wealth decile chart to the same file as the average impact by decile chart. It also improves the readability of the chart headings by changing the wording and spacing.

> _`Decile` charts merge_
> _Wording and spacing improve_
> _Winter of refact'ring_

### Walkthrough
*  Refactor and improve the wording and spacing of the charts for average and relative impact by decile ([link](https://github.com/PolicyEngine/policyengine-app/pull/552/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L128-R135), [link](https://github.com/PolicyEngine/policyengine-app/pull/552/files?diff=unified&w=0#diff-3479abe14967df8c0649d35cc8a385878b52956281431d871039601f975a133cL126-R129))



I was looking around and saw this type of wording happens in two other places. I could only replicate the two in the screen shot and  RelativeImpactByDecile was done in prev PR https://github.com/PolicyEngine/policyengine-app/pull/551
<img width="500" alt="Screenshot 2023-05-24 at 10 36 56 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/110482616/eb2a6dc4-016f-45b9-9955-de5b1a6e4e54">
