### PR TITLE
Fix written error in WFTCA post

### DIFF
--- a/src/posts/analysis-of-guaranteed-income-for-the-21st-century.md
+++ b/src/posts/analysis-of-guaranteed-income-for-the-21st-century.md
@@ -56,7 +56,7 @@ While we apply the benefit and phase-out to tax units in the 2021 Current Popula
 
 As an example, suppose a 22-year-old, who earns $30,000, lives with their parent, who earns $100,000. 21GI would provide the parent nothing and the child $6,250, half the maximum benefit, given their earnings fall halfway within the $10,000–50,000 phase-out range. But the SCF would show the household as a single tax filing unit with $130,000 income, and thus disqualified from any 21GI benefit.
 
-21GI would alter incentives to file separately; neither PolicyEngine nor New School models changing filing behavior as a result.
+21GI would alter incentives to file separately; however, neither PolicyEngine nor New School models changing filing behavior as a result.
 
 ### Impact by income decile
 

--- a/src/posts/malliotakis-steel-working-families-tax-cut-act.md
+++ b/src/posts/malliotakis-steel-working-families-tax-cut-act.md
@@ -16,7 +16,7 @@ The bill reduces this additional standard deduction by 5% of adjusted gross inco
 
 ## Household impacts
 
-Consider a [single filer in New York](https://policyengine.org/us/household?focus=householdOutput.mtr&reform=14512&region=ny&timePeriod=2023&baseline=2&household=31355) with no itemized deductions other than state income tax. The WFTCA would provide [benefits](https://policyengine.org/us/household?focus=householdOutput.earnings&reform=14512&region=ny&timePeriod=2023&baseline=2&household=31356) if they earn between $11,000 and $240,000, with the maximum dollar benefit of $640 at around $200,000 earnings.
+Consider a [single filer in New York](https://policyengine.org/us/household?focus=householdOutput.mtr&reform=14512&region=ny&timePeriod=2023&baseline=2&household=31355) with no itemized deductions other than state income tax. The WFTCA would provide [benefits](https://policyengine.org/us/household?focus=householdOutput.earnings&reform=14512&region=ny&timePeriod=2023&baseline=2&household=31356) if they earn between $13,851 ($1 above the current standard deduction) and $240,000, with the maximum dollar benefit of $640 at around $200,000 earnings.
 
 ![](https://cdn-images-1.medium.com/max/3200/0*dv92M9FKwiIP5zCY)
 


### PR DESCRIPTION
Fixes #579

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f1d0906</samp>

### Summary
🔄📈🗒️

<!--
1.  🔄 This emoji indicates that a word or phrase was replaced or substituted with another one, without changing the overall meaning of the sentence.
2.  📈 This emoji indicates that a numerical value or range was increased or updated to reflect more accurate or current data or assumptions.
3.  🗒️ This emoji indicates that a clarification or explanation was added in parentheses to provide more context or detail for the reader.
-->
This pull request fixes some minor errors and inconsistencies in two blog posts about policy simulations. It corrects the wording and punctuation in `analysis-of-guaranteed-income-for-the-21st-century.md` and updates the earnings threshold and adds a clarification in `malliotakis-steel-working-families-tax-cut-act.md`.

> _`WFTCA` update_
> _Clarify words and numbers_
> _Autumn of research_

### Walkthrough
*  Update the lower bound of the earnings range that would benefit from the WFTCA to reflect the 2023 standard deduction and add a clarification in parentheses ([link](https://github.com/PolicyEngine/policyengine-app/pull/580/files?diff=unified&w=0#diff-faaf2ea62b02e662cbabadddde9086d403027829401af100450bb8fedb5f797cL19-R19))
* Replace "neither" with "however" and add a comma to improve the clarity and flow of the sentence about filing behavior in `src/posts/analysis-of-guaranteed-income-for-the-21st-century.md` ([link](https://github.com/PolicyEngine/policyengine-app/pull/580/files?diff=unified&w=0#diff-e9e2062f1f3808c0c7a782261d145de989b5d5cb776a50787387f77ae458509bL59-R59))


