### PR TITLE
Add reusable logic to util file

### DIFF
--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -8,6 +8,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { getLabel } from './utils'
 
 export default function AverageImpactByDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -106,10 +107,7 @@ export default function AverageImpactByDecile(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
+  const label = getLabel(region, options)
   
   const data = Object.entries(impact.decile.average).map(([key, value]) => [
     `Decile ${key}`,

--- a/src/pages/policy/output/AverageImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByWealthDecile.jsx
@@ -8,6 +8,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { getLabel } from './utils'
 
 export default function AverageImpactByWealthDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -107,10 +108,9 @@ export default function AverageImpactByWealthDecile(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
+
+  const label = getLabel(region, options)
+
   const data = Object.entries(impact.wealth_decile.average).map(([key, value]) => [
     `Decile ${key}`,
     value,

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from "./DownloadCsvButton";
+import { getLabel } from './utils'
 
 export default function BudgetaryImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -150,10 +151,7 @@ export default function BudgetaryImpact(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-    region === "us" || region === "uk"
-      ? ""
-      : "in " + options.find((option) => option.value === region)?.label;
+  const label = getLabel(region, options)
 
   // rewrite above but using labels/values
   const data = labels.map((label, index) => {

--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -12,6 +12,7 @@ import ResultsPanel from "../../../layout/ResultsPanel";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { getLabel } from './utils'
 
 export default function CliffImpact(props) {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -184,10 +185,7 @@ export default function CliffImpact(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : " in " + options.find((option) => option.value === region)?.label;
+  const label = getLabel(region, options)
 
   const title = `${policyLabel} ${
     cliff_share_change === 0 && cliff_gap_change === 0

--- a/src/pages/policy/output/DeepPovertyImpact.jsx
+++ b/src/pages/policy/output/DeepPovertyImpact.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { getLabel } from './utils'
 
 export default function DeepPovertyImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -138,11 +139,7 @@ export default function DeepPovertyImpact(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
-  
+  const label = getLabel(region, options)
   const csvHeader = ['Age Group', 'Baseline', 'Reform', 'Change'];
   const data = [
     csvHeader,

--- a/src/pages/policy/output/DeepPovertyImpactByGender.jsx
+++ b/src/pages/policy/output/DeepPovertyImpactByGender.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { getLabel } from './utils'
 
 export default function DeepPovertyImpactByGender(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -137,10 +138,7 @@ export default function DeepPovertyImpactByGender(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
+  const label = getLabel(region, options)
   
   const csvHeader = ["Sex", "Baseline", "Reform", "Change"];
   const data = [

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import {getLabel} from './utils'
 
 export default function InequalityImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -156,11 +157,7 @@ export default function InequalityImpact(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
-  
+  const label = getLabel(region, options)
   const csvHeader = ["Metric", "Baseline", "Reform", "Change"];
   const metricLabels = ["Gini index", "Top 10% share", "Top 1% share"];
   const baselineValues = [

--- a/src/pages/policy/output/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/IntraDecileImpact.jsx
@@ -8,6 +8,7 @@ import { cardinal, percent } from "../../../api/language";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
+import { getLabelForPopulation } from './utils'
 
 export default function IntraDecileImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -290,10 +291,7 @@ export default function IntraDecileImpact(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? " of the population"
-    : " of " + options.find((option) => option.value === region)?.label + " residents";
+  const label = getLabelForPopulation(region, options)
   
   const csvHeader = [
     "Decile",

--- a/src/pages/policy/output/IntraWealthDecileImpact.jsx
+++ b/src/pages/policy/output/IntraWealthDecileImpact.jsx
@@ -8,6 +8,7 @@ import { cardinal, percent } from "../../../api/language";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
+import { getLabelForPopulation } from './utils'
 
 export default function IntraWealthDecileImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -289,10 +290,7 @@ export default function IntraWealthDecileImpact(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? " of the population"
-    : " of " + options.find((option) => option.value === region)?.label + " residents";
+  const label = getLabelForPopulation(region, options)
 
   const csvHeader = [
     "Wealth Decile",

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { getLabel } from './utils'
 
 export default function PovertyImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -135,11 +136,7 @@ export default function PovertyImpact(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
-  
+  const label = getLabel(region, options)
   const csvHeader = ['Age Group', 'Baseline', 'Reform', 'Change'];
   const data = [
     csvHeader,

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { getLabel } from './utils'
 
 export default function PovertyImpactByGender(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -137,10 +138,7 @@ export default function PovertyImpactByGender(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
+  const label = getLabel(region, options)
   
   const csvHeader = ['Sex', 'Baseline', 'Reform', 'Change'];
   const data = [

--- a/src/pages/policy/output/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/PovertyImpactByRace.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { getLabel } from './utils'
 
 export default function PovertyImpactByRace(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -155,10 +156,7 @@ export default function PovertyImpactByRace(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
+  const label = getLabel(region, options)
   
   const csvHeader = ['Race', 'Baseline', 'Reform', 'Change'];
   const data = [

--- a/src/pages/policy/output/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByDecile.jsx
@@ -8,6 +8,7 @@ import { cardinal, percent } from "../../../api/language";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
+import { getLabel } from './utils'
 
 export default function RelativeImpactByDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -102,10 +103,7 @@ export default function RelativeImpactByDecile(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
+  const label = getLabel(region, options)
   
   const csvHeader = ['Income Decile', 'Relative Change'];
   const data = [

--- a/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
@@ -8,6 +8,7 @@ import { cardinal, percent } from "../../../api/language";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
+import { getLabel } from './utils'
 
 export default function RelativeImpactByWealthDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -102,10 +103,7 @@ export default function RelativeImpactByWealthDecile(props) {
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
+  const label = getLabel(region, options)
   const csvHeader = ['Wealth Decile', 'Relative Change'];
   const data = [
     csvHeader,

--- a/src/pages/policy/output/utils.js
+++ b/src/pages/policy/output/utils.js
@@ -1,0 +1,15 @@
+const isUsOrUk = (region) => region === "us" || region === "uk";
+
+const getLabel = (region, options) =>
+  isUsOrUk(region)
+    ? ""
+    : "in " + options.find((option) => option.value === region)?.label;
+
+const getLabelForPopulation = (region, options) =>
+  isUsOrUk(region)
+    ? " of the population"
+    : " of " +
+      options.find((option) => option.value === region)?.label +
+      " residents";
+
+export { getLabel, getLabelForPopulation };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 690f954</samp>

### Summary
🛠️🏷️📊

<!--
1.  🛠️ - This emoji represents the refactoring and improvement of the code quality and readability, as well as the reduction of code duplication.
2. 🏷️ - This emoji represents the creation and use of the utility functions for generating labels based on the options array, which is a key feature of the changes.
3. 📊 - This emoji represents the impact of the changes on the various components that display charts and graphs based on the region and population labels.
-->
This pull request refactors the code for generating labels in various output components, using utility functions `getLabel` and `getLabelForPopulation` from `utils.js`. This improves the readability, consistency, and maintainability of the code.

> _We're refactoring the code, me hearties, yo ho ho_
> _We're using `getLabel` and `getLabelForPopulation`, yo ho ho_
> _We're making it more readable and maintainable, yo ho ho_
> _We're heaving on the line on the count of three, yo ho ho_

### Walkthrough
*  Extract the logic for generating the label for the region and the population based on the options array into two helper functions `getLabel` and `getLabelForPopulation` in the `utils.js` file ([link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-11cc7d4a3f8c94ad9a513f540317c7c1998a6077335b84aa6b1f368a35eff988R1-R15))
* Import and use the `getLabel` function in the following components to simplify the code and avoid repetition: `AverageImpactByDecile`, `AverageImpactByWealthDecile`, `BudgetaryImpact`, `CliffImpact`, `DeepPovertyImpact`, `DeepPovertyImpactByGender`, `InequalityImpact`, `PovertyImpact`, `PovertyImpactByGender`, and `PovertyImpactByRace` ([link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2R11), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L109-R110), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aR11), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aL110-R113), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3R10), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L153-R154), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3R15), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L187-R188), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8R10), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8L141-R142), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cR10), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cL140-R141), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82R10), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L159-R160), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33R10), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L138-R139), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-04e2d157bf184eb210182f434c2f34a470a711a29e5aa61e626d0cabb949526fR10), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-04e2d157bf184eb210182f434c2f34a470a711a29e5aa61e626d0cabb949526fL140-R141), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-666b4a2954e170f5d63c511ffebea4d88b6f3ef1c2d7e836d4cfc6b6fe268bcbR10), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-666b4a2954e170f5d63c511ffebea4d88b6f3ef1c2d7e836d4cfc6b6fe268bcbL158-R159))
* Import and use the `getLabelForPopulation` function in the following components to simplify the code and avoid repetition: `IntraDecileImpact` and `IntraWealthDecileImpact` ([link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-71b88b3f4ac09980a01bd897cb30749591d957adfb78c6de0b91e8010b71072aR11), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-71b88b3f4ac09980a01bd897cb30749591d957adfb78c6de0b91e8010b71072aL293-R294), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-d41e88c8038a48564a3b9efe556677354d37e1fc69a77bd612f33d5aa98cda85R11), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-d41e88c8038a48564a3b9efe556677354d37e1fc69a77bd612f33d5aa98cda85L292-R293))
* Import and use the `getLabel` function in the following components to simplify the code and avoid repetition: `RelativeImpactByDecile` and `RelativeImpactByWealthDecile` ([link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-2b5717cbee57bbbc685fbb5310eb4f84ee1f0b60fc6215373dd876f733f47fb4R11), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-2b5717cbee57bbbc685fbb5310eb4f84ee1f0b60fc6215373dd876f733f47fb4L105-R106), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-3479abe14967df8c0649d35cc8a385878b52956281431d871039601f975a133cR11), [link](https://github.com/PolicyEngine/policyengine-app/pull/563/files?diff=unified&w=0#diff-3479abe14967df8c0649d35cc8a385878b52956281431d871039601f975a133cL105-R106))


