### PR TITLE
Fix cliff chart screenshot region

### DIFF
--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -11,8 +11,8 @@ import useMobile from "../../../layout/Responsive";
 import ResultsPanel from "../../../layout/ResultsPanel";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
-import DownloadCsvButton from './DownloadCsvButton';
-import { plotLayoutFont } from 'pages/policy/output/utils';
+import DownloadCsvButton from "./DownloadCsvButton";
+import { plotLayoutFont } from "pages/policy/output/utils";
 
 export default function CliffImpact(props) {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -137,7 +137,7 @@ export default function CliffImpact(props) {
           b: 80,
         },
         height: mobile ? 300 : 450,
-        ...plotLayoutFont
+        ...plotLayoutFont,
       }}
       config={{
         displayModeBar: false,
@@ -187,9 +187,9 @@ export default function CliffImpact(props) {
     return { value: region.name, label: region.label };
   });
   const label =
-  region === "us" || region === "uk"
-    ? ""
-    : " in " + options.find((option) => option.value === region)?.label;
+    region === "us" || region === "uk"
+      ? ""
+      : " in " + options.find((option) => option.value === region)?.label;
 
   const title = `${policyLabel} ${
     cliff_share_change === 0 && cliff_gap_change === 0
@@ -205,44 +205,44 @@ export default function CliffImpact(props) {
   const data = [
     csvHeader,
     ...[
-    {
-      Metric: "Cliff rate",
-      Baseline: impact.baseline.cliff_share,
-      Reform: impact.reform.cliff_share,
-      Change: cliff_share_change,
-    },
-    {
-      Metric: "Cliff gap",
-      Baseline: impact.baseline.cliff_gap,
-      Reform: impact.reform.cliff_gap,
-      Change: cliff_gap_change,
-    },
+      {
+        Metric: "Cliff rate",
+        Baseline: impact.baseline.cliff_share,
+        Reform: impact.reform.cliff_share,
+        Change: cliff_share_change,
+      },
+      {
+        Metric: "Cliff gap",
+        Baseline: impact.baseline.cliff_gap,
+        Reform: impact.reform.cliff_gap,
+        Change: cliff_gap_change,
+      },
     ].map((row) => [row.Metric, row.Baseline, row.Reform, row.Change]),
   ];
 
-  
   const downloadButtonStyle = {
     position: "absolute",
     bottom: "5px",
     left: "100px",
   };
-  
 
   return (
-    <ResultsPanel title={title}>
+    <ResultsPanel>
       <Screenshottable>
+        <h2>{title}</h2>
         <HoverCard content={hovercard}>{chart}</HoverCard>
-        <div className="chart-container">
-          {!mobile && 
-            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
-              content={data}
-              filename="cliffImpact.csv"
-              style={downloadButtonStyle}
-            />
-          }
-       </div>
       </Screenshottable>
-      <p style={{ marginTop: '10px' }}>
+      <div className="chart-container">
+        {!mobile && (
+          <DownloadCsvButton
+            preparingForScreenshot={preparingForScreenshot}
+            content={data}
+            filename="cliffImpact.csv"
+            style={downloadButtonStyle}
+          />
+        )}
+      </div>
+      <p style={{ marginTop: "10px" }}>
         The cliff rate is the share of households whose net income falls if each
         adult earned an additional {metadata.currency}2,000. The cliff gap is
         the sum of the losses incurred by all households on a cliff if their


### PR DESCRIPTION
Enables the cliff impact chart to be screenshottable with CTRL+K

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8ed9a2a</samp>

### Summary
🐛🎨📝

<!--
1.  🐛 for fixing a bug
2.  🎨 for improving code formatting or structure
3.  📝 for updating documentation or comments
-->
This pull request fixes a bug and improves code formatting in the output panel of the policy simulation app. It mainly modifies the `CliffImpact.jsx` file to correctly display the title of the cliff impact chart and to follow the code style guidelines.

> _Oh we're the jolly coders of the `CliffImpact` crew_
> _We fix the bugs and format the code as we sail the ocean blue_
> _We heave away and haul away with every pull request_
> _And when we see the panel title render right we feel the best_

### Walkthrough
*  Fix title rendering bug in cliff impact output panel by removing title prop from ResultsPanel component and adding h2 element inside Screenshottable component ([link](https://github.com/PolicyEngine/policyengine-app/pull/574/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L229-R245))
* Format import statements, object spreads, variable assignments, and JSX syntax to follow Prettier code formatter rules and improve readability ([link](https://github.com/PolicyEngine/policyengine-app/pull/574/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L14-R15), [link](https://github.com/PolicyEngine/policyengine-app/pull/574/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L140-R140), [link](https://github.com/PolicyEngine/policyengine-app/pull/574/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L190-R192), [link](https://github.com/PolicyEngine/policyengine-app/pull/574/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L208-R222), [link](https://github.com/PolicyEngine/policyengine-app/pull/574/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L229-R245))


