### PR TITLE
Add UK program breakdown chart

### DIFF
--- a/src/api/call.js
+++ b/src/api/call.js
@@ -1,7 +1,7 @@
 import { buildParameterTree } from "./parameters";
 import { buildVariableTree, getTreeLeavesInOrder } from "./variables";
 
-const POLICYENGINE_API = "https://api.policyengine.org";
+const POLICYENGINE_API = "http://127.0.0.1:5000";
 
 export function apiCall(path, body, method, secondAttempt = false) {
   return fetch(POLICYENGINE_API + path, {

--- a/src/api/call.js
+++ b/src/api/call.js
@@ -1,7 +1,7 @@
 import { buildParameterTree } from "./parameters";
 import { buildVariableTree, getTreeLeavesInOrder } from "./variables";
 
-const POLICYENGINE_API = "http://127.0.0.1:5000";
+const POLICYENGINE_API = "https://api.policyengine.org";
 
 export function apiCall(path, body, method, secondAttempt = false) {
   return fetch(POLICYENGINE_API + path, {

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -163,6 +163,7 @@ export default function BudgetaryImpact(props) {
     return [label, values[index]];
   });
 
+
   return (
     <>
       <Screenshottable>

--- a/src/pages/policy/output/DetailedBudgetaryImpact.jsx
+++ b/src/pages/policy/output/DetailedBudgetaryImpact.jsx
@@ -1,0 +1,204 @@
+import { useContext } from "react";
+import Plot from "react-plotly.js";
+import { ChartLogo } from "../../../api/charts";
+import { aggregateCurrency, cardinal } from "../../../api/language";
+import { formatVariableValue } from "../../../api/variables";
+import HoverCard, {HoverCardContext} from "../../../layout/HoverCard";
+import useMobile from "../../../layout/Responsive";
+import Screenshottable from "../../../layout/Screenshottable";
+import style from "../../../style";
+import DownloadCsvButton from './DownloadCsvButton';
+import { avgChangeDirection, plotLayoutFont} from './utils';
+
+export default function DetailedBudgetaryImpact(props) {
+  const { impact, policyLabel, metadata, preparingForScreenshot } = props;
+  const mobile = useMobile();
+
+  // impact.budget_detail[program] = { baseline: x, reform: y, different: y - z }
+  // We need a bar chart showing the programs with nonzero different
+
+  const xValues = [];
+  const yValues = [];
+  const textValues = [];
+
+  if (!impact.detailed_budget) {
+    return null;
+  }
+
+    Object.entries(impact.detailed_budget).forEach(([program, values]) => {
+        if (values.difference !== 0) {
+            yValues.push(values.difference);
+            const programLabel = metadata.variables[program].label;
+            xValues.push(programLabel);
+            // [label]'s budgetary impact [rises/falls] by [abs(value)], from [baseline] to [reform].
+            textValues.push(
+                `${programLabel}'s budgetary impact ${avgChangeDirection(values.different)} by ${aggregateCurrency(
+                values.difference,
+                metadata.countryId
+                )}, from ${aggregateCurrency(
+                values.baseline,
+                metadata.countryId
+                )} to ${aggregateCurrency(values.reform, metadata.countryId)}.`
+            );
+        }
+    });
+    
+    console.log(xValues, yValues, textValues)
+
+
+  function DetailedBudgetaryImpactPlot() {
+    const setHoverCard = useContext(HoverCardContext);
+    // Decile bar chart. Bars are grey if negative, green if positive.
+    return (
+      <Plot
+        data={[
+          {
+            x: xValues.concat(["Total"]),
+            y: yValues.concat([impact.budget.budgetary_impact]),
+            type: "waterfall",
+            orientation: "v",
+            measure:
+              textValues.length > 0
+                ? Array(textValues.length - 1)
+                  .fill("relative")
+                  .concat(["total"])
+                : ["total"],
+            marker: {
+              color: Object.values(impact.decile.average).map((value) =>
+                value < 0 ? style.colors.DARK_GRAY : style.colors.DARK_GREEN
+              ),
+            },
+            increasing: { marker: { color: style.colors.DARK_GREEN } },
+            decreasing: { marker: { color: style.colors.DARK_GRAY } },
+            // Total should be dark gray if negative, dark green if positive
+            totals: {
+              marker: {
+                color:
+                  impact.budget.budgetary_impact < 0
+                    ? style.colors.DARK_GRAY
+                    : style.colors.DARK_GREEN,
+              },
+            },
+            text: textValues,
+            textangle: 0,
+            hoverinfo: "none",
+          },
+        ]}
+        layout={{
+          xaxis: {
+            title: "Income decile",
+            tickvals: Object.keys(impact.decile.average),
+          },
+          yaxis: {
+            title: "Average change",
+            tickprefix: metadata.countryId === "uk" ? "£" : "$",
+            tickformat: ",.0f",
+          },
+          showlegend: false,
+          uniformtext: {
+            mode: "hide",
+            minsize: mobile ? 4 : 8,
+          },
+          ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),
+          margin: {
+            t: 0,
+            b: 80,
+            l: 60,
+            r: 20,
+          },
+          height: mobile ? 300 : 500,
+          ...plotLayoutFont
+        }}
+        config={{
+          displayModeBar: false,
+          responsive: true,
+        }}
+        style={{
+          width: "100%",
+          marginBottom: !mobile && 50,
+        }}
+        onHover={(data) => {
+          const decile = cardinal(data.points[0].x);
+          const change = data.points[0].y;
+          const message =
+            change > 0.0001
+              ? `This reform raises the income of households in the ${decile} decile by an average of ${formatVariableValue(
+                metadata.variables.household_net_income,
+                change,
+                0
+              )} per year.`
+              : change < -0.0001
+                ? `This reform lowers the income of households in the ${decile} decile by an average of ${formatVariableValue(
+                  metadata.variables.household_net_income,
+                  -change,
+                  0
+                )} per year.`
+                : change === 0
+                  ? `This reform has no impact on the income of households in the ${decile} decile.`
+                  : (change > 0 ? "This reform raises " : "This reform lowers ") +
+                  ` the income of households in the ${decile} decile by less than 0.01%.`;
+          setHoverCard({
+            title: `Decile ${data.points[0].x}`,
+            body: message,
+          });
+        }}
+        onUnhover={() => {
+          setHoverCard(null);
+        }}
+      />
+    );
+  }
+
+  const averageChange =
+    -impact.budget.budgetary_impact / impact.budget.households;
+  
+  const urlParams = new URLSearchParams(window.location.search);
+  const region = urlParams.get("region");
+  const options = metadata.economy_options.region.map((region) => {
+    return { value: region.name, label: region.label };
+  });
+  const label =
+  region === "us" || region === "uk"
+    ? ""
+    : "in " + options.find((option) => option.value === region)?.label;
+  
+  const data = Object.entries(impact.decile.average).map(([key, value]) => [
+    `Decile ${key}`,
+    value,
+  ]);    
+  const downloadButtonStyle = {
+    position: "absolute",
+    bottom: "48px",
+    left: "70px",
+  };
+
+  return (
+    <>
+      <Screenshottable>
+        <h2>
+          {`${policyLabel} ${avgChangeDirection(averageChange)} the net income of households ${label} by ${
+          formatVariableValue(
+            metadata.variables.household_net_income,
+            Math.abs(averageChange),
+            0
+          )} on average`}
+        </h2>
+        <HoverCard>
+          <DetailedBudgetaryImpactPlot/>
+        </HoverCard>
+      </Screenshottable>
+        <div className="chart-container"> 
+          {!mobile &&
+            <DownloadCsvButton preparingForScreenshot={preparingForScreenshot}
+              content={data}
+              filename="absoluteImpactByIncomeDecile.csv"
+              style={downloadButtonStyle}
+            />
+          }
+        </div>
+      <p>
+        {JSON.stringify(impact.detailed_budget)}
+      </p>
+    </>
+  );
+}

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -5,6 +5,7 @@ import SearchOptions from "../../../controls/SearchOptions";
 import LoadingCentered from "../../../layout/LoadingCentered";
 import ResultsPanel from "../../../layout/ResultsPanel";
 import BudgetaryImpact from "./BudgetaryImpact";
+import DetailedBudgetaryImpact from "./DetailedBudgetaryImpact";
 import PovertyImpact from "./PovertyImpact";
 import DeepPovertyImpact from "./DeepPovertyImpact";
 import PovertyImpactByGender from "./PovertyImpactByGender";
@@ -341,6 +342,16 @@ export default function PolicyOutput(props) {
     document.title = `${policyLabel} | Budgetary impact | PolicyEngine`;
     pane = (
       <BudgetaryImpact
+        preparingForScreenshot={preparingForScreenshot}
+        metadata={metadata}
+        impact={impact}
+        policyLabel={policyLabel}
+      />
+    );
+  } else if (focus === "policyOutput.detailedBudgetaryImpact") {
+    document.title = `${policyLabel} | Detailed budgetary impact | PolicyEngine`;
+    pane = (
+      <DetailedBudgetaryImpact
         preparingForScreenshot={preparingForScreenshot}
         metadata={metadata}
         impact={impact}

--- a/src/pages/policy/output/tree.jsx
+++ b/src/pages/policy/output/tree.jsx
@@ -1,6 +1,7 @@
 const getPolicyOutputTree = (countryId) => {
   const shouldShowWealth = countryId === "uk";
   const shouldShowRacialPoverty = countryId === "us";
+  const shouldShowProgramBreakdown = countryId === "uk";
   return [
     {
       name: "policyOutput",
@@ -10,7 +11,7 @@ const getPolicyOutputTree = (countryId) => {
           name: "policyOutput.netIncome",
           label: "Budgetary impact",
         },
-        {
+        shouldShowProgramBreakdown && {
           name: "policyOutput.detailedBudgetaryImpact",
           label: "Budgetary impact by program",
         },

--- a/src/pages/policy/output/tree.jsx
+++ b/src/pages/policy/output/tree.jsx
@@ -11,6 +11,10 @@ const getPolicyOutputTree = (countryId) => {
           label: "Budgetary impact",
         },
         {
+          name: "policyOutput.detailedBudgetaryImpact",
+          label: "Budgetary impact by program",
+        },
+        {
           name: "policyOutput.decileAverageImpact",
           label: "Absolute impact by income decile",
         },


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8b4ac11</samp>

### Summary
🛠️📊📝

<!--
1.  🛠️ - This emoji represents the change to the `POLICYENGINE_API` constant, which is a temporary fix for testing purposes and should not be merged into the main branch.
2. 📊 - This emoji represents the addition of the `DetailedBudgetaryImpact` component, which shows a graphical and tabular representation of the budgetary impact of the reform by program.
3. 📝 - This emoji represents the addition of the `policyOutput.detailedBudgetaryImpact` option to the `getPolicyOutputTree` function, which adds a new menu item to the policy output page that allows the user to access the detailed budgetary impact pane.
-->
Added a new feature to the policy output page that shows the detailed budgetary impact of the policy simulation by program. This feature consists of a new component `DetailedBudgetaryImpact` that renders a waterfall chart and a CSV download button, and a new sidebar menu option `policyOutput.detailedBudgetaryImpact` that links to the component. The `POLICYENGINE_API` constant was temporarily changed for testing purposes and should not be merged.

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous chart to show the impact of reform_
> _On every program of the state, and how he tried_
> _To test his work with `POLICYENGINE_API` transformed_

### Walkthrough
*  Add `DetailedBudgetaryImpact` component to render and download budgetary impact by program ([link](https://github.com/PolicyEngine/policyengine-app/pull/595/files?diff=unified&w=0#diff-d50bb4f3433b375516906846f34ac9a1d86d9d361680f9d47cf9cf58f4a44cf5R1-R204), [link](https://github.com/PolicyEngine/policyengine-app/pull/595/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR8), [link](https://github.com/PolicyEngine/policyengine-app/pull/595/files?diff=unified&w=0#diff-c22fbb710a983e682ce6baa65ea3b0a8866993290ef6b15a6a5aa1e29bf31a4bR351-R360))
*  Update sidebar menu to include `policyOutput.detailedBudgetaryImpact` option ([link](https://github.com/PolicyEngine/policyengine-app/pull/595/files?diff=unified&w=0#diff-a8e68e0558456d6a7bafed4f2aaae340fd36576e83ea2df95d4b68c99f6e465cR14-R17))


