### PR TITLE
added mobile support and "snap" effect for HoverCard

### DIFF
--- a/src/layout/HoverCard.jsx
+++ b/src/layout/HoverCard.jsx
@@ -1,27 +1,24 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { createContext, useEffect, useState, memo } from "react";
+import { createContext, useState, memo } from "react";
 import style from "../style";
 import Divider from "./Divider";
 
-export const HoverCardContext = createContext((obj) => obj);
+export const HoverCardContext = createContext({});
 
 export default function HoverCard(props) {
   const { children } = props;
-  const [enabled, setEnabled] = useState(false);
   const [position, setPosition] = useState({left: 0, top: 0});
   const [content, setContent] = useState({title: "", body: ""});
   const title = content && content.title ? content.title : "";
   const body = content && content.body ? content.body : "";
   const notEmpty = title.length !== 0 || body.length !== 0;
-  const visible = enabled && notEmpty;
 
   const hoverCardElement = (
     <motion.div
       style={{
         backgroundColor: style.colors.WHITE,
         position: "absolute",
-        left: position.left,
-        top: position.top,
+        ...position,
         zIndex: 1002,
         padding: 10,
         borderRadius: 15,
@@ -40,26 +37,14 @@ export default function HoverCard(props) {
     </motion.div>
   );
 
-  useEffect(() => {
-    const mouseMoveHandler = (e) => {
-      if (visible) {
-        setPosition({left: e.clientX + 10, top: e.clientY + 10});
-      }
-    };
-    window.addEventListener("mousemove", mouseMoveHandler);
-    return () => {
-      window.removeEventListener("mousemove", mouseMoveHandler);
-    };
-  }, [visible]);
-
   return (
     <>
       <AnimatePresence>
-        {visible && hoverCardElement}
+        {notEmpty && hoverCardElement}
       </AnimatePresence>
       <MemoizedChildren
         setContent={setContent}
-        setEnabled={setEnabled}
+        setPosition={setPosition}
       >
         {children}
       </MemoizedChildren>
@@ -68,17 +53,36 @@ export default function HoverCard(props) {
 }
 
 const MemoizedChildren = memo(function MemoizedChildren(props) {
-  const {children, setContent, setEnabled} = props;
+  const {children, setContent, setPosition} = props;
+  const id = "child-plot";
+
+  const setCoordinates = (left, top, corner = "top-left") => {
+    const bodyRect = document.body.getBoundingClientRect();
+    const divRect = document.getElementById(id).getBoundingClientRect();
+    if (corner === "top-left") {
+      const leftOffset = divRect.left - bodyRect.left;
+      const topOffset = divRect.top - bodyRect.top;
+      setPosition({left: left + leftOffset, top: top + topOffset});
+    } else if (corner === "bottom-left") {
+      const leftOffset = divRect.left - bodyRect.left;
+      const bottomOffset = bodyRect.bottom - divRect.bottom;
+      setPosition({left: left + leftOffset, bottom: divRect.height - top + bottomOffset});
+    } else if (corner === "bottom-right") {
+      const rightOffset = bodyRect.right - divRect.right;
+      const bottomOffset = bodyRect.bottom - divRect.bottom;
+      setPosition({right: divRect.width - left + rightOffset, bottom: divRect.height - top + bottomOffset});
+    } else if (corner === "top-right") {
+      const rightOffset = bodyRect.right - divRect.right;
+      const topOffset = divRect.top - bodyRect.top;
+      setPosition({right: divRect.width - left + rightOffset, top: top + topOffset});
+    } else {
+      console.log(`Corner ${corner} not supported.`);
+    }
+  };
+
   return (
-    <HoverCardContext.Provider value={setContent}>
-      <div
-        onMouseEnter={() => {
-          setEnabled(true);
-        }}
-        onMouseLeave={() => {
-          setEnabled(false);
-        }}
-      >
+    <HoverCardContext.Provider value={{setContent, setCoordinates}}>
+      <div id={id}>
         {children}
       </div>
     </HoverCardContext.Provider>

--- a/src/pages/policy/output/AverageImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByWealthDecile.jsx
@@ -16,7 +16,43 @@ export default function AverageImpactByWealthDecile(props) {
   const mobile = useMobile();
 
   function AverageImpactByWealthDecilePlot() {
-    const setHoverCard = useContext(HoverCardContext);
+    const {setContent, setCoordinates} = useContext(HoverCardContext);
+
+    const dataHandler = (data) => {
+      const point = data.points[0];
+      const change = point.y;
+      const plotLeft = point.xaxis.d2p(point.x);
+      const left = plotLeft + point.xaxis._offset;
+      const top = point.yaxis.d2p(change) + point.yaxis._offset;
+      if (plotLeft <= point.xaxis._length / 2) {
+        setCoordinates(left, top, change >= 0 ? "bottom-left" : "top-left");
+      } else {
+        setCoordinates(left, top, change >= 0 ? "bottom-right" : "top-right");
+      }
+      const decile = cardinal(point.x);
+      const message =
+        change > 0.0001
+          ? `This reform raises the income of households in the ${decile} wealth decile by an average of ${formatVariableValue(
+            metadata.variables.household_net_income,
+            change,
+            0
+          )} per year.`
+          : change < -0.0001
+            ? `This reform lowers the income of households in the ${decile} wealth decile by an average of ${formatVariableValue(
+              metadata.variables.household_net_income,
+              -change,
+              0
+            )} per year.`
+            : change === 0
+              ? `This reform has no impact on the income of households in the ${decile} wealth decile.`
+              : (change > 0 ? "This reform raises " : "This reform lowers ") +
+              ` the income of households in the ${decile} wealth decile by less than 0.01%.`;
+      setContent({
+        title: `Decile ${point.x}`,
+        body: message,
+      });
+    };
+
     // Decile bar chart. Bars are grey if negative, green if positive.
     return (
       <Plot
@@ -72,33 +108,10 @@ export default function AverageImpactByWealthDecile(props) {
           width: "100%",
           marginBottom: !mobile && 50,
         }}
-        onHover={(data) => {
-          const decile = cardinal(data.points[0].x);
-          const change = data.points[0].y;
-          const message =
-            change > 0.0001
-              ? `This reform raises the income of households in the ${decile} wealth decile by an average of ${formatVariableValue(
-                metadata.variables.household_net_income,
-                change,
-                0
-              )} per year.`
-              : change < -0.0001
-                ? `This reform lowers the income of households in the ${decile} wealth decile by an average of ${formatVariableValue(
-                  metadata.variables.household_net_income,
-                  -change,
-                  0
-                )} per year.`
-                : change === 0
-                  ? `This reform has no impact on the income of households in the ${decile} wealth decile.`
-                  : (change > 0 ? "This reform raises " : "This reform lowers ") +
-                  ` the income of households in the ${decile} wealth decile by less than 0.01%.`;
-          setHoverCard({
-            title: `Decile ${data.points[0].x}`,
-            body: message,
-          });
-        }}
+        onClick={dataHandler}
+        onHover={dataHandler}
         onUnhover={() => {
-          setHoverCard(null);
+          setContent(null);
         }}
       />
     );

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -49,7 +49,50 @@ export default function BudgetaryImpact(props) {
   console.log(values, labels, valuesBeforeFilter, labelsBeforeFilter);
 
   function BudgetaryImpactPlot() {
-    const setHoverCard = useContext(HoverCardContext);
+    const {setContent, setCoordinates} = useContext(HoverCardContext);
+
+    const dataHandler = (data) => {
+      const point = data.points[0];
+      const label = point.x;
+      const plotLeft = point.xaxis.d2p(label);
+      const left = plotLeft + point.xaxis._offset;
+      const top = point.yaxis.d2p(point.y) + point.yaxis._offset;
+      if (plotLeft <= point.xaxis._length / 2) {
+        setCoordinates(left, top, point.y >= 0 ? "bottom-left" : "top-left");
+      } else {
+        setCoordinates(left, top, point.y >= 0 ? "bottom-right" : "top-right");
+      }
+      // look up label/values array
+      let relevantFigure = values[labels.indexOf(label)] * 1e9;
+      // If tax revenues, negate
+      if (label.toLowerCase().includes("tax")) {
+        relevantFigure = -relevantFigure;
+      }
+      let body =
+        relevantFigure < 0
+          ? "This reform would increase "
+          : relevantFigure > 0
+            ? "This reform would reduce "
+            : "This reform would not impact ";
+      body += label.toLowerCase().includes("tax")
+        ? label.toLowerCase()
+        : label.toLowerCase().includes("benefit")
+          ? "benefit spending"
+          : "the budget deficit";
+      if (relevantFigure === 0) {
+        body += ".";
+      } else {
+        body += ` by ${aggregateCurrency(
+          Math.abs(relevantFigure),
+          metadata
+        )}.`;
+      }
+      setContent({
+        title: label,
+        body: body,
+      });
+    };
+
     // Waterfall chart
     return (
       <Plot
@@ -112,40 +155,10 @@ export default function BudgetaryImpact(props) {
         style={{
           width: "100%",
         }}
-        onHover={(data) => {
-          const label = data.points[0].x;
-          // look up label/values array
-          let relevantFigure = values[labels.indexOf(label)] * 1e9;
-          // If tax revenues, negate
-          if (label.toLowerCase().includes("tax")) {
-            relevantFigure = -relevantFigure;
-          }
-          let body =
-            relevantFigure < 0
-              ? "This reform would increase "
-              : relevantFigure > 0
-                ? "This reform would reduce "
-                : "This reform would not impact ";
-          body += label.toLowerCase().includes("tax")
-            ? label.toLowerCase()
-            : label.toLowerCase().includes("benefit")
-              ? "benefit spending"
-              : "the budget deficit";
-          if (relevantFigure === 0) {
-            body += ".";
-          } else {
-            body += ` by ${aggregateCurrency(
-              Math.abs(relevantFigure),
-              metadata
-            )}.`;
-          }
-          setHoverCard({
-            title: label,
-            body: body,
-          });
-        }}
+        onClick={dataHandler}
+        onHover={dataHandler}
         onUnhover={() => {
-          setHoverCard(null);
+          setContent(null);
         }}
       />
     );

--- a/src/pages/policy/output/DeepPovertyImpact.jsx
+++ b/src/pages/policy/output/DeepPovertyImpact.jsx
@@ -49,7 +49,45 @@ export default function DeepPovertyImpact(props) {
   const mobile = useMobile();
 
   function DeepPovertyImpactPlot() {
-    const setHoverCard = useContext(HoverCardContext);
+    const {setContent, setCoordinates} = useContext(HoverCardContext);
+
+    const dataHandler = (data) => {
+      const point = data.points[0];
+      const group = point.x;
+      const change = point.y;
+      const plotLeft = point.xaxis.d2p(group);
+      const left = plotLeft + point.xaxis._offset;
+      const top = point.yaxis.d2p(change) + point.yaxis._offset;
+      if (plotLeft <= point.xaxis._length / 2) {
+        setCoordinates(left, top, change >= 0 ? "bottom-left" : "top-left");
+      } else {
+        setCoordinates(left, top, change >= 0 ? "bottom-right" : "top-right");
+      }
+      const baseline =
+        impact.poverty.deep_poverty[labelToKey[group]].baseline;
+      const reform = impact.poverty.deep_poverty[labelToKey[group]].reform;
+      const message = `The percentage of ${
+        group === "All" ? "people" : group.toLowerCase()
+      } in deep poverty ${
+        change < -0.001
+          ? `would fall ${percent(-change)} from ${percent(
+            baseline
+          )} to ${percent(reform)}.`
+          : change > 0.001
+            ? `would rise ${percent(change)} from ${percent(
+              baseline
+            )} to ${percent(reform)}.`
+            : change === 0
+              ? `would remain at ${percent(baseline)}.`
+              :(change > 0 ? "would rise " : "would fall ") +
+              ` by less than 0.1%.`
+      }`;
+      setContent({
+        title: group,
+        body: message,
+      });
+    };
+
     // Decile bar chart. Bars are grey if negative, green if positive.
     return (
       <Plot
@@ -103,35 +141,10 @@ export default function DeepPovertyImpact(props) {
         style={{
           width: "100%",
         }}
-        onHover={(data) => {
-          const group = data.points[0].x;
-          const change = data.points[0].y;
-          const baseline =
-            impact.poverty.deep_poverty[labelToKey[group]].baseline;
-          const reform = impact.poverty.deep_poverty[labelToKey[group]].reform;
-          const message = `The percentage of ${
-            group === "All" ? "people" : group.toLowerCase()
-          } in deep poverty ${
-            change < -0.001
-              ? `would fall ${percent(-change)} from ${percent(
-                baseline
-              )} to ${percent(reform)}.`
-              : change > 0.001
-                ? `would rise ${percent(change)} from ${percent(
-                  baseline
-                )} to ${percent(reform)}.`
-                : change === 0
-                  ? `would remain at ${percent(baseline)}.`
-                  :(change > 0 ? "would rise " : "would fall ") +
-                  ` by less than 0.1%.`
-          }`;
-          setHoverCard({
-            title: group,
-            body: message,
-          });
-        }}
+        onClick={dataHandler}
+        onHover={dataHandler}
         onUnhover={() => {
-          setHoverCard(null);
+          setContent(null);
         }}
       />
     );

--- a/src/pages/policy/output/DeepPovertyImpactByGender.jsx
+++ b/src/pages/policy/output/DeepPovertyImpactByGender.jsx
@@ -43,7 +43,49 @@ export default function DeepPovertyImpactByGender(props) {
   const mobile = useMobile();
 
   function DeepPovertyImpactByGenderPlot() {
-    const setHoverCard = useContext(HoverCardContext);
+    const {setContent, setCoordinates} = useContext(HoverCardContext);
+
+    const dataHandler = (data) => {
+      const point = data.points[0];
+      const group = point.x;
+      const change = point.y;
+      const plotLeft = point.xaxis.d2p(group);
+      const left = plotLeft + point.xaxis._offset;
+      const top = point.yaxis.d2p(change) + point.yaxis._offset;
+      if (plotLeft <= point.xaxis._length / 2) {
+        setCoordinates(left, top, change >= 0 ? "bottom-left" : "top-left");
+      } else {
+        setCoordinates(left, top, change >= 0 ? "bottom-right" : "top-right");
+      }
+      const baseline =
+        group === "All"
+          ? impact.poverty.deep_poverty[labelToKey[group]].baseline
+          : impact.poverty_by_gender.deep_poverty[labelToKey[group]].baseline;
+      const reform =
+        group === "All"
+          ? impact.poverty.deep_poverty[labelToKey[group]].reform
+          : impact.poverty_by_gender.deep_poverty[labelToKey[group]].reform;
+      const message = `The percentage of ${
+        group === "All"
+          ? "people"
+          : { male: "men", female: "women" }[group.toLowerCase()]
+      } in deep poverty ${
+        change < -0.001
+          ? `would fall ${percent(-change)} from ${percent(
+            baseline
+          )} to ${percent(reform)}.`
+          : change > 0.001
+            ? `would rise ${percent(change)} from ${percent(
+              baseline
+            )} to ${percent(reform)}.`
+            : `would remain at ${percent(baseline)}.`
+      }`;
+      setContent({
+        title: group,
+        body: message,
+      });
+    };
+
     // Decile bar chart. Bars are grey if negative, green if positive.
     return (
       <Plot
@@ -97,39 +139,10 @@ export default function DeepPovertyImpactByGender(props) {
         style={{
           width: "100%",
         }}
-        onHover={(data) => {
-          const group = data.points[0].x;
-          const change = data.points[0].y;
-          const baseline =
-            group === "All"
-              ? impact.poverty.deep_poverty[labelToKey[group]].baseline
-              : impact.poverty_by_gender.deep_poverty[labelToKey[group]].baseline;
-          const reform =
-            group === "All"
-              ? impact.poverty.deep_poverty[labelToKey[group]].reform
-              : impact.poverty_by_gender.deep_poverty[labelToKey[group]].reform;
-          const message = `The percentage of ${
-            group === "All"
-              ? "people"
-              : { male: "men", female: "women" }[group.toLowerCase()]
-          } in deep poverty ${
-            change < -0.001
-              ? `would fall ${percent(-change)} from ${percent(
-                baseline
-              )} to ${percent(reform)}.`
-              : change > 0.001
-                ? `would rise ${percent(change)} from ${percent(
-                  baseline
-                )} to ${percent(reform)}.`
-                : `would remain at ${percent(baseline)}.`
-          }`;
-          setHoverCard({
-            title: group,
-            body: message,
-          });
-        }}
+        onClick={dataHandler}
+        onHover={dataHandler}
         onUnhover={() => {
-          setHoverCard(null);
+          setContent(null);
         }}
       />
     );

--- a/src/pages/policy/output/DetailedBudgetaryImpact.jsx
+++ b/src/pages/policy/output/DetailedBudgetaryImpact.jsx
@@ -46,7 +46,26 @@ export default function DetailedBudgetaryImpact(props) {
 
 
   function DetailedBudgetaryImpactPlot() {
-    const setHoverCard = useContext(HoverCardContext);
+    const {setContent, setCoordinates} = useContext(HoverCardContext);
+
+    const dataHandler = (data) => {
+      const point = data.points[0];
+      const program = point.x;
+      const change = point.y;
+      const plotLeft = point.xaxis.d2p(program);
+      const left = plotLeft + point.xaxis._offset;
+      const top = point.yaxis.d2p(change) + point.yaxis._offset;
+      if (plotLeft <= point.xaxis._length / 2) {
+        setCoordinates(left, top, change >= 0 ? "bottom-left" : "top-left");
+      } else {
+        setCoordinates(left, top, change >= 0 ? "bottom-right" : "top-right");
+      }
+      setContent({
+        title: `${program}`,
+        body: aggregateCurrency(change, metadata)
+      });
+    };
+
     // Decile bar chart. Bars are grey if negative, green if positive.
     return (
       <Plot
@@ -115,16 +134,10 @@ export default function DetailedBudgetaryImpact(props) {
           width: "100%",
           marginBottom: !mobile && 50,
         }}
-        onHover={(data) => {
-          const program = data.points[0].x;
-          const change = data.points[0].y;
-          setHoverCard({
-            title: `${program}`,
-            body: aggregateCurrency(change, metadata)
-          });
-        }}
+        onClick={dataHandler}
+        onHover={dataHandler}
         onUnhover={() => {
-          setHoverCard(null);
+          setContent(null);
         }}
       />
     );

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -26,7 +26,81 @@ export default function InequalityImpact(props) {
   const mobile = useMobile();
 
   function InequalityImpactPlot() {
-    const setHoverCard = useContext(HoverCardContext)
+    const {setContent, setCoordinates} = useContext(HoverCardContext);
+
+    const dataHandler = (data) => {
+      const point = data.points[0];
+      const label = point.x;
+      const plotLeft = point.xaxis.d2p(label);
+      const left = plotLeft + point.xaxis._offset;
+      const top = point.yaxis.d2p(point.y) + point.yaxis._offset;
+      if (plotLeft <= point.xaxis._length / 2) {
+        setCoordinates(left, top, point.y >= 0 ? "bottom-left" : "top-left");
+      } else {
+        setCoordinates(left, top, point.y >= 0 ? "bottom-right" : "top-right");
+      }
+      let body = null;
+      if (label === "Gini index") {
+        // 'This reform reduces/increases tax revenues by £X/This reform has no impact on tax revenues'
+        const baseline = impact.inequality.gini.baseline;
+        const reform = impact.inequality.gini.reform;
+        const change = reform / baseline - 1;
+        body =
+          change > 0.001
+            ? `This reform would increase the Gini index of net income from
+                  ${baseline.toFixed(3)} to ${reform.toFixed(3)}, a change of
+                  ${change.toFixed(3)}.`
+            : change < -0.001
+              ? `This reform would reduce the Gini index of net income from
+                  ${baseline.toFixed(3)} to ${reform.toFixed(3)}, a change of
+                  ${percent(change)}.`
+              : change === 0
+                ? "This reform would not impact the Gini index of net income."
+                : (change > 0 ? "This reform would increase " : "This reform would reduce ") +
+                " the Gini index of net income by less than 0.1%.";
+      } else if (label === "Top 10% share") {
+        // 'This reform reduces/increases benefit spending by £X/This reform has no impact on benefit spending'
+        const baseline = impact.inequality.top_10_pct_share.baseline;
+        const reform = impact.inequality.top_10_pct_share.reform;
+        const change = reform / baseline - 1;
+        body =
+          change > 0.001
+            ? `This reform would increase the share of total net income held by people in the top 10% of households from
+                  ${percent(baseline)} to ${percent(reform)}, an increase of
+                  ${percent(change)}.`
+            : change < -0.001
+              ? `This reform would reduce the share of total net income held by people in the top 10% of households from
+                  ${percent(baseline)} to ${percent(reform)}, a reduction of
+                  ${percent(-change)}.`
+              : change === 0
+                ? "This reform would not impact the share of total net income held by people in the top 10% of households."
+                : (change > 0 ? "This reform would increase " : "This reform would reduce ") +
+                " the share of total net income held by people in the top 10% of households by less than 0.1%.";
+      } else {
+        // 'This reform reduces/increases the budget deficit by £X/This reform has no impact on the budget deficit'
+        const baseline = impact.inequality.top_1_pct_share.baseline;
+        const reform = impact.inequality.top_1_pct_share.reform;
+        const change = reform / baseline - 1;
+        body =
+          change > 0.001
+            ? `This reform would increase the share of total net income held by people in the top 1% of households from
+                  ${percent(baseline)} to ${percent(reform)}, an increase of
+                  ${percent(change)}.`
+            : change < -0.001
+              ? `This reform would reduce the share of total net income held by people in the top 1% of households from
+                  ${percent(baseline)} to ${percent(reform)}, a reduction of
+                  ${percent(-change)}.`
+              : change === 0
+                ? "This reform would not impact the share of total net income held by people in the top 1% of households."
+                : (change > 0 ? "This reform would increase " : "This reform would reduce ") +
+                " the share of total net income held by people in the top 10% of households by less than 0.1%.";
+      }
+      setContent({
+        title: label,
+        body: body,
+      });
+    };
+
     return (
       <Plot
         data={[
@@ -77,71 +151,10 @@ export default function InequalityImpact(props) {
         style={{
           width: "100%",
         }}
-        onHover={(data) => {
-          const label = data.points[0].x;
-          let body = null;
-          if (label === "Gini index") {
-            // 'This reform reduces/increases tax revenues by £X/This reform has no impact on tax revenues'
-            const baseline = impact.inequality.gini.baseline;
-            const reform = impact.inequality.gini.reform;
-            const change = reform / baseline - 1;
-            body =
-              change > 0.001
-                ? `This reform would increase the Gini index of net income from
-                  ${baseline.toFixed(3)} to ${reform.toFixed(3)}, a change of
-                  ${change.toFixed(3)}.`
-                : change < -0.001
-                  ? `This reform would reduce the Gini index of net income from
-                  ${baseline.toFixed(3)} to ${reform.toFixed(3)}, a change of
-                  ${percent(change)}.`
-                  : change === 0
-                    ? "This reform would not impact the Gini index of net income."
-                    : (change > 0 ? "This reform would increase " : "This reform would reduce ") +
-                    " the Gini index of net income by less than 0.1%.";
-          } else if (label === "Top 10% share") {
-            // 'This reform reduces/increases benefit spending by £X/This reform has no impact on benefit spending'
-            const baseline = impact.inequality.top_10_pct_share.baseline;
-            const reform = impact.inequality.top_10_pct_share.reform;
-            const change = reform / baseline - 1;
-            body =
-              change > 0.001
-                ? `This reform would increase the share of total net income held by people in the top 10% of households from
-                  ${percent(baseline)} to ${percent(reform)}, an increase of
-                  ${percent(change)}.`
-                : change < -0.001
-                  ? `This reform would reduce the share of total net income held by people in the top 10% of households from
-                  ${percent(baseline)} to ${percent(reform)}, a reduction of
-                  ${percent(-change)}.`
-                  : change === 0
-                    ? "This reform would not impact the share of total net income held by people in the top 10% of households."
-                    : (change > 0 ? "This reform would increase " : "This reform would reduce ") +
-                    " the share of total net income held by people in the top 10% of households by less than 0.1%.";
-          } else {
-            // 'This reform reduces/increases the budget deficit by £X/This reform has no impact on the budget deficit'
-            const baseline = impact.inequality.top_1_pct_share.baseline;
-            const reform = impact.inequality.top_1_pct_share.reform;
-            const change = reform / baseline - 1;
-            body =
-              change > 0.001
-                ? `This reform would increase the share of total net income held by people in the top 1% of households from
-                  ${percent(baseline)} to ${percent(reform)}, an increase of
-                  ${percent(change)}.`
-                : change < -0.001
-                  ? `This reform would reduce the share of total net income held by people in the top 1% of households from
-                  ${percent(baseline)} to ${percent(reform)}, a reduction of
-                  ${percent(-change)}.`
-                  : change === 0
-                    ? "This reform would not impact the share of total net income held by people in the top 1% of households."
-                    : (change > 0 ? "This reform would increase " : "This reform would reduce ") +
-                    " the share of total net income held by people in the top 10% of households by less than 0.1%.";
-          }
-          setHoverCard({
-            title: label,
-            body: body,
-          });
-        }}
+        onClick={dataHandler}
+        onHover={dataHandler}
         onUnhover={() => {
-          setHoverCard(null);
+          setContent(null);
         }}
       />
     );

--- a/src/pages/policy/output/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/IntraDecileImpact.jsx
@@ -20,7 +20,7 @@ export default function IntraDecileImpact(props) {
   const mobile = useMobile();
 
   function IntraDecileImpactPlot() {
-    const setHoverCard = useContext(HoverCardContext);
+    const {setContent, setCoordinates} = useContext(HoverCardContext);
 
     const data = [
       {
@@ -212,6 +212,30 @@ export default function IntraDecileImpact(props) {
       },
     ];
 
+    const dataHandler = (data) => {
+      const point = data.points[0];
+      const group = point.y;
+      const value = point.x;
+      const top = point.yaxis.d2p(group) + point.yaxis._offset;
+      const category = point.data.name;
+      if (category.includes("Lose")) {
+        setCoordinates(point.xaxis._offset, top);
+      } else {
+        setCoordinates(point.xaxis._length + point.xaxis._offset, top, "top-right");
+      }
+      const title = group === "All" ? "All households" : `Decile ${group}`;
+      const message = `Of ${
+        group === "All"
+          ? "all households"
+          : `households in the ${cardinal(group)} decile`
+      }, ${policyLabel} would cause ${percent(value)} of people to
+        ${category.toLowerCase()} of their net income.`;
+      setContent({
+        title: title,
+        body: message,
+      });
+    };
+
     return (
       <Plot
         data={data}
@@ -269,24 +293,10 @@ export default function IntraDecileImpact(props) {
           width: "100%",
           marginBottom: !mobile && 50,
         }}
-        onHover={(data) => {
-          const group = data.points[0].y;
-          const title = group === "All" ? "All households" : `Decile ${group}`;
-          const category = data.points[0].data.name;
-          const value = data.points[0].x;
-          const message = `Of ${
-            group === "All"
-              ? "all households"
-              : `households in the ${cardinal(group)} decile`
-          }, ${policyLabel} would cause ${percent(value)} of people to
-        ${category.toLowerCase()} of their net income.`;
-          setHoverCard({
-            title: title,
-            body: message,
-          });
-        }}
+        onClick={dataHandler}
+        onHover={dataHandler}
         onUnhover={() => {
-          setHoverCard(null);
+          setContent(null);
         }}
       />
     );

--- a/src/pages/policy/output/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/IntraDecileImpact.jsx
@@ -212,20 +212,48 @@ export default function IntraDecileImpact(props) {
       },
     ];
 
+    const categories = [
+      "Gain more than 5%",
+      "Gain less than 5%",
+      "No change",
+      "Lose less than 5%",
+      "Lose more than 5%"
+    ];
+    const indices = new Map();
+    indices.set(categories[0], 0);
+    indices.set(categories[1], 1);
+    indices.set(categories[2], 2);
+    indices.set(categories[3], 3);
+    indices.set(categories[4], 4);
+
     const dataHandler = (data) => {
       const point = data.points[0];
       const group = point.y;
       const value = point.x;
-      const top = point.yaxis.d2p(group) + point.yaxis._offset;
+      let left = point.xaxis.d2p(value) + point.xaxis._offset;
+      const topOffset = (point.yaxis.d2p(1) - point.yaxis.d2p(2)) / 2;
+      const top = point.yaxis.d2p(group) + point.yaxis._offset + topOffset;
       const category = point.data.name;
-      if (category.includes("Lose")) {
-        setCoordinates(point.xaxis._offset, top);
-      } else {
-        setCoordinates(point.xaxis._length + point.xaxis._offset, top, "top-right");
+      const index = indices.get(category);
+      const isAll = group === "All";
+      if (index >= 1) {
+        left += point.xaxis.d2p(isAll ? all[categories[0]] : deciles[categories[0]][group - 1]);
       }
-      const title = group === "All" ? "All households" : `Decile ${group}`;
+      if (index >= 2) {
+        left += point.xaxis.d2p(isAll ? all[categories[1]] : deciles[categories[1]][group - 1]);
+      }
+      if (index >= 3) {
+        left += point.xaxis.d2p(isAll ? all[categories[2]] : deciles[categories[2]][group - 1]);
+      }
+      if (index >= 4) {
+        left += point.xaxis.d2p(isAll ? all[categories[3]] : deciles[categories[3]][group - 1]);
+      }
+      const leftHalf = left - point.xaxis._offset <= point.xaxis._length / 2;
+      const corner = leftHalf ? "top-left" : "top-right";
+      setCoordinates(left, top, corner);
+      const title = isAll ? "All households" : `Decile ${group}`;
       const message = `Of ${
-        group === "All"
+        isAll
           ? "all households"
           : `households in the ${cardinal(group)} decile`
       }, ${policyLabel} would cause ${percent(value)} of people to

--- a/src/pages/policy/output/IntraWealthDecileImpact.jsx
+++ b/src/pages/policy/output/IntraWealthDecileImpact.jsx
@@ -212,20 +212,48 @@ export default function IntraWealthDecileImpact(props) {
       },
     ];
 
+    const categories = [
+      "Gain more than 5%",
+      "Gain less than 5%",
+      "No change",
+      "Lose less than 5%",
+      "Lose more than 5%"
+    ];
+    const indices = new Map();
+    indices.set(categories[0], 0);
+    indices.set(categories[1], 1);
+    indices.set(categories[2], 2);
+    indices.set(categories[3], 3);
+    indices.set(categories[4], 4);
+
     const dataHandler = (data) => {
       const point = data.points[0];
       const group = point.y;
       const value = point.x;
-      const top = point.yaxis.d2p(group) + point.yaxis._offset;
+      let left = point.xaxis.d2p(value) + point.xaxis._offset;
+      const topOffset = (point.yaxis.d2p(1) - point.yaxis.d2p(2)) / 2;
+      const top = point.yaxis.d2p(group) + point.yaxis._offset + topOffset;
       const category = point.data.name;
-      if (category.includes("Lose")) {
-        setCoordinates(point.xaxis._offset, top);
-      } else {
-        setCoordinates(point.xaxis._length + point.xaxis._offset, top, "top-right");
+      const index = indices.get(category);
+      const isAll = group === "All";
+      if (index >= 1) {
+        left += point.xaxis.d2p(isAll ? all[categories[0]] : deciles[categories[0]][group - 1]);
       }
-      const title = group === "All" ? "All households" : `Decile ${group}`;
+      if (index >= 2) {
+        left += point.xaxis.d2p(isAll ? all[categories[1]] : deciles[categories[1]][group - 1]);
+      }
+      if (index >= 3) {
+        left += point.xaxis.d2p(isAll ? all[categories[2]] : deciles[categories[2]][group - 1]);
+      }
+      if (index >= 4) {
+        left += point.xaxis.d2p(isAll ? all[categories[3]] : deciles[categories[3]][group - 1]);
+      }
+      const leftHalf = left - point.xaxis._offset <= point.xaxis._length / 2;
+      const corner = leftHalf ? "top-left" : "top-right";
+      setCoordinates(left, top, corner);
+      const title = isAll ? "All households" : `Decile ${group}`;
       const message = `${percent(value)} of ${
-        group === "All"
+        isAll
           ? "all households"
           : `households in the ${cardinal(group)} decile`
       } ${category.toLowerCase()}.`;

--- a/src/pages/policy/output/IntraWealthDecileImpact.jsx
+++ b/src/pages/policy/output/IntraWealthDecileImpact.jsx
@@ -20,7 +20,7 @@ export default function IntraWealthDecileImpact(props) {
   const mobile = useMobile();
 
   function IntraWealthDecileImpactPlot() {
-    const setHoverCard = useContext(HoverCardContext);
+    const {setContent, setCoordinates} = useContext(HoverCardContext);
 
     const data = [
       {
@@ -212,6 +212,29 @@ export default function IntraWealthDecileImpact(props) {
       },
     ];
 
+    const dataHandler = (data) => {
+      const point = data.points[0];
+      const group = point.y;
+      const value = point.x;
+      const top = point.yaxis.d2p(group) + point.yaxis._offset;
+      const category = point.data.name;
+      if (category.includes("Lose")) {
+        setCoordinates(point.xaxis._offset, top);
+      } else {
+        setCoordinates(point.xaxis._length + point.xaxis._offset, top, "top-right");
+      }
+      const title = group === "All" ? "All households" : `Decile ${group}`;
+      const message = `${percent(value)} of ${
+        group === "All"
+          ? "all households"
+          : `households in the ${cardinal(group)} decile`
+      } ${category.toLowerCase()}.`;
+      setContent({
+        title: title,
+        body: message,
+      });
+    };
+
     return (
       <Plot
         data={data}
@@ -269,23 +292,10 @@ export default function IntraWealthDecileImpact(props) {
           width: "100%",
           marginBottom: !mobile && 50,
         }}
-        onHover={(data) => {
-          const group = data.points[0].y;
-          const title = group === "All" ? "All households" : `Decile ${group}`;
-          const category = data.points[0].data.name;
-          const value = data.points[0].x;
-          const message = `${percent(value)} of ${
-            group === "All"
-              ? "all households"
-              : `households in the ${cardinal(group)} decile`
-          } ${category.toLowerCase()}.`;
-          setHoverCard({
-            title: title,
-            body: message,
-          });
-        }}
+        onClick={dataHandler}
+        onHover={dataHandler}
         onUnhover={() => {
-          setHoverCard(null);
+          setContent(null);
         }}
       />
     );

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -47,7 +47,44 @@ export default function PovertyImpact(props) {
   const mobile = useMobile();
 
   function PovertyImpactPlot() {
-    const setHoverCard = useContext(HoverCardContext);
+    const {setContent, setCoordinates} = useContext(HoverCardContext);
+
+    const dataHandler = (data) => {
+      const point = data.points[0];
+      const group = point.x;
+      const change = point.y;
+      const plotLeft = point.xaxis.d2p(group);
+      const left = plotLeft + point.xaxis._offset;
+      const top = point.yaxis.d2p(change) + point.yaxis._offset;
+      if (plotLeft <= point.xaxis._length / 2) {
+        setCoordinates(left, top, change >= 0 ? "bottom-left" : "top-left");
+      } else {
+        setCoordinates(left, top, change >= 0 ? "bottom-right" : "top-right");
+      }
+      const baseline = impact.poverty.poverty[labelToKey[group]].baseline;
+      const reform = impact.poverty.poverty[labelToKey[group]].reform;
+      const message = `The percentage of ${
+        group === "All" ? "people" : group.toLowerCase()
+      } in poverty ${
+        change < -0.001
+          ? `would fall ${percent(-change)} from ${percent(
+            baseline
+          )} to ${percent(reform)}.`
+          : change > 0.001
+            ? `would rise ${percent(change)} from ${percent(
+              baseline
+            )} to ${percent(reform)}.`
+            : change === 0
+              ? `would remain at ${percent(baseline)}.`
+              : (change > 0 ? "would rise " : "would fall ") +
+              ` by less than 0.1%.`
+      }`;
+      setContent({
+        title: group,
+        body: message,
+      });
+    };
+
     // Decile bar chart. Bars are grey if negative, green if positive.
     return (
       <Plot
@@ -101,34 +138,10 @@ export default function PovertyImpact(props) {
         style={{
           width: "100%",
         }}
-        onHover={(data) => {
-          const group = data.points[0].x;
-          const change = data.points[0].y;
-          const baseline = impact.poverty.poverty[labelToKey[group]].baseline;
-          const reform = impact.poverty.poverty[labelToKey[group]].reform;
-          const message = `The percentage of ${
-            group === "All" ? "people" : group.toLowerCase()
-          } in poverty ${
-            change < -0.001
-              ? `would fall ${percent(-change)} from ${percent(
-                baseline
-              )} to ${percent(reform)}.`
-              : change > 0.001
-                ? `would rise ${percent(change)} from ${percent(
-                  baseline
-                )} to ${percent(reform)}.`
-                : change === 0
-                  ? `would remain at ${percent(baseline)}.`
-                  : (change > 0 ? "would rise " : "would fall ") +
-                  ` by less than 0.1%.`
-          }`;
-          setHoverCard({
-            title: group,
-            body: message,
-          });
-        }}
+        onClick={dataHandler}
+        onHover={dataHandler}
         onUnhover={() => {
-          setHoverCard(null);
+          setContent(null);
         }}
       />
     );

--- a/src/pages/policy/output/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/PovertyImpactByRace.jsx
@@ -54,7 +54,57 @@ export default function PovertyImpactByRace(props) {
   const mobile = useMobile();
 
   function PovertyImpactByRacePlot() {
-    const setHoverCard = useContext(HoverCardContext);
+    const {setContent, setCoordinates} = useContext(HoverCardContext);
+
+    const dataHandler = (data) => {
+      const point = data.points[0];
+      const group = point.x;
+      const change = point.y;
+      const plotLeft = point.xaxis.d2p(group);
+      const left = plotLeft + point.xaxis._offset;
+      const top = point.yaxis.d2p(change) + point.yaxis._offset;
+      if (plotLeft <= point.xaxis._length / 2) {
+        setCoordinates(left, top, change >= 0 ? "bottom-left" : "top-left");
+      } else {
+        setCoordinates(left, top, change >= 0 ? "bottom-right" : "top-right");
+      }
+      const baseline =
+        group === "All"
+          ? impact.poverty.poverty[labelToKey[group]].baseline
+          : impact.poverty_by_race.poverty[labelToKey[group]].baseline;
+      const reform =
+        group === "All"
+          ? impact.poverty.poverty[labelToKey[group]].reform
+          : impact.poverty_by_race.poverty[labelToKey[group]].reform;
+      const message = `The percentage of ${
+        group === "All"
+          ? "people"
+          : {
+            white: "White (non-Hispanic) people",
+            black: "Black (non-Hispanic) people",
+            hispanic: "Hispanic people",
+            other: "people of other racial groups",
+          }[group.toLowerCase()]
+      } in poverty ${
+        change < -0.001
+          ? `would fall ${percent(-change)} from ${percent(
+            baseline
+          )} to ${percent(reform)}.`
+          : change > 0.001
+            ? `would rise ${percent(change)} from ${percent(
+              baseline
+            )} to ${percent(reform)}.`
+            : change === 0
+              ?  `would remain at ${percent(baseline)}.`
+              : (change > 0 ? "would rise " : "would fall ") +
+              ` by less than 0.1%.`
+      }`;
+      setContent({
+        title: group,
+        body: message,
+      });
+    };
+
     // Decile bar chart. Bars are grey if negative, green if positive.
     return (
       <Plot
@@ -108,47 +158,10 @@ export default function PovertyImpactByRace(props) {
         style={{
           width: "100%",
         }}
-        onHover={(data) => {
-          const group = data.points[0].x;
-          const change = data.points[0].y;
-          const baseline =
-            group === "All"
-              ? impact.poverty.poverty[labelToKey[group]].baseline
-              : impact.poverty_by_race.poverty[labelToKey[group]].baseline;
-          const reform =
-            group === "All"
-              ? impact.poverty.poverty[labelToKey[group]].reform
-              : impact.poverty_by_race.poverty[labelToKey[group]].reform;
-          const message = `The percentage of ${
-            group === "All"
-              ? "people"
-              : {
-                white: "White (non-Hispanic) people",
-                black: "Black (non-Hispanic) people",
-                hispanic: "Hispanic people",
-                other: "people of other racial groups",
-              }[group.toLowerCase()]
-          } in poverty ${
-            change < -0.001
-              ? `would fall ${percent(-change)} from ${percent(
-                baseline
-              )} to ${percent(reform)}.`
-              : change > 0.001
-                ? `would rise ${percent(change)} from ${percent(
-                  baseline
-                )} to ${percent(reform)}.`
-                : change === 0
-                  ?  `would remain at ${percent(baseline)}.`
-                  : (change > 0 ? "would rise " : "would fall ") +
-                  ` by less than 0.1%.`
-          }`;
-          setHoverCard({
-            title: group,
-            body: message,
-          });
-        }}
+        onClick={dataHandler}
+        onHover={dataHandler}
         onUnhover={() => {
-          setHoverCard(null);
+          setContent(null);
         }}
       />
     );

--- a/src/pages/policy/output/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByDecile.jsx
@@ -16,7 +16,39 @@ export default function RelativeImpactByDecile(props) {
   const mobile = useMobile();
 
   function RelativeImpactByDecilePlot() {
-    const setHoverCard = useContext(HoverCardContext);
+    const {setContent, setCoordinates} = useContext(HoverCardContext);
+
+    const dataHandler = (data) => {
+      const point = data.points[0];
+      const relativeChange = point.y;
+      const plotLeft = point.xaxis.d2p(point.x);
+      const left = plotLeft + point.xaxis._offset;
+      const top = point.yaxis.d2p(relativeChange) + point.yaxis._offset;
+      if (plotLeft <= point.xaxis._length / 2) {
+        setCoordinates(left, top, relativeChange >= 0 ? "bottom-left" : "top-left");
+      } else {
+        setCoordinates(left, top, relativeChange >= 0 ? "bottom-right" : "top-right");
+      }
+      const decile = cardinal(point.x);
+      const message =
+        relativeChange > 0.001
+          ? `This reform would raise the income of households in the ${decile} decile by an average of ${percent(
+            relativeChange
+          )}.`
+          : relativeChange < -0.001
+            ? `This reform would lower the income of households in the ${decile} decile by an average of ${percent(
+              -relativeChange
+            )}.`
+            : relativeChange === 0
+              ? `This reform would not impact the income of households in the ${decile} decile.`
+              : (relativeChange > 0 ? "This reform would raise " : "This reform would lower ") +
+              ` the income of households in the ${decile} decile by less than 0.1%.`;
+      setContent({
+        title: `Decile ${point.x}`,
+        body: message,
+      });
+    };
+
     // Decile bar chart. Bars are grey if negative, green if positive.
     return (
       <Plot
@@ -72,29 +104,10 @@ export default function RelativeImpactByDecile(props) {
           width: "100%",
           marginBottom: !mobile && 50,
         }}
-        onHover={(data) => {
-          const decile = cardinal(data.points[0].x);
-          const relativeChange = data.points[0].y;
-          const message =
-            relativeChange > 0.001
-              ? `This reform would raise the income of households in the ${decile} decile by an average of ${percent(
-                relativeChange
-              )}.`
-              : relativeChange < -0.001
-                ? `This reform would lower the income of households in the ${decile} decile by an average of ${percent(
-                  -relativeChange
-                )}.`
-                : relativeChange === 0
-                  ?  `This reform would not impact the income of households in the ${decile} decile.`
-                  : (relativeChange > 0 ? "This reform would raise " : "This reform would lower ") +
-                  ` the income of households in the ${decile} decile by less than 0.1%.`;
-          setHoverCard({
-            title: `Decile ${data.points[0].x}`,
-            body: message,
-          });
-        }}
+        onClick={dataHandler}
+        onHover={dataHandler}
         onUnhover={() => {
-          setHoverCard(null);
+          setContent(null);
         }}
       />
     );


### PR DESCRIPTION
Fixes #373 

After long investigation, I had found a way to have Plotly emit pixel coordinates of a data point when it is either clicked or hovered, so I redesigned the custom HoverCard once more, so that Plotly can now not only set the contents but also set the position, fully enabling HoverCard to "snap" to any data point of a plot on any device. 

![RPReplay_Final1690336610](https://github.com/PolicyEngine/policyengine-app/assets/17683171/b9724882-9a2e-4772-a92f-ce6ef94b8a29)

![RPReplay_Final1690336796](https://github.com/PolicyEngine/policyengine-app/assets/17683171/2d1c161e-2bbb-4a3b-bba6-26284ca161bd)

The magic that makes Plotly able to emit pixel coordinates of a data point is from the `xaxis` and `yaxis` objects referenced by any data point object passed to click and hover event handlers. These axis objects contain a function `d2p` which can convert the data's `x` or `y` value to its corresponding top or left pixels respectively, relative to the plot. Together with these axis objects' `_offset` and `_length` fields, Plotly can tell HoverCard the accurate coordinates to "snap" to points.

The HoverCard component has been changed such that it no longer maintains mouse move listeners, since it is now the plots' responsibility to set the coordinates of the hover card. In addition, HoverCard now supports positioning itself by one of its four corners, which is to help it visible on devices with smaller screens and is demonstrated in the above demo.

~~There is a known issue that prevents HoverCard from appearing at desired pixel coordinates in IntraDecileImpact component. Since the bars are stacked horizontally, the left coordinate of any bar which does not stick to the y-axis can not be obtained correctly, because Plotly treat the bars as if they do not stack and simply grow from the y-axis. The current remedy is to ignore the bar's left coordinate and have HoverCard simply appear at either side of the plot based on whether the bar's category is "Gain" or "Lose".~~

HoverCard can now "snap" to the bars rendered by IntraDecileImpact component.

The flexibility and functionality of HoverCard currently should prove that there's no need to fallback to #603, unless the aforementioned issue is unbearable.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 82b6865</samp>

### Summary
🔄🚀🎨

<!--
1.  🔄 - This emoji represents the refactoring of the code to use a shared context and a data handler function, which simplifies the logic and improves the consistency of the hover card functionality across different plots.
2.  🚀 - This emoji represents the improvement of the user experience and the responsiveness of the hover card, which makes it easier to interact with the plots and see the relevant information.
3.  🎨 - This emoji represents the improvement of the code readability and reusability, which makes it easier to maintain and extend the code and the hover card display.
-->
Refactored the hover card functionality for various plots using a shared `HoverCardContext` and a new `dataHandler` function. This improves the code quality, consistency, and flexibility, and enhances the user experience of the hover card display.

> _Sing, O Muse, of the skillful refactorer_
> _Who tamed the complex logic of the `HoverCard`_
> _And made it use a shared and mighty context_
> _To render its content and position with ease._

### Walkthrough
*  Refactored the `HoverCard` component to use `content` and `position` states instead of `visible` and `useEffect` hook ([link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-5d1dc17d97a98d51b4605c651b36fbe67c8119b72f5340a0bb11837501e983edL2-R9), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-5d1dc17d97a98d51b4605c651b36fbe67c8119b72f5340a0bb11837501e983edL16), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-5d1dc17d97a98d51b4605c651b36fbe67c8119b72f5340a0bb11837501e983edL23-R21), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-5d1dc17d97a98d51b4605c651b36fbe67c8119b72f5340a0bb11837501e983edL43-R47), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-5d1dc17d97a98d51b4605c651b36fbe67c8119b72f5340a0bb11837501e983edL71-R85))
*  Changed the `HoverCardContext` to provide `setContent` and `setCoordinates` functions to update the hover card states from the plotly events ([link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-5d1dc17d97a98d51b4605c651b36fbe67c8119b72f5340a0bb11837501e983edL71-R85))
*  Replaced the `setHoverCard` function with the `setContent` and `setCoordinates` functions in the `Plot` components of various output charts ([link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL140-R141), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98L59-R114), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L19-R55), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aL19-R55), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L52-R95), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L96-R138), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8L52-R90), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cL46-R88), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-d50bb4f3433b375516906846f34ac9a1d86d9d361680f9d47cf9cf58f4a44cf5L49-R68), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L29-R103))
*  Added the `dataHandler` function to extract the relevant information from the plotly event data and pass it to the hover card functions, handling different cases of hover or click events ([link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bR190-R243), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL226-R283), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL272-R294), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bR328-R353), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL349-R399), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98L130-R187), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L75-R114), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aL75-R114), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L115-R161), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L151-R196), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8L106-R147), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cL100-R145), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-d50bb4f3433b375516906846f34ac9a1d86d9d361680f9d47cf9cf58f4a44cf5L118-R140), [link](https://github.com/PolicyEngine/policyengine-app/pull/626/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L80-R157))


