### PR TITLE
Fix #459: Add caution modal for US impacts of State tax reforms

### DIFF
--- a/src/controls/NavigationButton.jsx
+++ b/src/controls/NavigationButton.jsx
@@ -4,33 +4,35 @@ import { copySearchParams } from "../api/call";
 import Button from "./Button";
 
 export default function NavigationButton(props) {
-  const { text, focus, target, style, primary, disabled } = props;
+  const { text, focus, target, style, primary, disabled, onClick} = props;
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
 
+  const handleClick = onClick || (() => {
+    let newSearch = copySearchParams(searchParams);
+    newSearch.set("focus", focus);
+    if (target) {
+      navigate(target + "?" + newSearch);
+      gtag("event", "navigate", {
+        event_category: "link",
+        event_label: target,
+      });
+    } else {
+      setSearchParams(newSearch);
+      gtag("event", "navigate", {
+        event_category: "focus",
+        event_label: focus,
+      });
+    }
+  });
+
   return (
     <Button
-      primary={primary}
-      disabled={disabled}
-      text={text}
-      style={{ ...style, margin: 10 }}
-      onClick={() => {
-        let newSearch = copySearchParams(searchParams);
-        newSearch.set("focus", focus);
-        if (target) {
-          navigate(target + "?" + newSearch);
-          gtag("event", "navigate", {
-            event_category: "link",
-            event_label: target,
-          });
-        } else {
-          setSearchParams(newSearch);
-          gtag("event", "navigate", {
-            event_category: "focus",
-            event_label: focus,
-          });
-        }
-      }}
-    />
+    primary={primary}
+    disabled={disabled}
+    text={text}
+    style={{ ...style, margin: 10 }}
+    onClick={handleClick}
+  />
   );
 }

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -13,6 +13,7 @@ import style from "../../style";
 import { RegionSelector, TimePeriodSelector } from "./output/PolicyOutput";
 import PolicySearch from "./PolicySearch";
 import { Alert, Modal} from "antd";
