### PR TITLE
Add sharing layouts to all household charts

### DIFF
--- a/src/layout/Screenshottable.jsx
+++ b/src/layout/Screenshottable.jsx
@@ -2,7 +2,7 @@ import { Modal } from "antd";
 import { useCallback, useEffect, useState } from "react";
 
 export default function Screenshottable(props) {
-  const { children } = props;
+  const { children, title } = props;
   // This component watches for the keyboard shortcut Ctrl + K, and when it
   // is pressed, it shows the children in a modal dialog with lots of whitespace
   // around them, so that they can be easily copied and pasted into a document.
@@ -52,8 +52,14 @@ export default function Screenshottable(props) {
             paddingBottom: 120,
             borderWidth: 1,
             borderStyle: "dashed",
+            minHeight: 800,
           }}
         >
+          {
+            title && (
+              <h2>{title}</h2>
+            )
+          }
           {children}
         </div>
       </Modal>

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -14,6 +14,7 @@ import HoverCard, {HoverCardContext} from "../../../../layout/HoverCard";
 import { convertToCurrencyString } from "./convertToCurrencyString";
 import { plotLayoutFont } from 'pages/policy/output/utils';
 import useMobile from "layout/Responsive";
+import Screenshottable from "layout/Screenshottable";
 
 export default function BaselineAndReformChart(props) {
   const {
@@ -187,6 +188,7 @@ function BaselineAndReformTogetherPlot(props) {
     },
   ];
   const plotObject = (
+    <Screenshottable title="Household net income by employment income">
     <Plot
       data={data}
       key="reform"
@@ -260,6 +262,7 @@ function BaselineAndReformTogetherPlot(props) {
         setHoverCard(null);
       }}
     />
+    </Screenshottable>
   );
 
   return <FadeIn>{plotObject}</FadeIn>;
@@ -302,6 +305,7 @@ function BaselineReformDeltaPlot(props) {
     },
   ];
   const plotObject = (
+    <Screenshottable title={`Change to household net income by employment income`}>
     <Plot
       data={data}
       key="reform"
@@ -362,8 +366,10 @@ function BaselineReformDeltaPlot(props) {
       onUnhover={() => {
         setHoverCard(null);
       }}
-    />
+    /></Screenshottable>
   );
 
-  return <FadeIn>{plotObject}</FadeIn>;
+  return <FadeIn>
+      {plotObject}
+  </FadeIn>;
 }

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -13,6 +13,7 @@ import { getCliffs } from "./cliffs";
 import HoverCard, {HoverCardContext} from "../../../../layout/HoverCard";
 import { convertToCurrencyString } from "./convertToCurrencyString";
 import { plotLayoutFont } from 'pages/policy/output/utils';
