### PR TITLE
Avoid form edits on placeholder values

### DIFF
--- a/src/__tests__/InputField.test.js
+++ b/src/__tests__/InputField.test.js
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import InputField from "../controls/InputField";
+
+const testProps = {
+    placeholder: "Test Placeholder",
+    onChange: jest.fn(),
+};
+const patternProp = {pattern: "%"};
+const testInput = "Test Input";
+
+const setup = (props) => {
+    const utils = render(<InputField {...props} />);
+    const input = screen.getByPlaceholderText(testProps.placeholder);
+
+    return {
+        input,
+        ...utils
+    }
+};
+
+test("Should handle non-percent input & submit on blur", () => {
+    const { input } = setup(testProps);
+    fireEvent.change(input, {target: {value: testInput}});
+    expect(input.value).toBe(testInput);
+    expect(testProps.onChange).not.toHaveBeenCalled();
+
+    fireEvent.blur(input);
+    expect(testProps.onChange).toHaveBeenCalledWith(testInput);
+});
+
+test("Should append '%' for percent pattern & submit on blur", () => {
+    const { input } = setup({...testProps, ...patternProp});
+    fireEvent.change(input, {target: {value: testInput}});
+    expect(input.value).toBe(testInput + "%");
+    expect(testProps.onChange).not.toHaveBeenCalled();
+
+    fireEvent.blur(input);
+    expect(testProps.onChange).toHaveBeenCalledWith(testInput + "%");
+
+});

--- a/src/controls/InputField.jsx
+++ b/src/controls/InputField.jsx
@@ -1,15 +1,17 @@
 import { motion } from "framer-motion";
 import useMobile from "../layout/Responsive";
 import style from "../style";
+import { useRef, useState } from "react";
 
 export default function InputField(props) {
-  const { placeholder, onChange, padding, width, type, inputmode, pattern } =
+  const { onChange, padding, width, type, inputmode, pattern, value } =
     props;
+  const [inputValue, setInputValue] = useState(value ? value : "");
+  const placeholder = useRef(props.placeholder);
   const mobile = useMobile();
   const re = /^[0-9\b]*[.]?[0-9\b]*?$/;
   const onInput = (e) => {
     let value = e.target.value;
-    e.target.value = null;
     if (value !== "") {
       onChange(value);
     }
@@ -38,7 +40,6 @@ export default function InputField(props) {
           if (value !== "") {
             onChange(value);
           }
-          e.target.value = null;
           if (!mobile) {
             e.target.blur();
           }
@@ -49,28 +50,26 @@ export default function InputField(props) {
 
         // evaluating percentage input
         if (pattern === "%") {
-          if (!value.includes("%")) {
+          if (!value.includes("%") && value !== "") {
             e.target.value += "%";
-            e.target.setSelectionRange(
-              e.target.value.length - 1,
-              e.target.value.length - 1
-            );
-          } else {
+          } else if (value !== "") {
             let val = value.slice(0, e.target.value.length - 1);
             e.target.value = val + "%";
-            e.target.setSelectionRange(
-              e.target.value.length - 1,
-              e.target.value.length - 1
-            );
           }
+          e.target.setSelectionRange(
+            e.target.value.length - 1,
+            e.target.value.length - 1
+          );
         } else if (pattern === "number") {
           if (value !== "" && !re.test(value)) {
             const val = value.replace(/[^\d.]+/g, "");
             e.target.value = val.includes(".") ? parseFloat(val) : val;
           }
         }
+        setInputValue(e.target.value);
       }}
-      placeholder={placeholder}
+      value = {inputValue}
+      placeholder={placeholder.current}
     />
   );
 }

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -29,6 +29,8 @@ function PolicyNamer(props) {
           inputmode="text"
           padding={10}
           width="100%"
+          value={label}
+          key={label}
           onChange={(name) => {
             getNewPolicyId(metadata.countryId, policy.reform.data, name).then(
               (data) => {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a021089</samp>

### Summary
🧪🔑🛠️

<!--
1.  🧪 This emoji represents testing, experimentation, or science, and can be used to indicate that a new test file or test case was added or updated.
2.  🔑 This emoji represents a key, security, or access, and can be used to indicate that a new prop or attribute was added or updated, especially if it affects the identification or functionality of a component or element.
3.  🛠️ This emoji represents a tool, repair, or improvement, and can be used to indicate that a bug was fixed, a refactoring was done, or a feature was enhanced.
-->
This pull request refactors the `InputField` component to fix a bug and improve the input logic, adds a test file for the `InputField` component, and passes the value and key props to the `InputField` component inside the `PolicyNamer` component. These changes enhance the functionality and usability of the custom input fields for naming and editing policies.

> _We test the input field of doom_
> _We set the value and the key_
> _We use the state and the ref_
> _We fix the bug and add the `%`_

### Walkthrough
*  Modify `InputField` component to use state and ref for input value and placeholder ([link](https://github.com/PolicyEngine/policyengine-app/pull/594/files?diff=unified&w=0#diff-10323c70aaa8c36a4d474a2c79df4d291dc1a09fbf1e17b0c4ddae37404abd29L4-R14), [link](https://github.com/PolicyEngine/policyengine-app/pull/594/files?diff=unified&w=0#diff-10323c70aaa8c36a4d474a2c79df4d291dc1a09fbf1e17b0c4ddae37404abd29L41), [link](https://github.com/PolicyEngine/policyengine-app/pull/594/files?diff=unified&w=0#diff-10323c70aaa8c36a4d474a2c79df4d291dc1a09fbf1e17b0c4ddae37404abd29L52-R62), [link](https://github.com/PolicyEngine/policyengine-app/pull/594/files?diff=unified&w=0#diff-10323c70aaa8c36a4d474a2c79df4d291dc1a09fbf1e17b0c4ddae37404abd29L72-R72))
* Add value and key props to `InputField` component inside `PolicyNamer` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/594/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285R32-R33))
* Add test file for `InputField` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/594/files?diff=unified&w=0#diff-e217baee6f19e2e78342dc24d5d7a60120b6ef45e9466740f9d10fbec0af551cL1-R39))



Updated InputField to use state for value, ref for placeholder, RightPolicySidebar to use the label as value & id to properly refresh state.

Created PR to resolve https://github.com/PolicyEngine/policyengine-app/issues/526