### PR TITLE
Add extra safety check to state prompt

### DIFF
--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -12,7 +12,7 @@ import NavigationButton from "../../controls/NavigationButton";
 import style from "../../style";
 import { RegionSelector, TimePeriodSelector } from "./output/PolicyOutput";
 import PolicySearch from "./PolicySearch";
-import { Alert, Modal} from "antd";
+import { Alert, Modal } from "antd";
 import { ExclamationCircleOutlined } from "@ant-design/icons";
 
 function PolicyNamer(props) {
@@ -138,7 +138,8 @@ function PolicyItem(props) {
 }
 
 function PolicyDisplay(props) {
-  const { policy, metadata, region, timePeriod, closeDrawer, hideButtons } = props;
+  const { policy, metadata, region, timePeriod, closeDrawer, hideButtons } =
+    props;
   const reformLength = Object.keys(policy.reform.data).length;
   const navigate = useNavigate();
   return (
@@ -206,15 +207,21 @@ export default function PolicyRightSidebar(props) {
     return { value: stateAbbreviation.name, label: stateAbbreviation.label };
   });
   options.push({ value: region, label: region });
-  const label = options.find((option) => option.value === stateAbbreviation)?.label;
+  const label = options.find(
+    (option) => option.value === stateAbbreviation
+  )?.label;
   const regionLabel = options.find((option) => option.value === region)?.label;
+  const validatedStateAbbreviation = options.find(
+    (option) => option.value === stateAbbreviation
+  )?.value;
   const confirmEconomicImpact = () => {
     let message = "";
-    if (stateAbbreviation && stateAbbreviation !== region) {
+    if (validatedStateAbbreviation && stateAbbreviation !== region) {
       message = `You are about to calculate the economic impact of a tax reform in ${label} for ${regionLabel} `;
     }
     if (region === "us" && focus.startsWith("gov.states")) {
-      message = "You are about to calculate the economic impact of a state tax reform for the entire US, which PolicyEngine does not currently support. ";
+      message =
+        "You are about to calculate the economic impact of a state tax reform for the entire US, which PolicyEngine does not currently support. ";
     }
     if (message) {
       Modal.confirm({
@@ -231,15 +238,15 @@ export default function PolicyRightSidebar(props) {
         cancelText: "Continue",
         okButtonProps: {
           style: {
-            backgroundColor: "#2C6496", 
-            borderColor: "#2C6496", 
+            backgroundColor: "#2C6496",
+            borderColor: "#2C6496",
           },
         },
         bodyStyle: {
-          paddingLeft: '9px' 
+          paddingLeft: "9px",
         },
         style: {
-          top: "25%", 
+          top: "25%",
         },
       });
     } else {


### PR DESCRIPTION
Adds an extra safety check to ensure that e.g. the UK doesn't get the prompt from #459.

(cc @QianruZhang78 - I missed this is my review of your PR, no other issues with it!)

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aa85089</samp>

### Summary
🐛🎨🔥

<!--
1.  🐛 for fixing the bug with the region selector confirmation message.
2.  🎨 for improving the code style and readability.
3.  🔥 for removing trailing spaces in style objects.
-->
This pull request refactors `PolicyRightSidebar.jsx` to improve code style and readability, and fixes a bug with the region selector confirmation message.

> _The sidebar of policy was a mess_
> _With imports and styles in excess_
> _So they added some spaces_
> _And broke long code cases_
> _And fixed the region message success_

### Walkthrough
*  Add validation for state abbreviation in region selector and format confirmation message ([link](https://github.com/PolicyEngine/policyengine-app/pull/569/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285L209-R224))
*  Split long lines of code into multiple lines for readability ([link](https://github.com/PolicyEngine/policyengine-app/pull/569/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285L141-R142), [link](https://github.com/PolicyEngine/policyengine-app/pull/569/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285L209-R224), [link](https://github.com/PolicyEngine/policyengine-app/pull/569/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285L234-R249))
*  Remove trailing spaces in style objects for consistency ([link](https://github.com/PolicyEngine/policyengine-app/pull/569/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285L234-R249))
*  Add space after comma in import statement for consistency ([link](https://github.com/PolicyEngine/policyengine-app/pull/569/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285L15-R15))