+import useMobile from "layout/Responsive";
 
 export default function BaselineAndReformChart(props) {
   const {
@@ -136,6 +137,7 @@ export default function BaselineAndReformChart(props) {
 
 function BaselineAndReformTogetherPlot(props) {
   const setHoverCard = useContext(HoverCardContext);
+  const mobile = useMobile();
   const {
     earningsArray,
     baselineArray,
@@ -209,7 +211,7 @@ function BaselineAndReformTogetherPlot(props) {
           y: 1.2,
           orientation: "h",
         },
-        ...ChartLogo,
+        ...ChartLogo(mobile ? 0.97 : 1.05, mobile ? -0.25 : -0.17),
         ...plotLayoutFont
       }}
       config={{
@@ -265,6 +267,7 @@ function BaselineAndReformTogetherPlot(props) {
 
 function BaselineReformDeltaPlot(props) {
   const setHoverCard = useContext(HoverCardContext);
+  const mobile = useMobile();
   const {
     earningsArray,
     baselineArray,
@@ -328,7 +331,8 @@ function BaselineReformDeltaPlot(props) {
         margin: {
           t: 0,
         },
-        ...plotLayoutFont
+        ...plotLayoutFont,
+        ...ChartLogo(mobile ? 0.97 : 1.05, mobile ? -0.25 : -0.17),
       }}
       config={{
         displayModeBar: false,

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -13,6 +13,7 @@ import HoverCard, {HoverCardContext} from "../../../../layout/HoverCard";
 import { plotLayoutFont } from 'pages/policy/output/utils';
 
 import { convertToCurrencyString } from "./convertToCurrencyString";
+import useMobile from "layout/Responsive";
 
 export default function BaselineOnlyChart(props) {
   const {
@@ -55,6 +56,7 @@ export default function BaselineOnlyChart(props) {
 
   function BaselineOnlyPlot() {
     const setHoverCard = useContext(HoverCardContext);
+    const mobile = useMobile();
     // Add the main line, then add a 'you are here' line
     return (
       <FadeIn key="baseline">
@@ -110,7 +112,7 @@ export default function BaselineOnlyChart(props) {
               y: 1.2,
               orientation: "h",
             },
-            ...ChartLogo,
+            ...ChartLogo(mobile ? 0.97 : 1.05, mobile ? -0.25 : -0.17),
             margin: {
               t: 0,
             },

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -14,6 +14,7 @@ import { plotLayoutFont } from 'pages/policy/output/utils';
 
 import { convertToCurrencyString } from "./convertToCurrencyString";
 import useMobile from "layout/Responsive";
+import Screenshottable from "layout/Screenshottable";
 
 export default function BaselineOnlyChart(props) {
   const {
@@ -60,6 +61,7 @@ export default function BaselineOnlyChart(props) {
     // Add the main line, then add a 'you are here' line
     return (
       <FadeIn key="baseline">
+        <Screenshottable title="Household net income by employment income">
         <Plot
           key="baseline"
           data={[
@@ -162,6 +164,7 @@ export default function BaselineOnlyChart(props) {
             setHoverCard(null);
           }}
         />
+        </Screenshottable>
       </FadeIn>
     );
   }

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -16,6 +16,7 @@ import LoadingCentered from "../../../layout/LoadingCentered";
 import { ChartLogo } from "../../../api/charts";
 import { plotLayoutFont } from 'pages/policy/output/utils';
 import useMobile from "layout/Responsive";
+import Screenshottable from "layout/Screenshottable";
 
 export default function MarginalTaxRates(props) {
   const { householdInput, householdBaseline, metadata, policyLabel, policy } = props;
@@ -126,6 +127,8 @@ export default function MarginalTaxRates(props) {
     // Add the main line, then add a 'you are here' line
     plot = (
       <FadeIn>
+        
+        <Screenshottable title="Marginal tax rate by employment income">
         <Plot
           data={[
             {
@@ -154,6 +157,9 @@ export default function MarginalTaxRates(props) {
               ...getPlotlyAxisFormat(metadata.variables.employment_income.unit),
               tickformat: ",.0f",
             },
+            margin: {
+              t: 0,
+            },
             yaxis: {
               title: "Marginal tax rate",
               ...getPlotlyAxisFormat(metadata.variables.marginal_tax_rate.unit),
@@ -175,6 +181,7 @@ export default function MarginalTaxRates(props) {
             width: "100%",
           }}
         />
+        </Screenshottable>
       </FadeIn>
     );
   } else if (baselineMtr && reformMtr) {
@@ -306,6 +313,11 @@ export default function MarginalTaxRates(props) {
             buttonStyle="solid"
           />
         </div>
+        <Screenshottable title={
+          showDelta ?
+            "Change to marginal tax rate by employment income" :
+            "Marginal tax rate by employment income"
+        }>
         <Plot
           data={data}
           layout={{
@@ -330,7 +342,10 @@ export default function MarginalTaxRates(props) {
               y: 1.1,
               orientation: "h",
             },
-            ...ChartLogo,
+            margin: {
+              t: 0,
+            },
+            ...ChartLogo(mobile ? 0.97 : 1.05, mobile ? -0.25 : -0.2),
             ...plotLayoutFont
           }}
           config={{
@@ -341,6 +356,7 @@ export default function MarginalTaxRates(props) {
             width: "100%",
           }}
         />
+        </Screenshottable>
       </FadeIn>
     );
   }

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -15,6 +15,7 @@ import { Radio } from "antd";
 import LoadingCentered from "../../../layout/LoadingCentered";
 import { ChartLogo } from "../../../api/charts";
 import { plotLayoutFont } from 'pages/policy/output/utils';
+import useMobile from "layout/Responsive";
 
 export default function MarginalTaxRates(props) {
   const { householdInput, householdBaseline, metadata, policyLabel, policy } = props;
@@ -27,6 +28,7 @@ export default function MarginalTaxRates(props) {
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
   const [showDelta, setShowDelta] = useState(false);
+  const mobile = useMobile();
   let title;
 
   const currentEarnings = getValueFromHousehold(
@@ -162,7 +164,7 @@ export default function MarginalTaxRates(props) {
               y: 1.1,
               orientation: "h",
             },
-            ...ChartLogo,
+            ...ChartLogo(mobile ? 0.97 : 1.05, mobile ? -0.25 : -0.2),
             ...plotLayoutFont
           }}
           config={{


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f5a246b</samp>

### Summary
📱📸📊

<!--
1.  📱 - This emoji represents the responsiveness and mobile-friendliness of the components, as well as the use of the `useMobile` hook.
2. 📸 - This emoji represents the screenshot functionality and the use of the `Screenshottable` component, as well as the improved appearance of the screenshot modal dialog.
3. 📊 - This emoji represents the charts and the data visualization aspects of the components, as well as the comparison and delta features.
-->
This pull request enhances the responsiveness and screenshot functionality of several components that display charts on the household output page. It uses a custom `Screenshottable` component and a `useMobile` hook to adapt the charts to different screen sizes and enable users to capture and share them. It also adds a title option to the `Screenshottable` component and a feature to show the change in marginal tax rate by employment income on the `MarginalTaxRates` component.

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous tool to capture and display the charts_
> _That show the income and the tax of mortal households_
> _Under the shifting scenarios of policy reforms._

### Walkthrough
*  Add `title` prop to `Screenshottable` component and render it as a heading element in the screenshot container ([link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-6cfd9dc81d631ac665a795fff44b744629016c434a56a9d68bc05adf4c31a11eL5-R5), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-6cfd9dc81d631ac665a795fff44b744629016c434a56a9d68bc05adf4c31a11eL55-R62))
*  Wrap `Plot` components with `Screenshottable` component and pass appropriate `title` props for each chart ([link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bR191), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bR265), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bR308), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL361-R374), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98L58-R64), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98R167), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9R130-R131), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9R184), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9R316-R320), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9R359))
*  Use `useMobile` hook to determine device type and adjust chart logo positioning accordingly ([link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bR16-R17), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bR141), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL212-R216), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bR273), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL331-R339), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98R16-R17), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98L113-R117), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9R18-R19), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9R32), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L165-R173), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L331-R348))
*  Remove top margin of charts by adding `margin` object to `layout` prop of `Plot` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9R160-R162), [link](https://github.com/PolicyEngine/policyengine-app/pull/625/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L331-R348))



cc @MaxGhenis 

e.g. like the below

<img width="1507" alt="image" src="https://github.com/PolicyEngine/policyengine-app/assets/35577657/5a2c46d0-7689-4064-8a76-720e75171d9a">
