### PR TITLE
Fix #438: Consistent y axis for poverty charts

### DIFF
--- a/src/pages/policy/output/DeepPovertyImpact.jsx
+++ b/src/pages/policy/output/DeepPovertyImpact.jsx
@@ -78,7 +78,7 @@ export default function DeepPovertyImpact(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
-          range: [minChange, maxChange],
+          range: [Math.min(minChange, 0), Math.max(maxChange, 0)],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/DeepPovertyImpact.jsx
+++ b/src/pages/policy/output/DeepPovertyImpact.jsx
@@ -8,6 +8,8 @@ import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 import { plotLayoutFont } from 'pages/policy/output/utils';
+import { useContext, useEffect } from 'react';
+import { PovertyChangeContext } from './PovertyChangeContext';
 
 export default function DeepPovertyImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -33,6 +35,10 @@ export default function DeepPovertyImpact(props) {
     seniorPovertyChange,
     totalPovertyChange,
   ];
+  const { minChange, maxChange, addChanges } = useContext(PovertyChangeContext);
+  useEffect(() => {
+    addChanges(povertyChanges);
+  }, [povertyChanges, addChanges]);
   const povertyLabels = ["Children", "Working-age adults", "Seniors", "All"];
   const labelToKey = {
     Children: "child",
@@ -72,7 +78,7 @@ export default function DeepPovertyImpact(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
-          range: [-0.05, 0.05],
+          range: [minChange, maxChange],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/DeepPovertyImpact.jsx
+++ b/src/pages/policy/output/DeepPovertyImpact.jsx
@@ -72,6 +72,7 @@ export default function DeepPovertyImpact(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
+          range: [-0.05, 0.05],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/DeepPovertyImpactByGender.jsx
+++ b/src/pages/policy/output/DeepPovertyImpactByGender.jsx
@@ -8,6 +8,8 @@ import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 import { plotLayoutFont } from 'pages/policy/output/utils';
+import { useContext, useEffect } from 'react';
+import { PovertyChangeContext } from './PovertyChangeContext';
 
 export default function DeepPovertyImpactByGender(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -28,6 +30,10 @@ export default function DeepPovertyImpactByGender(props) {
     femalePovertyChange,
     totalPovertyChange,
   ];
+  const { minChange, maxChange, addChanges } = useContext(PovertyChangeContext);
+  useEffect(() => {
+    addChanges(povertyChanges);
+  }, [povertyChanges, addChanges]);
   const povertyLabels = ["Male", "Female", "All"];
   const labelToKey = {
     Male: "male",
@@ -66,7 +72,7 @@ export default function DeepPovertyImpactByGender(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
-          range: [-0.05, 0.05],
+          range: [minChange, maxChange],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/DeepPovertyImpactByGender.jsx
+++ b/src/pages/policy/output/DeepPovertyImpactByGender.jsx
@@ -72,7 +72,7 @@ export default function DeepPovertyImpactByGender(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
-          range: [minChange, maxChange],
+          range: [Math.min(minChange, 0), Math.max(maxChange, 0)],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/DeepPovertyImpactByGender.jsx
+++ b/src/pages/policy/output/DeepPovertyImpactByGender.jsx
@@ -66,6 +66,7 @@ export default function DeepPovertyImpactByGender(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
+          range: [-0.05, 0.05],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -35,6 +35,7 @@ import React from "react";
 import { message } from "antd";
 import Analysis from "./Analysis";
 import style from "../../../style";
+import { PovertyChangeProvider } from './PovertyChangeContext';
 
 import { useScreenshot } from "use-react-screenshot";
 
@@ -379,52 +380,63 @@ export default function PolicyOutput(props) {
   } else if (focus === "policyOutput.povertyImpact") {
     document.title = `${policyLabel} | Poverty impact | PolicyEngine`;
     pane = (
-      <PovertyImpact
-        preparingForScreenshot={preparingForScreenshot}
-        metadata={metadata}
-        impact={impact}
-        policyLabel={policyLabel}
-      />
+      <PovertyChangeProvider>
+        <PovertyImpact
+          preparingForScreenshot={preparingForScreenshot}
+          metadata={metadata}
+          impact={impact}
+          policyLabel={policyLabel}
+        />
+      </PovertyChangeProvider>
+      
     );
   } else if (focus === "policyOutput.deepPovertyImpact") {
     document.title = `${policyLabel} | Deep poverty impact | PolicyEngine`;
     pane = (
-      <DeepPovertyImpact
-        preparingForScreenshot={preparingForScreenshot}
-        metadata={metadata}
-        impact={impact}
-        policyLabel={policyLabel}
-      />
+      <PovertyChangeProvider>
+        <DeepPovertyImpact
+          preparingForScreenshot={preparingForScreenshot}
+          metadata={metadata}
+          impact={impact}
+          policyLabel={policyLabel}
+        />
+      </PovertyChangeProvider>
     );
   } else if (focus === "policyOutput.genderPovertyImpact") {
     document.title = `${policyLabel} | Gender poverty impact | PolicyEngine`
     pane = (
-      <PovertyImpactByGender
-        preparingForScreenshot={preparingForScreenshot}
-        metadata={metadata}
-        impact={impact}
-        policyLabel={policyLabel}
-      />
+      <PovertyChangeProvider>
+        <PovertyImpactByGender
+          preparingForScreenshot={preparingForScreenshot}
+          metadata={metadata}
+          impact={impact}
+          policyLabel={policyLabel}
+        />
+      </PovertyChangeProvider>
     );
   } else if (focus === "policyOutput.genderDeepPovertyImpact") {
     document.title = `${policyLabel} | Gender deep poverty impact | PolicyEngine`
     pane = (
-      <DeepPovertyImpactByGender
-        preparingForScreenshot={preparingForScreenshot}
-        metadata={metadata}
-        impact={impact}
-        policyLabel={policyLabel}
-      />
+      <PovertyChangeProvider>
+        <DeepPovertyImpactByGender
+          preparingForScreenshot={preparingForScreenshot}
+          metadata={metadata}
+          impact={impact}
+          policyLabel={policyLabel}
+        />
+      </PovertyChangeProvider>
     );
   } else if (focus === "policyOutput.racialPovertyImpact") {
     document.title = `${policyLabel} | Racial poverty impact | PolicyEngine`
     pane = (
-      <PovertyImpactByRace
-        preparingForScreenshot={preparingForScreenshot}
-        metadata={metadata}
-        impact={impact}
-        policyLabel={policyLabel}
-      />
+      <PovertyChangeProvider>
+        <PovertyImpactByRace
+          preparingForScreenshot={preparingForScreenshot}
+          metadata={metadata}
+          impact={impact}
+          policyLabel={policyLabel}
+        />
+      </PovertyChangeProvider>
     );
   } else if (focus === "policyOutput.inequalityImpact") {
     document.title = `${policyLabel} | Inequality impact | PolicyEngine`;

--- a/src/pages/policy/output/PovertyChangeContext.jsx
+++ b/src/pages/policy/output/PovertyChangeContext.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export const PovertyChangeContext = React.createContext({
+  minChange: 0,
+  maxChange: 0,
+  addChanges: () => {},
+});
+export const PovertyChangeProvider = ({ children }) => {
+    const [minChange, setMinChange] = React.useState(0);
+    const [maxChange, setMaxChange] = React.useState(0);
+  
+    const addChanges = (changes) => {
+      setMinChange((currentMin) => Math.min(currentMin, ...changes));
+      setMaxChange((currentMax) => Math.max(currentMax, ...changes));
+    };
+  
+    return (
+      <PovertyChangeContext.Provider value={{ minChange, maxChange, addChanges }}>
+        {children}
+      </PovertyChangeContext.Provider>
+    );
+  };
+  

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -8,6 +8,8 @@ import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 import { plotLayoutFont } from 'pages/policy/output/utils';
+import { useContext, useEffect } from 'react';
+import { PovertyChangeContext } from './PovertyChangeContext';
 
 export default function PovertyImpact(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -31,6 +33,10 @@ export default function PovertyImpact(props) {
     seniorPovertyChange,
     totalPovertyChange,
   ];
+  const { minChange, maxChange, addChanges } = useContext(PovertyChangeContext);
+  useEffect(() => {
+    addChanges(povertyChanges);
+  }, [povertyChanges, addChanges]);
   const povertyLabels = ["Children", "Working-age adults", "Seniors", "All"];
   const labelToKey = {
     Children: "child",
@@ -70,7 +76,7 @@ export default function PovertyImpact(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
-          range: [-0.05, 0.05],
+          range: [minChange, maxChange],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -76,7 +76,7 @@ export default function PovertyImpact(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
-          range: [minChange, maxChange],
+          range: [Math.min(minChange, 0), Math.max(maxChange, 0)],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -70,6 +70,7 @@ export default function PovertyImpact(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
+          range: [-0.05, 0.05],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -64,6 +64,7 @@ export default function PovertyImpactByGender(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
+          range: [-0.05, 0.05],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -70,7 +70,7 @@ export default function PovertyImpactByGender(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
-          range: [minChange, maxChange],
+          range: [Math.min(minChange, 0), Math.max(maxChange, 0)],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -8,6 +8,8 @@ import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 import { plotLayoutFont } from 'pages/policy/output/utils';
+import { useContext, useEffect } from 'react';
+import { PovertyChangeContext } from './PovertyChangeContext';
 
 export default function PovertyImpactByGender(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -26,6 +28,10 @@ export default function PovertyImpactByGender(props) {
     femalePovertyChange,
     totalPovertyChange,
   ];
+  const { minChange, maxChange, addChanges } = useContext(PovertyChangeContext);
+  useEffect(() => {
+    addChanges(povertyChanges);
+  }, [povertyChanges, addChanges]);
   const povertyLabels = ["Male", "Female", "All"];
   const labelToKey = {
     Male: "male",
@@ -64,7 +70,7 @@ export default function PovertyImpactByGender(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
-          range: [-0.05, 0.05],
+          range: [minChange, maxChange],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/PovertyImpactByRace.jsx
@@ -8,6 +8,8 @@ import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 import { plotLayoutFont } from 'pages/policy/output/utils';
+import { useContext, useEffect } from 'react';
+import { PovertyChangeContext } from './PovertyChangeContext';
 
 export default function PovertyImpactByRace(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
@@ -37,6 +39,10 @@ export default function PovertyImpactByRace(props) {
     otherPovertyChange,
     totalPovertyChange,
   ];
+  const { minChange, maxChange, addChanges } = useContext(PovertyChangeContext);
+  useEffect(() => {
+    addChanges(povertyChanges);
+  }, [povertyChanges, addChanges]);
   const povertyLabels = ["White (non-Hispanic)", "Black (non-Hispanic)", "Hispanic", "Other", "All"];
   const labelToKey = {
     "White (non-Hispanic)": "white",
@@ -77,7 +83,7 @@ export default function PovertyImpactByRace(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
-          range: [-0.05, 0.05],
+          range: [minChange, maxChange],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/PovertyImpactByRace.jsx
@@ -77,6 +77,7 @@ export default function PovertyImpactByRace(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
+          range: [-0.05, 0.05],
         },
         showlegend: false,
         uniformtext: {

--- a/src/pages/policy/output/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/PovertyImpactByRace.jsx
@@ -83,7 +83,7 @@ export default function PovertyImpactByRace(props) {
         yaxis: {
           title: "Relative change",
           tickformat: "+,.1%",
-          range: [minChange, maxChange],
+          range: [Math.min(minChange, 0), Math.max(maxChange, 0)],
         },
         showlegend: false,
         uniformtext: {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 292366e</samp>

### Summary
📉📊🧑‍🤝‍🧑

<!--
1.  📉 This emoji represents the downward trend of the poverty and deep poverty rates for different groups as a result of the policy changes. It also implies a positive impact on reducing poverty and deep poverty.
2.  📊 This emoji represents the charts that show the percentage change in poverty and deep poverty rates by different groups. It also implies a data-driven and visual way of presenting the results of the policy changes.
3.  🧑‍🤝‍🧑 This emoji represents the diversity and inclusion of different groups in the analysis of the policy changes. It also implies a social and human aspect of the poverty and deep poverty impact.
-->
Set the y-axis range for the poverty and deep poverty impact charts to be between -0.05 and 0.05. This improves the readability and consistency of the charts that show how different groups are affected by the policy reforms.

> _`y-axis` range set_
> _to show impact on poverty_
> _autumn of reform_

### Walkthrough
*  Set the y-axis range for the charts that show the percentage change in poverty or deep poverty rates by different groups to be between -0.05 and 0.05, based on the data values, to improve readability and consistency ([link](https://github.com/PolicyEngine/policyengine-app/pull/578/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8R75), [link](https://github.com/PolicyEngine/policyengine-app/pull/578/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cR69), [link](https://github.com/PolicyEngine/policyengine-app/pull/578/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33R73), [link](https://github.com/PolicyEngine/policyengine-app/pull/578/files?diff=unified&w=0#diff-04e2d157bf184eb210182f434c2f34a470a711a29e5aa61e626d0cabb949526fR67), [link](https://github.com/PolicyEngine/policyengine-app/pull/578/files?diff=unified&w=0#diff-666b4a2954e170f5d63c511ffebea4d88b6f3ef1c2d7e836d4cfc6b6fe268bcbR80))


