### PR TITLE
issues65: Use the UI text font for charts

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "baseUrl": "src"
+    }
+}

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -12,6 +12,7 @@ import style from "../../../../style";
 import { getCliffs } from "./cliffs";
 import HoverCard from "../../../../layout/HoverCard";
 import { convertToCurrencyString } from "./convertToCurrencyString";
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function BaselineAndReformChart(props) {
   const {
@@ -200,6 +201,7 @@ function BaselineAndReformTogetherChart(props) {
           orientation: "h",
         },
         ...ChartLogo,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,
@@ -321,6 +323,7 @@ function BaselineReformDeltaChart(props) {
         margin: {
           t: 0,
         },
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -10,6 +10,7 @@ import FadeIn from "../../../../layout/FadeIn";
 import style from "../../../../style";
 import { getCliffs } from "./cliffs";
 import HoverCard from "../../../../layout/HoverCard";
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 import { convertToCurrencyString } from "./convertToCurrencyString";
 
@@ -111,6 +112,7 @@ export default function BaselineOnlyChart(props) {
           margin: {
             t: 0,
           },
+          ...plotLayoutFont
         }}
         config={{
           displayModeBar: false,

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -14,6 +14,7 @@ import { useSearchParams } from "react-router-dom";
 import { Radio } from "antd";
 import LoadingCentered from "../../../layout/LoadingCentered";
 import { ChartLogo } from "../../../api/charts";
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function MarginalTaxRates(props) {
   const { householdInput, householdBaseline, metadata, policyLabel, policy } = props;
@@ -162,6 +163,7 @@ export default function MarginalTaxRates(props) {
               orientation: "h",
             },
             ...ChartLogo,
+            ...plotLayoutFont
           }}
           config={{
             displayModeBar: false,
@@ -327,6 +329,7 @@ export default function MarginalTaxRates(props) {
               orientation: "h",
             },
             ...ChartLogo,
+            ...plotLayoutFont
           }}
           config={{
             displayModeBar: false,

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -4,6 +4,7 @@ import { getReformedParameter } from "../../../api/parameters";
 import { getPlotlyAxisFormat } from "../../../api/variables";
 import useMobile from "../../../layout/Responsive";
 import style from "../../../style";
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function ParameterOverTime(props) {
   const { parameter, policy } = props;
@@ -104,6 +105,7 @@ export default function ParameterOverTime(props) {
             t: 0,
             r: mobile && 30,
           },
+          ...plotLayoutFont
         }}
         style={{
           width: "100%",

--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -8,7 +8,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
-import { avgChangeDirection} from './utils';
+import { avgChangeDirection, plotLayoutFont} from './utils';
 
 export default function AverageImpactByDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -59,6 +59,7 @@ export default function AverageImpactByDecile(props) {
           r: 20,
         },
         height: mobile ? 300 : 500,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/AverageImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByWealthDecile.jsx
@@ -8,7 +8,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
-import { avgChangeDirection} from './utils';
+import { avgChangeDirection, plotLayoutFont } from './utils';
 
 export default function AverageImpactByWealthDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -59,6 +59,7 @@ export default function AverageImpactByWealthDecile(props) {
           r: 20,
         },
         height: mobile ? 300 : 500,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from "./DownloadCsvButton";
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function BudgetaryImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -101,6 +102,7 @@ export default function BudgetaryImpact(props) {
           r: 0,
         },
         height: mobile ? 300 : 500,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -12,6 +12,7 @@ import ResultsPanel from "../../../layout/ResultsPanel";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function CliffImpact(props) {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -136,6 +137,7 @@ export default function CliffImpact(props) {
           b: 80,
         },
         height: mobile ? 300 : 450,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/DeepPovertyImpact.jsx
+++ b/src/pages/policy/output/DeepPovertyImpact.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function DeepPovertyImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -84,6 +85,7 @@ export default function DeepPovertyImpact(props) {
           r: 0,
         },
         height: mobile ? 350 : 450,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/DeepPovertyImpactByGender.jsx
+++ b/src/pages/policy/output/DeepPovertyImpactByGender.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function DeepPovertyImpactByGender(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -78,6 +79,7 @@ export default function DeepPovertyImpactByGender(props) {
           r: 0,
         },
         height: mobile ? 350 : 450,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function InequalityImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -65,6 +66,7 @@ export default function InequalityImpact(props) {
           r: 0,
         },
         height: mobile ? 300 : 500,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/IntraDecileImpact.jsx
@@ -8,6 +8,7 @@ import { cardinal, percent } from "../../../api/language";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function IntraDecileImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -254,6 +255,7 @@ export default function IntraDecileImpact(props) {
           r: 0,
         },
         height: mobile ? 300 : 450,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/IntraWealthDecileImpact.jsx
+++ b/src/pages/policy/output/IntraWealthDecileImpact.jsx
@@ -8,6 +8,7 @@ import { cardinal, percent } from "../../../api/language";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function IntraWealthDecileImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -254,6 +255,7 @@ export default function IntraWealthDecileImpact(props) {
           r: 0,
         },
         height: mobile ? 300 : 450,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function PovertyImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -82,6 +83,7 @@ export default function PovertyImpact(props) {
           r: 0,
         },
         height: mobile ? 300 : 500,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function PovertyImpactByGender(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -76,6 +77,7 @@ export default function PovertyImpactByGender(props) {
           r: 0,
         },
         height: mobile ? 350 : 450,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/PovertyImpactByRace.jsx
@@ -7,6 +7,7 @@ import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
+import { plotLayoutFont } from 'pages/policy/output/utils';
 
 export default function PovertyImpactByRace(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -89,6 +90,7 @@ export default function PovertyImpactByRace(props) {
           r: 0,
         },
         height: mobile ? 350 : 450,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByDecile.jsx
@@ -8,7 +8,7 @@ import { cardinal, percent } from "../../../api/language";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
-import { avgChangeDirection} from './utils';
+import { avgChangeDirection, plotLayoutFont } from './utils';
 
 export default function RelativeImpactByDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -59,6 +59,7 @@ export default function RelativeImpactByDecile(props) {
           l: 60,
         },
         height: mobile ? 300 : 500,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
@@ -8,7 +8,7 @@ import { cardinal, percent } from "../../../api/language";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import DownloadCsvButton from './DownloadCsvButton';
-import { avgChangeDirection} from './utils';
+import { avgChangeDirection, plotLayoutFont } from './utils';
 
 export default function RelativeImpactByWealthDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -59,6 +59,7 @@ export default function RelativeImpactByWealthDecile(props) {
           l: 60,
         },
         height: mobile ? 300 : 500,
+        ...plotLayoutFont
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/policy/output/utils.js
+++ b/src/pages/policy/output/utils.js
@@ -1,1 +1,8 @@
-export const avgChangeDirection = change => change >= 0 ? "would increase" : "would decrease";
+const avgChangeDirection = (change) =>
+  change >= 0 ? "would increase" : "would decrease";
+
+const plotLayoutFont = {
+  font: { family: "Roboto, sans-serif" },
+};
+
+export { avgChangeDirection, plotLayoutFont };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e58b9d9</samp>

### Summary
📊🛠️🎨

<!--
1.  📊 This emoji represents the changes related to the Plotly charts and their font styles, which are the main focus of this pull request.
2.  🛠️ This emoji represents the changes related to the `utils` module and the `jsconfig.json` file, which are tools that help with the code organization and readability.
3.  🎨 This emoji represents the changes related to the visual appearance and consistency of the output pages, which improve the user experience and design.
-->
This pull request standardizes the font family of the Plotly charts across the app by using a common `plotLayoutFont` object imported from the `utils` module. It also adds a `jsconfig.json` file to simplify the relative imports from the `src` folder.

> _To make the output charts look nice_
> _They imported a `plotLayoutFont` twice_
> _Or more times, to be fair_
> _From the `utils` module there_
> _And applied it with minimal splice_

### Walkthrough
*  Add a `jsconfig.json` file to enable relative imports from the `src` folder ([link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-7fe0ab2d61296b5df4add971654584ba7ee8082cc5b79ffa3b60da0ed9f0b3ebR1-R5))
*  Define and export a `plotLayoutFont` object to specify a common font family for Plotly charts ([link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-11cc7d4a3f8c94ad9a513f540317c7c1998a6077335b84aa6b1f368a35eff988L1-R8))
*  Import and apply the `plotLayoutFont` object to the layout of various Plotly chart components in the output pages ([link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bR15), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bR204), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bR326), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98R13), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98R115), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9R17), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9R166), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9R332), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-b668174e6bcd7b963e980d1a5951bb5209b5fc87dfa52c8dfe35588442c77691R7), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-b668174e6bcd7b963e980d1a5951bb5209b5fc87dfa52c8dfe35588442c77691R108), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L11-R11), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2R62), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aL11-R11), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aR62), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3R10), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3R105), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3R15), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3R140), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8R10), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8R88), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cR10), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cR82), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82R10), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82R69), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-71b88b3f4ac09980a01bd897cb30749591d957adfb78c6de0b91e8010b71072aR11), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-71b88b3f4ac09980a01bd897cb30749591d957adfb78c6de0b91e8010b71072aR258), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-d41e88c8038a48564a3b9efe556677354d37e1fc69a77bd612f33d5aa98cda85R11), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-d41e88c8038a48564a3b9efe556677354d37e1fc69a77bd612f33d5aa98cda85R258), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33R10), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33R86), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-04e2d157bf184eb210182f434c2f34a470a711a29e5aa61e626d0cabb949526fR10), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-04e2d157bf184eb210182f434c2f34a470a711a29e5aa61e626d0cabb949526fR80), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-666b4a2954e170f5d63c511ffebea4d88b6f3ef1c2d7e836d4cfc6b6fe268bcbR10), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-666b4a2954e170f5d63c511ffebea4d88b6f3ef1c2d7e836d4cfc6b6fe268bcbR93), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-2b5717cbee57bbbc685fbb5310eb4f84ee1f0b60fc6215373dd876f733f47fb4L11-R11), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-2b5717cbee57bbbc685fbb5310eb4f84ee1f0b60fc6215373dd876f733f47fb4R62), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-3479abe14967df8c0649d35cc8a385878b52956281431d871039601f975a133cL11-R11), [link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-3479abe14967df8c0649d35cc8a385878b52956281431d871039601f975a133cR62))
*  Refactor the export of the `avgChangeDirection` function to use a named export instead of a default export ([link](https://github.com/PolicyEngine/policyengine-app/pull/571/files?diff=unified&w=0#diff-11cc7d4a3f8c94ad9a513f540317c7c1998a6077335b84aa6b1f368a35eff988L1-R8))


fixes issues/65