### PR TITLE
Fixed the "shaking" when hovering charts and improved HoverCard performance

### DIFF
--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { Radio } from "antd";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../../api/charts";
@@ -10,7 +10,7 @@ import {
 import FadeIn from "../../../../layout/FadeIn";
 import style from "../../../../style";
 import { getCliffs } from "./cliffs";
-import HoverCard from "../../../../layout/HoverCard";
+import HoverCard, {HoverCardContext} from "../../../../layout/HoverCard";
 import { convertToCurrencyString } from "./convertToCurrencyString";
 import { plotLayoutFont } from 'pages/policy/output/utils';
 
@@ -25,31 +25,6 @@ export default function BaselineAndReformChart(props) {
     variableLabel,
     policy,
   } = props;
-  const [showDelta, setShowDelta] = useState(false);
-  const options = [
-    {
-      label: "Baseline and reform",
-      value: false,
-    },
-    {
-      label: "Difference",
-      value: true,
-    },
-  ];
-  const onDelta = ({ target: { value } }) => {
-    console.log("checked", value);
-    setShowDelta(value);
-  };
-  const toggle = (
-    <div style={{ display: "flex", justifyContent: "center" }}>
-      <Radio.Group
-        options={options}
-        onChange={onDelta}
-        value={showDelta}
-        buttonStyle="solid"
-      />
-    </div>
-  );
   const earningsArray = getValueFromHousehold(
     "employment_income",
     "2023",
@@ -92,11 +67,62 @@ export default function BaselineAndReformChart(props) {
     householdBaseline,
     metadata
   );
-  return (
-    <>
-      {toggle}
-      {showDelta ? (
-        <BaselineReformDeltaChart
+  const plotProps = {
+    metadata,
+    variable,
+    variableLabel,
+    policy,
+    earningsArray,
+    baselineArray,
+    reformArray,
+    currentEarnings,
+    currentValue,
+    baselineValue,
+  };
+  return <BaselineAndReformChartWithToggle {...plotProps} />;
+}
+
+function BaselineAndReformChartWithToggle(props) {
+  const {
+    metadata,
+    variable,
+    variableLabel,
+    policy,
+    earningsArray,
+    baselineArray,
+    reformArray,
+    currentEarnings,
+    currentValue,
+    baselineValue,
+  } = props;
+  const [showDelta, setShowDelta] = useState(false);
+  const options = [
+    {
+      label: "Baseline and reform",
+      value: false,
+    },
+    {
+      label: "Difference",
+      value: true,
+    },
+  ];
+  const onDelta = ({ target: { value } }) => {
+    console.log("checked", value);
+    setShowDelta(value);
+  };
+  const toggle = (
+    <div style={{ display: "flex", justifyContent: "center" }}>
+      <Radio.Group
+        options={options}
+        onChange={onDelta}
+        value={showDelta}
+        buttonStyle="solid"
+      />
+    </div>
+  );
+  const plot = (
+      showDelta ? (
+        <BaselineReformDeltaPlot
           earningsArray={earningsArray}
           baselineArray={baselineArray}
           reformArray={reformArray}
@@ -108,7 +134,7 @@ export default function BaselineAndReformChart(props) {
           variable={variable}
         />
       ) : (
-        <BaselineAndReformTogetherChart
+        <BaselineAndReformTogetherPlot
           earningsArray={earningsArray}
           baselineArray={baselineArray}
           reformArray={reformArray}
@@ -120,12 +146,18 @@ export default function BaselineAndReformChart(props) {
           variable={variable}
           policy={policy}
         />
-      )}
+      )
+  );
+  return (
+    <>
+      {toggle}
+      <HoverCard>{plot}</HoverCard>
     </>
   );
 }
 
-function BaselineAndReformTogetherChart(props) {
+function BaselineAndReformTogetherPlot(props) {
+  const setHoverCard = useContext(HoverCardContext);
   const {
     earningsArray,
     baselineArray,
@@ -136,7 +168,6 @@ function BaselineAndReformTogetherChart(props) {
     metadata,
     variable,
   } = props;
-  const [hovercard, setHoverCard] = useState(null);
   let data = [
     ...(variable === "household_net_income"
       ? getCliffs(baselineArray, earningsArray)
@@ -251,14 +282,11 @@ function BaselineAndReformTogetherChart(props) {
     />
   );
 
-  return (
-    <HoverCard content={hovercard}>
-      <FadeIn>{plotObject}</FadeIn>
-    </HoverCard>
-  );
+  return <FadeIn>{plotObject}</FadeIn>;
 }
 
-function BaselineReformDeltaChart(props) {
+function BaselineReformDeltaPlot(props) {
+  const setHoverCard = useContext(HoverCardContext);
   const {
     earningsArray,
     baselineArray,
@@ -270,7 +298,6 @@ function BaselineReformDeltaChart(props) {
     metadata,
     variable,
   } = props;
-  const [hovercard, setHoverCard] = useState(null);
   let data = [
     {
       x: earningsArray,
@@ -356,9 +383,5 @@ function BaselineReformDeltaChart(props) {
     />
   );
 
-  return (
-    <HoverCard content={hovercard}>
-      <FadeIn>{plotObject}</FadeIn>
-    </HoverCard>
-  );
+  return <FadeIn>{plotObject}</FadeIn>;
 }

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useContext } from "react";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../../api/charts";
 import { capitalize } from "../../../../api/language";
@@ -9,7 +9,7 @@ import {
 import FadeIn from "../../../../layout/FadeIn";
 import style from "../../../../style";
 import { getCliffs } from "./cliffs";
-import HoverCard from "../../../../layout/HoverCard";
+import HoverCard, {HoverCardContext} from "../../../../layout/HoverCard";
 import { plotLayoutFont } from 'pages/policy/output/utils';
 
 import { convertToCurrencyString } from "./convertToCurrencyString";
@@ -22,7 +22,6 @@ export default function BaselineOnlyChart(props) {
     variable,
     variableLabel,
   } = props;
-  const [hovercard, setHoverCard] = useState(null);
 
   const earningsArray = getValueFromHousehold(
     "employment_income",
@@ -53,8 +52,36 @@ export default function BaselineOnlyChart(props) {
     householdBaseline,
     metadata
   );
+
+  const plotProps = {
+    metadata,
+    variable,
+    variableLabel,
+    earningsArray,
+    netIncomeArray,
+    currentEarnings,
+    currentNetIncome,
+  };
+  return (
+    <HoverCard>
+      <BaselineOnlyPlot {...plotProps} />
+    </HoverCard>
+  );
+}
+
+function BaselineOnlyPlot(props) {
+  const setHoverCard = useContext(HoverCardContext);
+  const {
+    metadata,
+    variable,
+    variableLabel,
+    earningsArray,
+    netIncomeArray,
+    currentEarnings,
+    currentNetIncome,
+  } = props;
   // Add the main line, then add a 'you are here' line
-  const plot = (
+  return (
     <FadeIn key="baseline">
       <Plot
         key="baseline"
@@ -160,5 +187,4 @@ export default function BaselineOnlyChart(props) {
       />
     </FadeIn>
   );
-  return <HoverCard content={hovercard}>{plot}</HoverCard>;
 }

--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useContext } from "react";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
 import { cardinal } from "../../../api/language";
 import { formatVariableValue } from "../../../api/variables";
-import HoverCard from "../../../layout/HoverCard";
+import HoverCard, {HoverCardContext} from "../../../layout/HoverCard";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
@@ -12,10 +12,71 @@ import { avgChangeDirection, plotLayoutFont} from './utils';
 
 export default function AverageImpactByDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
-  // Decile bar chart. Bars are grey if negative, green if positive.
-  const [hovercard, setHoverCard] = useState(null);
   const mobile = useMobile();
-  const chart = (
+
+  const averageChange =
+    -impact.budget.budgetary_impact / impact.budget.households;
+  
+  const urlParams = new URLSearchParams(window.location.search);
+  const region = urlParams.get("region");
+  const options = metadata.economy_options.region.map((region) => {
+    return { value: region.name, label: region.label };
+  });
+  const label =
+  region === "us" || region === "uk"
+    ? ""
+    : "in " + options.find((option) => option.value === region)?.label;
+  
+  const data = Object.entries(impact.decile.average).map(([key, value]) => [
+    `Decile ${key}`,
+    value,
+  ]);    
+  const downloadButtonStyle = {
+    position: "absolute",
+    bottom: "48px",
+    left: "70px",
+  };
+
+  const plotProps = {impact, metadata, mobile};
+
+  return (
+    <>
+      <Screenshottable>
+        <h2>
+          {`${policyLabel} ${avgChangeDirection(averageChange)} the net income of households ${label} by ${
+          formatVariableValue(
+            metadata.variables.household_net_income,
+            Math.abs(averageChange),
+            0
+          )} on average`}
+        </h2>
+        <HoverCard>
+          <AverageImpactByDecilePlot {...plotProps} />
+        </HoverCard>
+      </Screenshottable>
+        <div className="chart-container"> 
+          {!mobile &&
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
+              content={data}
+              filename="absoluteImpactByIncomeDecile.csv"
+              style={downloadButtonStyle}
+            />
+          }
+        </div>
+      <p>
+        The chart above shows the relative change in income for each income
+        decile. Households are sorted into ten equally-populated groups
+        according to their equivalised household net income.
+      </p>
+    </>
+  );
+}
+
+function AverageImpactByDecilePlot(props) {
+  const setHoverCard = useContext(HoverCardContext);
+  const {impact, metadata, mobile} = props;
+  // Decile bar chart. Bars are grey if negative, green if positive.
+  return (
     <Plot
       data={[
         {
@@ -98,58 +159,5 @@ export default function AverageImpactByDecile(props) {
         setHoverCard(null);
       }}
     />
-  );
-
-  const averageChange =
-    -impact.budget.budgetary_impact / impact.budget.households;
-  
-  const urlParams = new URLSearchParams(window.location.search);
-  const region = urlParams.get("region");
-  const options = metadata.economy_options.region.map((region) => {
-    return { value: region.name, label: region.label };
-  });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
-  
-  const data = Object.entries(impact.decile.average).map(([key, value]) => [
-    `Decile ${key}`,
-    value,
-  ]);    
-  const downloadButtonStyle = {
-    position: "absolute",
-    bottom: "48px",
-    left: "70px",
-  };
-
-  return (
-    <>
-      <Screenshottable>
-        <h2>
-          {`${policyLabel} ${avgChangeDirection(averageChange)} the net income of households ${label} by ${
-          formatVariableValue(
-            metadata.variables.household_net_income,
-            Math.abs(averageChange),
-            0
-          )} on average`}
-        </h2>
-        <HoverCard content={hovercard}>{chart}</HoverCard>
-      </Screenshottable>
-        <div className="chart-container"> 
-          {!mobile &&
-            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
-              content={data}
-              filename="absoluteImpactByIncomeDecile.csv"
-              style={downloadButtonStyle}
-            />
-          }
-        </div>
-      <p>
-        The chart above shows the relative change in income for each income
-        decile. Households are sorted into ten equally-populated groups
-        according to their equivalised household net income.
-      </p>
-    </>
   );
 }

--- a/src/pages/policy/output/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/IntraDecileImpact.jsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useContext } from "react";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
 import { formatVariableValue } from "../../../api/variables";
 import style from "../../../style";
-import HoverCard from "../../../layout/HoverCard";
+import HoverCard, {HoverCardContext} from "../../../layout/HoverCard";
 import { cardinal, percent } from "../../../api/language";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
@@ -16,8 +16,89 @@ export default function IntraDecileImpact(props) {
   const decileNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   const all = impact.intra_decile.all;
   const totalAhead = all["Gain more than 5%"] + all["Gain less than 5%"];
-  const [hovercard, setHovercard] = useState(null);
   const mobile = useMobile();
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const region = urlParams.get("region");
+  const options = metadata.economy_options.region.map((region) => {
+    return { value: region.name, label: region.label };
+  });
+  const label =
+  region === "us" || region === "uk"
+    ? " of the population"
+    : " of " + options.find((option) => option.value === region)?.label + " residents";
+  
+  const csvHeader = [
+    "Decile",
+    "Gain more than 5%",
+    "Gain less than 5%",
+    "No change",
+    "Lose less than 5%",
+    "Lose more than 5%"
+  ];
+  const csvData = [
+    csvHeader,
+    ...decileNumbers.map((decile) => {
+      return [
+        decile,
+        deciles["Gain more than 5%"][decile - 1],
+        deciles["Gain less than 5%"][decile - 1],
+        deciles["No change"][decile - 1],
+        deciles["Lose less than 5%"][decile - 1],
+        deciles["Lose more than 5%"][decile - 1]
+      ];
+    }),
+    [
+      "All",
+      all["Gain more than 5%"],
+      all["Gain less than 5%"],
+      all["No change"],
+      all["Lose less than 5%"],
+      all["Lose more than 5%"]
+    ]
+  ];
+  const downloadButtonStyle = {
+    position: "absolute",
+    bottom: "60px",
+    left: "40px",
+  };
+
+  const plotProps = {mobile, deciles, decileNumbers, all, policyLabel};
+
+  return (
+    <>
+      <Screenshottable>
+        <h2>
+          {policyLabel} would benefit{" "}
+          {formatVariableValue({ unit: "/1" }, totalAhead, 0)}{label}
+        </h2>
+        <HoverCard>
+          <IntraDecileImpactPlot {...plotProps} />
+        </HoverCard>
+      </Screenshottable>
+        <div className="chart-container">
+          {!mobile && (
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
+              content={csvData}
+              filename="intraDecileImpact.csv"
+              style={downloadButtonStyle}
+            />
+          )}
+        </div>
+      <p>
+        The chart above shows percentage of of people in each household income
+        decile who experience different outcomes. Households are sorted into ten
+        equally-populated groups according to their equivalised household net
+        income.
+      </p>
+    </>
+  );
+}
+
+function IntraDecileImpactPlot(props) {
+  const setHoverCard = useContext(HoverCardContext);
+  const {mobile, deciles, decileNumbers, all, policyLabel} = props;
+
   const data = [
     {
       type: "bar",
@@ -208,7 +289,7 @@ export default function IntraDecileImpact(props) {
     },
   ];
 
-  const chart = (
+  return (
     <Plot
       data={data}
       layout={{
@@ -276,86 +357,14 @@ export default function IntraDecileImpact(props) {
             : `households in the ${cardinal(group)} decile`
         }, ${policyLabel} would cause ${percent(value)} of people to
         ${category.toLowerCase()} of their net income.`;
-        setHovercard({
+        setHoverCard({
           title: title,
           body: message,
         });
       }}
       onUnhover={() => {
-        setHovercard(null);
+        setHoverCard(null);
       }}
     />
-  );
-
-  const urlParams = new URLSearchParams(window.location.search);
-  const region = urlParams.get("region");
-  const options = metadata.economy_options.region.map((region) => {
-    return { value: region.name, label: region.label };
-  });
-  const label =
-  region === "us" || region === "uk"
-    ? " of the population"
-    : " of " + options.find((option) => option.value === region)?.label + " residents";
-  
-  const csvHeader = [
-    "Decile",
-    "Gain more than 5%",
-    "Gain less than 5%",
-    "No change",
-    "Lose less than 5%",
-    "Lose more than 5%"
-  ];
-  const csvData = [
-    csvHeader,
-    ...decileNumbers.map((decile) => {
-      return [
-        decile,
-        deciles["Gain more than 5%"][decile - 1],
-        deciles["Gain less than 5%"][decile - 1],
-        deciles["No change"][decile - 1],
-        deciles["Lose less than 5%"][decile - 1],
-        deciles["Lose more than 5%"][decile - 1]
-      ];
-    }),
-    [
-      "All",
-      all["Gain more than 5%"],
-      all["Gain less than 5%"],
-      all["No change"],
-      all["Lose less than 5%"],
-      all["Lose more than 5%"]
-    ]
-  ];
-  const downloadButtonStyle = {
-    position: "absolute",
-    bottom: "60px",
-    left: "40px",
-  };
-
-  return (
-    <>
-      <Screenshottable>
-        <h2>
-          {policyLabel} would benefit{" "}
-          {formatVariableValue({ unit: "/1" }, totalAhead, 0)}{label}
-        </h2>
-        <HoverCard content={hovercard}>{chart}</HoverCard>
-      </Screenshottable>
-        <div className="chart-container">
-          {!mobile && (
-            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
-              content={csvData}
-              filename="intraDecileImpact.csv"
-              style={downloadButtonStyle}
-            />
-          )}
-        </div>
-      <p>
-        The chart above shows percentage of of people in each household income
-        decile who experience different outcomes. Households are sorted into ten
-        equally-populated groups according to their equivalised household net
-        income.
-      </p>
-    </>
   );
 }

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -1,14 +1,13 @@
-import { useState } from "react";
+import { useContext, useEffect } from 'react';
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
 import { percent } from "../../../api/language";
-import HoverCard from "../../../layout/HoverCard";
+import HoverCard, {HoverCardContext} from "../../../layout/HoverCard";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 import { plotLayoutFont } from 'pages/policy/output/utils';
-import { useContext, useEffect } from 'react';
 import { PovertyChangeContext } from './PovertyChangeContext';
 
 export default function PovertyImpact(props) {
@@ -44,10 +43,76 @@ export default function PovertyImpact(props) {
     Seniors: "senior",
     All: "all",
   };
-  const [hovercard, setHoverCard] = useState(null);
   const mobile = useMobile();
+
+  const povertyRateChange = percent(Math.abs(totalPovertyChange));
+  const percentagePointChange =
+    Math.round(
+      Math.abs(
+        impact.poverty.poverty.all.reform - impact.poverty.poverty.all.baseline
+      ) * 1000
+    ) / 10;
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const region = urlParams.get("region");
+  const options = metadata.economy_options.region.map((region) => {
+    return { value: region.name, label: region.label };
+  });
+  const label =
+  region === "us" || region === "uk"
+    ? ""
+    : "in " + options.find((option) => option.value === region)?.label;
+  
+  const csvHeader = ['Age Group', 'Baseline', 'Reform', 'Change'];
+  const data = [
+    csvHeader,
+    ...povertyLabels.map((label) => {
+      const baseline = impact.poverty.poverty[labelToKey[label]].baseline;
+      const reform = impact.poverty.poverty[labelToKey[label]].reform;
+      const change = reform / baseline - 1;
+      return [label, baseline, reform, change];
+    }),
+  ];
+
+  const plotProps = {impact, mobile, povertyLabels, povertyChanges, minChange, maxChange, labelToKey};
+
+  return (
+    <>
+      <Screenshottable>
+        <h2>
+          {policyLabel}{" "}
+          {totalPovertyChange > 0
+            ? `would raise the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
+            : totalPovertyChange < 0
+            ? `would reduce the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
+            : `wouldn't change the poverty rate ${label}`}
+        </h2>
+        <HoverCard>
+          <PovertyImpactPlot {...plotProps} />
+        </HoverCard>
+      </Screenshottable>
+        <div className="chart-container">
+          {!mobile && (
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
+              content={data}
+              filename="povertyImpactByAge.csv"
+              className="download-button"
+            />
+          )}
+        </div>
+      <p>
+        The chart above shows the relative change in the poverty rate for each
+        age group.
+      </p>
+    </>
+  );
+}
+
+function PovertyImpactPlot(props) {
+  const setHoverCard = useContext(HoverCardContext);
+  const {impact, mobile, povertyLabels, povertyChanges, minChange, maxChange, labelToKey} = props;
   // Decile bar chart. Bars are grey if negative, green if positive.
-  const chart = (
+  return (
     <Plot
       data={[
         {
@@ -129,63 +194,5 @@ export default function PovertyImpact(props) {
         setHoverCard(null);
       }}
     />
-  );
-
-  const povertyRateChange = percent(Math.abs(totalPovertyChange));
-  const percentagePointChange =
-    Math.round(
-      Math.abs(
-        impact.poverty.poverty.all.reform - impact.poverty.poverty.all.baseline
-      ) * 1000
-    ) / 10;
-
-  const urlParams = new URLSearchParams(window.location.search);
-  const region = urlParams.get("region");
-  const options = metadata.economy_options.region.map((region) => {
-    return { value: region.name, label: region.label };
-  });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
-  
-  const csvHeader = ['Age Group', 'Baseline', 'Reform', 'Change'];
-  const data = [
-    csvHeader,
-    ...povertyLabels.map((label) => {
-      const baseline = impact.poverty.poverty[labelToKey[label]].baseline;
-      const reform = impact.poverty.poverty[labelToKey[label]].reform;
-      const change = reform / baseline - 1;
-      return [label, baseline, reform, change];
-    }),
-  ];
-    
-  return (
-    <>
-      <Screenshottable>
-        <h2>
-          {policyLabel}{" "}
-          {totalPovertyChange > 0
-            ? `would raise the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
-            : totalPovertyChange < 0
-            ? `would reduce the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
-            : `wouldn't change the poverty rate ${label}`}
-        </h2>
-        <HoverCard content={hovercard}>{chart}</HoverCard>
-      </Screenshottable>
-        <div className="chart-container">
-          {!mobile && (
-            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
-              content={data}
-              filename="povertyImpactByAge.csv"
-              className="download-button"
-            />
-          )}
-        </div>
-      <p>
-        The chart above shows the relative change in the poverty rate for each
-        age group.
-      </p>
-    </>
   );
 }

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -1,14 +1,13 @@
-import { useState } from "react";
+import { useContext, useEffect } from 'react';
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
 import { percent } from "../../../api/language";
-import HoverCard from "../../../layout/HoverCard";
+import HoverCard, {HoverCardContext} from "../../../layout/HoverCard";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
 import style from "../../../style";
 import DownloadCsvButton from './DownloadCsvButton';
 import { plotLayoutFont } from 'pages/policy/output/utils';
-import { useContext, useEffect } from 'react';
 import { PovertyChangeContext } from './PovertyChangeContext';
 
 export default function PovertyImpactByGender(props) {
@@ -38,10 +37,80 @@ export default function PovertyImpactByGender(props) {
     Female: "female",
     All: "all",
   };
-  const [hovercard, setHoverCard] = useState(null);
   const mobile = useMobile();
+
+  const povertyRateChange = percent(Math.abs(totalPovertyChange));
+  const percentagePointChange =
+    Math.round(
+      Math.abs(
+        impact.poverty.poverty.all.reform - impact.poverty.poverty.all.baseline
+      ) * 1000
+    ) / 10;
+  
+  const urlParams = new URLSearchParams(window.location.search);
+  const region = urlParams.get("region");
+  const options = metadata.economy_options.region.map((region) => {
+    return { value: region.name, label: region.label };
+  });
+  const label =
+  region === "us" || region === "uk"
+    ? ""
+    : "in " + options.find((option) => option.value === region)?.label;
+  
+  const csvHeader = ['Sex', 'Baseline', 'Reform', 'Change'];
+  const data = [
+    csvHeader,
+    ...povertyLabels.map((label) => {
+      const baseline = label === 'All'
+        ? impact.poverty.poverty[labelToKey[label]].baseline
+        : impact.poverty_by_gender.poverty[labelToKey[label]].baseline;
+      const reform = label === 'All'
+        ? impact.poverty.poverty[labelToKey[label]].reform
+        : impact.poverty_by_gender.poverty[labelToKey[label]].reform;
+      const change = reform / baseline - 1;
+      return [label, baseline, reform, change];
+    }),
+  ];
+
+  const plotProps = {impact, mobile, povertyLabels, povertyChanges, minChange, maxChange, labelToKey};
+
+  return (
+    <>
+      <Screenshottable>
+        <h2>
+          {policyLabel}{" "}
+          {totalPovertyChange > 0
+            ? `would raise the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
+            : totalPovertyChange < 0
+            ? `would reduce the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
+            : `wouldn't change the poverty rate ${label}`}
+        </h2>
+        <HoverCard>
+          <PovertyImpactByGenderPlot {...plotProps} />
+        </HoverCard>
+      </Screenshottable>
+        <div className="chart-container">
+          {!mobile && (
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
+              content={data}
+              filename="povertyImpactByGender.csv"
+              className="download-button"
+            />
+          )}
+        </div>
+      <p>
+        The chart above shows the relative change in the poverty rate for each
+        sex.
+      </p>
+    </>
+  );
+}
+
+function PovertyImpactByGenderPlot(props) {
+  const setHoverCard = useContext(HoverCardContext);
+  const {impact, mobile, povertyLabels, povertyChanges, minChange, maxChange, labelToKey} = props;
   // Decile bar chart. Bars are grey if negative, green if positive.
-  const chart = (
+  return (
     <Plot
       data={[
         {
@@ -131,67 +200,5 @@ export default function PovertyImpactByGender(props) {
         setHoverCard(null);
       }}
     />
-  );
-
-  const povertyRateChange = percent(Math.abs(totalPovertyChange));
-  const percentagePointChange =
-    Math.round(
-      Math.abs(
-        impact.poverty.poverty.all.reform - impact.poverty.poverty.all.baseline
-      ) * 1000
-    ) / 10;
-  
-  const urlParams = new URLSearchParams(window.location.search);
-  const region = urlParams.get("region");
-  const options = metadata.economy_options.region.map((region) => {
-    return { value: region.name, label: region.label };
-  });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
-  
-  const csvHeader = ['Sex', 'Baseline', 'Reform', 'Change'];
-  const data = [
-    csvHeader,
-    ...povertyLabels.map((label) => {
-      const baseline = label === 'All'
-        ? impact.poverty.poverty[labelToKey[label]].baseline
-        : impact.poverty_by_gender.poverty[labelToKey[label]].baseline;
-      const reform = label === 'All'
-        ? impact.poverty.poverty[labelToKey[label]].reform
-        : impact.poverty_by_gender.poverty[labelToKey[label]].reform;
-      const change = reform / baseline - 1;
-      return [label, baseline, reform, change];
-    }),
-  ];
-    
-  return (
-    <>
-      <Screenshottable>
-        <h2>
-          {policyLabel}{" "}
-          {totalPovertyChange > 0
-            ? `would raise the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
-            : totalPovertyChange < 0
-            ? `would reduce the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
-            : `wouldn't change the poverty rate ${label}`}
-        </h2>
-        <HoverCard content={hovercard}>{chart}</HoverCard>
-      </Screenshottable>
-        <div className="chart-container">
-          {!mobile && (
-            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
-              content={data}
-              filename="povertyImpactByGender.csv"
-              className="download-button"
-            />
-          )}
-        </div>
-      <p>
-        The chart above shows the relative change in the poverty rate for each
-        sex.
-      </p>
-    </>
   );
 }

--- a/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useContext } from "react";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
 import { formatVariableValue } from "../../../api/variables";
 import style from "../../../style";
-import HoverCard from "../../../layout/HoverCard";
+import HoverCard, {HoverCardContext} from "../../../layout/HoverCard";
 import { cardinal, percent } from "../../../api/language";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
@@ -12,10 +12,69 @@ import { avgChangeDirection, plotLayoutFont } from './utils';
 
 export default function RelativeImpactByWealthDecile(props) {
   const { impact, policyLabel, metadata, preparingForScreenshot } = props;
-  const [hovercard, setHoverCard] = useState(null);
   const mobile = useMobile();
+
+  const averageRelChange =
+    -impact.budget.budgetary_impact / impact.budget.baseline_net_income;
+  
+  const urlParams = new URLSearchParams(window.location.search);
+  const region = urlParams.get("region");
+  const options = metadata.economy_options.region.map((region) => {
+    return { value: region.name, label: region.label };
+  });
+  const label =
+  region === "us" || region === "uk"
+    ? ""
+    : "in " + options.find((option) => option.value === region)?.label;
+  const csvHeader = ['Wealth Decile', 'Relative Change'];
+  const data = [
+    csvHeader,
+    ...Object.entries(impact.wealth_decile.relative).map(([decile, relativeChange]) => {
+      return [decile, relativeChange];
+    }),
+  ];
+  const downloadButtonStyle = {
+    position: "absolute",
+    bottom: "48px",
+    left: "70px",
+  };
+
+  const plotProps = {impact, mobile};
+
+  return (
+    <>
+      <Screenshottable>
+        <h2>
+          {`${policyLabel} ${avgChangeDirection(averageRelChange)} the net income of households ${label} by ${
+            formatVariableValue({ unit: "/1" }, Math.abs(averageRelChange), 1)} on average`}
+        </h2>
+        <HoverCard>
+          <RelativeImpactByWealthDecilePlot {...plotProps} />
+        </HoverCard>
+      </Screenshottable>
+        <div className="chart-container">
+          {!mobile && (
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
+              content={data}
+              filename="relativeImpactByWealthDecile.csv"
+              style={downloadButtonStyle}
+            />
+          )}
+        </div>
+      <p>
+        The chart above shows the relative change in income for each wealth
+        decile. Households are sorted into ten equally-populated groups
+        according to their equivalised household net wealth.
+      </p>
+    </>
+  );
+}
+
+function RelativeImpactByWealthDecilePlot(props) {
+  const setHoverCard = useContext(HoverCardContext);
+  const {impact, mobile} = props;
   // Decile bar chart. Bars are grey if negative, green if positive.
-  const chart = (
+  return (
     <Plot
       data={[
         {
@@ -94,56 +153,5 @@ export default function RelativeImpactByWealthDecile(props) {
         setHoverCard(null);
       }}
     />
-  );
-
-  const averageRelChange =
-    -impact.budget.budgetary_impact / impact.budget.baseline_net_income;
-  
-  const urlParams = new URLSearchParams(window.location.search);
-  const region = urlParams.get("region");
-  const options = metadata.economy_options.region.map((region) => {
-    return { value: region.name, label: region.label };
-  });
-  const label =
-  region === "us" || region === "uk"
-    ? ""
-    : "in " + options.find((option) => option.value === region)?.label;
-  const csvHeader = ['Wealth Decile', 'Relative Change'];
-  const data = [
-    csvHeader,
-    ...Object.entries(impact.wealth_decile.relative).map(([decile, relativeChange]) => {
-      return [decile, relativeChange];
-    }),
-  ];
-  const downloadButtonStyle = {
-    position: "absolute",
-    bottom: "48px",
-    left: "70px",
-  };
-    
-  return (
-    <>
-      <Screenshottable>
-        <h2>
-          {`${policyLabel} ${avgChangeDirection(averageRelChange)} the net income of households ${label} by ${
-            formatVariableValue({ unit: "/1" }, Math.abs(averageRelChange), 1)} on average`}
-        </h2>
-        <HoverCard content={hovercard}>{chart}</HoverCard>
-      </Screenshottable>
-        <div className="chart-container">
-          {!mobile && (
-            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
-              content={data}
-              filename="relativeImpactByWealthDecile.csv"
-              style={downloadButtonStyle}
-            />
-          )}
-        </div>
-      <p>
-        The chart above shows the relative change in income for each wealth
-        decile. Households are sorted into ten equally-populated groups
-        according to their equivalised household net wealth.
-      </p>
-    </>
   );
 }


### PR DESCRIPTION
Fixes #504 

Was originally exploring the hovertemplate prop suggested by #307 but later found a better way, which allows the custom HoverCard component to be kept and also prevents the chart from re-rendering, thus fixing the "shaking" bug and making the hovering experience smooth. In addition, some optimization is made to the HoverCard rendering logic, including wrapping the mouse move handler by useEffect to prevent memory leak, and managing the position of the HoverCard directly by a state to prevent the element from appearing at the top-left corner of the screen in some times.

HoverCard performance BEFORE this fix:

![Shaking](https://github.com/PolicyEngine/policyengine-app/assets/17683171/d63ab266-b338-4545-a70f-15456221d942)

HoverCard performance AFTER this fix:

![Normal](https://github.com/PolicyEngine/policyengine-app/assets/17683171/ad99e78b-a08c-40c6-8767-83a9cf3cdfc1)

Previously, the content of the HoverCard was managed by a state declared by each chart component (parent of the Plot and the HoverCard), where the Plot set the state and the HoverCard read the state, so that a change of the content meant a change of the state, resulting the Plot being re-rendered every time the mouse moved a bit, which caused the "shaking".

Now, the aforementioned state is no longer declared by each chart component, but directly by the HoverCard, and the state setter is offered through React context. The HoverCard exports a context, each chart component imports that context, and each Plot rendering call is factored into a standalone component which uses that context to obtain the state setter provided by the HoverCard. Since the state lives directly in the HoverCard, when the state (content) changes only the HoverCard itself will re-render, so the charts will no longer "shake" and the HoverCard itself will move much smoother.

copilot:all