+import { ExclamationCircleOutlined } from "@ant-design/icons";
 
 function PolicyNamer(props) {
   const { policy, metadata } = props;
@@ -198,17 +199,36 @@ export default function PolicyRightSidebar(props) {
   const reformPolicyId = searchParams.get("reform");
   const baselinePolicyId = searchParams.get("baseline");
   const focus = searchParams.get("focus") || "";
+  const stateAbbreviation = focus.split(".")[2];
   const hasHousehold = searchParams.get("household") !== null;
   const [showReformSearch, setShowReformSearch] = useState(false);
+  const options = metadata.economy_options.region.map((stateAbbreviation) => {
+    return { value: stateAbbreviation.name, label: stateAbbreviation.label };
+  });
+  const label = options.find((option) => option.value === stateAbbreviation)?.label;
   const confirmEconomicImpact = () => {
     if (region === "us" && focus.startsWith("gov.states")) {
       Modal.confirm({
-        title: "Confirm",
-        content: "You are about to calculate the economic impact of a state tax reform for the entire US. Are you sure you want to proceed?",
+        title: " You are about to calculate the economic impact of a state tax reform for the entire US",
+        content: `To compute economic impacts over ${label} only, select that option in the region selector on the right pane.
+         Are you sure you want to proceed?`,
+        icon: <ExclamationCircleOutlined style={{ color: "#2C6496" }} />,
         onOk() {
           let newSearch = copySearchParams(searchParams);
           newSearch.set("focus", "policyOutput");
           setSearchParams(newSearch);
+        },
+        okButtonProps: {
+          style: {
+            backgroundColor: "#2C6496", 
+            borderColor: "#2C6496", 
+          },
+        },
+        bodyStyle: {
+          paddingLeft: '9px' 
+        },
+        style: {
+          top: "25%", 
         },
       });
     } else {

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -205,19 +205,30 @@ export default function PolicyRightSidebar(props) {
   const options = metadata.economy_options.region.map((stateAbbreviation) => {
     return { value: stateAbbreviation.name, label: stateAbbreviation.label };
   });
+  options.push({ value: region, label: region });
   const label = options.find((option) => option.value === stateAbbreviation)?.label;
+  const regionLabel = options.find((option) => option.value === region)?.label;
   const confirmEconomicImpact = () => {
+    let message = "";
+    if (stateAbbreviation && stateAbbreviation !== region) {
+      message = `You are about to calculate the economic impact of a tax reform in ${label} for ${regionLabel} `;
+    }
     if (region === "us" && focus.startsWith("gov.states")) {
+      message = "You are about to calculate the economic impact of a state tax reform for the entire US ";
+    }
+    if (message) {
       Modal.confirm({
-        title: " You are about to calculate the economic impact of a state tax reform for the entire US",
-        content: `To compute economic impacts over ${label} only, select that option in the region selector on the right pane.
-         Are you sure you want to proceed?`,
+        title: message,
+        content: `Change the simulation region to ${label} by clicking "Change State".`,
         icon: <ExclamationCircleOutlined style={{ color: "#2C6496" }} />,
         onOk() {
           let newSearch = copySearchParams(searchParams);
-          newSearch.set("focus", "policyOutput");
+          newSearch.set("region", stateAbbreviation);
           setSearchParams(newSearch);
+          window.location.reload();
         },
+        okText: "Change State", // Customize the OK button text
+        cancelText: "Continue",
         okButtonProps: {
           style: {
             backgroundColor: "#2C6496", 

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -12,7 +12,7 @@ import NavigationButton from "../../controls/NavigationButton";
 import style from "../../style";
 import { RegionSelector, TimePeriodSelector } from "./output/PolicyOutput";
 import PolicySearch from "./PolicySearch";
-import { Alert } from "antd";
+import { Alert, Modal} from "antd";
 
 function PolicyNamer(props) {
   const { policy, metadata } = props;
@@ -200,6 +200,24 @@ export default function PolicyRightSidebar(props) {
   const focus = searchParams.get("focus") || "";
   const hasHousehold = searchParams.get("household") !== null;
   const [showReformSearch, setShowReformSearch] = useState(false);
+  const confirmEconomicImpact = () => {
+    if (region === "us" && focus.startsWith("gov.states")) {
+      Modal.confirm({
+        title: "Confirm",
+        content: "You are about to calculate the economic impact of a state tax reform for the entire US. Are you sure you want to proceed?",
+        onOk() {
+          let newSearch = copySearchParams(searchParams);
+          newSearch.set("focus", "policyOutput");
+          setSearchParams(newSearch);
+        },
+      });
+    } else {
+      let newSearch = copySearchParams(searchParams);
+      newSearch.set("focus", "policyOutput");
+      setSearchParams(newSearch);
+    }
+  };
+
   useEffect(() => {
     if (!region || !timePeriod || !reformPolicyId || !baselinePolicyId) {
       const defaults = {
@@ -354,7 +372,7 @@ export default function PolicyRightSidebar(props) {
         <NavigationButton
           primary
           text="Calculate economic impact"
-          focus="policyOutput"
+          onClick={confirmEconomicImpact}
         />
       )}
       {!hideButtons && !hasHousehold && (

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -214,7 +214,7 @@ export default function PolicyRightSidebar(props) {
       message = `You are about to calculate the economic impact of a tax reform in ${label} for ${regionLabel} `;
     }
     if (region === "us" && focus.startsWith("gov.states")) {
-      message = "You are about to calculate the economic impact of a state tax reform for the entire US ";
+      message = "You are about to calculate the economic impact of a state tax reform for the entire US, which PolicyEngine does not currently support. ";
     }
     if (message) {
       Modal.confirm({


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1b6854c</samp>

### Summary
🛠️💬🚀

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate the modification of the `NavigationButton` component to accept an optional `onClick` prop.
2.  💬 - This emoji represents a speech bubble or a conversation, and can be used to indicate the addition of a confirmation dialog for calculating the economic impact of state tax reforms using the `Modal` component.
3.  🚀 - This emoji represents a rocket or a launch, and can be used to indicate the update of the `NavigationButton` component to use the new dialog function.
-->
This pull request adds a confirmation dialog for calculating the economic impact of state tax reforms on the policy page. It also enhances the `NavigationButton` component to allow custom click handlers. These changes improve the user experience and functionality of the policy page.

> _To make `NavigationButton` more clever_
> _We added an `onClick` prop lever_
> _It can show a `Modal`_
> _Before changing the total_
> _Of the state tax reform's endeavor_

### Walkthrough
*  Add confirmation dialog for economic impact calculation ([link](https://github.com/PolicyEngine/policyengine-app/pull/560/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285L15-R15), [link](https://github.com/PolicyEngine/policyengine-app/pull/560/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285R203-R220), [link](https://github.com/PolicyEngine/policyengine-app/pull/560/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285L357-R375))
*  Allow custom `onClick` prop for `NavigationButton` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/560/files?diff=unified&w=0#diff-fc3284b09378d8360c8bcfe2e7e44d6cbe6c4e806becdf3ace25facd8bb619a1L7-R36))


