### PR TITLE
Fix Household screen says reform instead of baseline policy

### DIFF
--- a/src/__tests__/HouseholdOutput.test.js
+++ b/src/__tests__/HouseholdOutput.test.js
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import HousholdOutput from "../pages/household/output/HouseholdOutput.jsx";
+import { BrowserRouter as Router } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
+import {
+    formatVariableValue,
+    getValueFromHousehold,
+  } from "../api/variables.js";
+
+const policy = {
+    reform: {label: "Reform Label"},
+    baseline: {label: "Baseline Label"}
+}
+const metadata={variables: {"household_net_income": {label: "variableName"}}};
+const householdInput={};
+const householdBaseline={};
+const householdReform=true;
+
+jest.mock("../api/variables.js", () => ({
+    formatVariableValue: jest.fn(),
+    getValueFromHousehold: jest.fn()
+}));
+jest.mock("react-plotly.js", () => jest.fn());
+jest.mock("react-router-dom", () => {
+    const originalModule = jest.requireActual("react-router-dom");
+    return {
+        __esModule: true,
+        ...originalModule,
+        useSearchParams: jest.fn()
+    }
+});
+
+
+describe("Test Render Output", () => {
+    test("Should render correct policy title", () => {
+        useSearchParams.mockImplementation(() => {
+            const get = (param) => {
+                if (param === "focus") {
+                    return "householdOutput.netIncome"
+                } else if (param === "reform") {
+                    return "13870"
+                } else if (param === "baseline") {
+                    return "13867"
+                }
+            }
+            return [{get}];
+        });
+        
+        render(
+            <Router>
+                <HousholdOutput 
+                    policy = {policy}
+                    metadata={metadata}
+                    householdInput={householdInput}
+                    householdBaseline={householdBaseline}
+                    householdReform={householdReform}
+                />
+            </Router>
+        );
+        expect(screen.getByText(policy.reform.label + ' (compared against ' + policy.baseline.label, {exact: false})).toBeTruthy();
+    });
+});

--- a/src/pages/household/output/HouseholdOutput.jsx
+++ b/src/pages/household/output/HouseholdOutput.jsx
@@ -45,7 +45,7 @@ export default function HouseholdOutput(props) {
   if (reformLabel !== "Current law" && baselineLabel === "Current law") {
     policyLabel = reformLabel;
   } else {
-    policyLabel = `${reformLabel} (compared against ${reformLabel})`;
+    policyLabel = `${reformLabel} (compared against ${baselineLabel})`;
   }
   let pane;
   if (loading) {


### PR DESCRIPTION
Fixes #565

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4c261a7</samp>

### Summary
:test_tube::bug::memo:

<!--
1.  :test_tube: This emoji represents the addition of a new test file, which is related to testing and quality assurance.
2.  :bug: This emoji represents the fixing of a typo, which is a minor bug or error in the code.
3.  :memo: This emoji represents the correction of a string interpolation, which is a minor change in the documentation or output of the code.
-->
This pull request adds a test file for the `HouseholdOutput` component and fixes a typo in its rendering logic. The test file verifies that the component displays the correct policy title based on the search params. The typo fix corrects the comparison of the baseline and reform policies.

> _`HouseholdOutput` test_
> _Mock data and modules set_
> _Fix typo in spring_

### Walkthrough
* Fix a typo in the policy title string interpolation that used the wrong label for the baseline ([link](https://github.com/PolicyEngine/policyengine-app/pull/584/files?diff=unified&w=0#diff-ec040841afa1a198c029f240d07eb3e001304de021910e91356cc6eaafc12909L48-R48))
* Add a test file for the HouseholdOutput component that checks if it renders the correct policy title based on the search params ([link](https://github.com/PolicyEngine/policyengine-app/pull/584/files?diff=unified&w=0#diff-2f831bf8fe2ee1817acb1ff0b7d594d844d58ca96bee5f6a0639b9c7c0571918L1-R61))



Updated HouseholdOutput to use both reform and baseline labels to generate policyLabel.

Also added a test file for HouseholdOutput that tests display of policyLabel.

![policy-label](https://github.com/PolicyEngine/policyengine-app/assets/49796873/af5734fe-8298-46ca-8cb5-e53b05081c52)
