### PR TITLE
Fix policyengine canada reproducibility

### DIFF
--- a/src/api/call.js
+++ b/src/api/call.js
@@ -93,6 +93,11 @@ export function updateMetadata(countryId, setMetadata) {
         variablesInOrder: variablesInOrder,
         parameterTree: parameterTree,
         countryId: countryId,
+        package: {
+          uk: "policyengine_uk",
+          us: "policyengine_us",
+          ca: "policyengine_canada",
+        }[countryId],
         currency: countryId === "uk" ? "£" : "$",
       };
       setMetadata(metadata);

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -89,7 +89,7 @@ export default function HouseholdReproducibility(props) {
   const [ earningVariation, setEarningVariation ] = useState(false);
 
   let initialLines = [
-    "from policyengine_" + metadata.countryId + " import Simulation",
+    "from " + metadata.package + " import Simulation",
   ];
 
   if (policy.reform.data) {

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -148,6 +148,9 @@ export default function PolicyOutput(props) {
   const selectedVersion = searchParams.get("version") || metadata.version;
   const POLICY_OUTPUT_TREE = getPolicyOutputTree(metadata.countryId);
   const mobile = useMobile();
+  const skipImpacts = POLICY_OUTPUT_TREE[0].children.find(
+    (item) => item.name === focus
+  ).skipImpacts;
   useEffect(() => {
     if (
       !!region &&
@@ -227,7 +230,7 @@ export default function PolicyOutput(props) {
     return null;
   }
 
-  if (error) {
+  if (error & !skipImpacts) {
     const baselineOK = error.baseline_economy.status === "ok";
     const reformOK = error.reform_economy.status === "ok";
     return (
@@ -309,9 +312,6 @@ export default function PolicyOutput(props) {
     policyLabel = `${baselineLabel} → ${reformLabel}`;
   }
   let pane;
-  const skipImpacts = POLICY_OUTPUT_TREE[0].children.find(
-    (item) => item.name === focus
-  ).skipImpacts;
 
   if (!impact & !skipImpacts) {
     // Show a Progress bar that fills up over time, taking 100 seconds to fill.

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -112,7 +112,7 @@ export default function PolicyReproducibility(props) {
   const { policy, metadata } = props;
 
   let initialLines = [
-    "from policyengine_" + metadata.countryId + " import Microsimulation",
+    "from " + metadata.package + " import Microsimulation",
   ];
 
   initialLines = initialLines.concat(getReformDefinitionCode(metadata, policy));


### PR DESCRIPTION
Fixes #209 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a8e7c36</samp>

### Summary
📦🐍🚫

<!--
1.  📦 for adding the package property to the metadata object
2.  🐍 for using the dynamic Python package name in the reproducibility code snippets
3.  🚫 for improving the error handling for the policy output component
-->
This pull request enhances the error handling and reproducibility features of the policy engine app. It adds a `skipImpacts` variable to `PolicyOutput.jsx`, a `package` property to `call.js`, and uses the `package` value in `HouseholdReproducibility.jsx` and `PolicyReproducibility.jsx`.

> _Sing, O Muse, of the skillful coder who devised_
> _A clever scheme to import the packages of each land_
> _By adding to the metadata a `package` property_
> _That mapped the countryId to the Python name at hand_

### Walkthrough
*  Add `package` property to metadata object to map countryId to Python package name ([link](https://github.com/PolicyEngine/policyengine-app/pull/582/files?diff=unified&w=0#diff-21944af492c6c9ee9158a5bc0a089aef67b9e83c6b6a9c1cce3dae2df054f259R96-R100))
* Use `metadata.package` value instead of hardcoded package name in reproducibility code snippets for household and policy simulations ([link](https://github.com/PolicyEngine/policyengine-app/pull/582/files?diff=unified&w=0#diff-27695a8486f76672e2544cc7d9e8cb5f4548260da07d6954330c2c605fdca50dL92-R92), [link](https://github.com/PolicyEngine/policyengine-app/pull/582/files?diff=unified&w=0#diff-a8b57d575938866563fc948a07a9c528ee0065813510590a564112e3ebea93c5L115-R115))
* Add `skipImpacts` variable to `PolicyOutput` component to indicate whether to skip economic impact calculations for focus item ([link](https://github.com/PolicyEngine/policyengine-app/pull/582/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR151-R153))
* Show error message only if economic impacts are not skipped in `PolicyOutput` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/582/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL230-R233))
* Remove redundant declaration of `skipImpacts` variable in `PolicyOutput` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/582/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bL312-L314))


