### PR TITLE
Add baseline and reform inequality measures when changes are less than 0.1%

### DIFF
--- a/src/api/language.js
+++ b/src/api/language.js
@@ -41,6 +41,13 @@ export function percent(number) {
   );
 }
 
+export function formatPercentageChange(number) {
+  const changePercentage = (number * 100).toFixed(6); 
+  const roundedPercentage = parseFloat(changePercentage);
+  const significantDigits = roundedPercentage.toPrecision(1);
+  return `${significantDigits}%`;
+}
+
 export function cardinal(number) {
   // E.g. 1 -> 'first', 2 -> 'second', 3 -> 'third'
   const suffixes = ["th", "st", "nd", "rd"];

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
-import { percent } from "../../../api/language";
+import { percent, formatPercentageChange } from "../../../api/language";
 import HoverCard, {HoverCardContext} from "../../../layout/HoverCard";
 import useMobile from "../../../layout/Responsive";
 import DownloadableScreenshottable from "./DownloadableScreenshottable";
@@ -39,12 +39,9 @@ export default function InequalityImpact(props) {
                 value < 0 ? style.colors.DARK_GREEN : style.colors.DARK_GRAY
               ),
             },
-            text: metricChanges.map(
-              (value) =>
-                (value >= 0 ? "+" : "") +
-                (value * 100).toFixed(1).toString() +
-                "%"
-            ),
+            text: metricChanges.map((value) => {
+              return formatPercentageChange(value);
+            }),
             textangle: 0,
             hoverinfo: "none",
           },
@@ -58,7 +55,7 @@ export default function InequalityImpact(props) {
             tickformat: ",.1%",
           },
           uniformtext: {
-            mode: "hide",
+            mode: "show",
             minsize: 12,
           },
           ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect } from 'react';
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
-import { percent } from "../../../api/language";
+import { percent, formatPercentageChange } from "../../../api/language";
 import HoverCard, {HoverCardContext} from "../../../layout/HoverCard";
 import useMobile from "../../../layout/Responsive";
 import DownloadableScreenshottable from "./DownloadableScreenshottable";
@@ -61,12 +61,9 @@ export default function PovertyImpact(props) {
                 value < 0 ? style.colors.DARK_GREEN : style.colors.DARK_GRAY
               ),
             },
-            text: povertyChanges.map(
-              (value) =>
-                (value >= 0 ? "+" : "") +
-                (value * 100).toFixed(1).toString() +
-                "%"
-            ),
+            text: povertyChanges.map((value) => {
+              return formatPercentageChange(value);
+            }),
             textangle: 0,
             hoverinfo: "none",
           },
@@ -134,7 +131,7 @@ export default function PovertyImpact(props) {
     );
   }
 
-  const povertyRateChange = percent(Math.abs(totalPovertyChange));
+  const povertyRateChange = formatPercentageChange(Math.abs(totalPovertyChange));
   const percentagePointChange =
     Math.round(
       Math.abs(


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eb8ff18</samp>

### Summary
📊🌟♻️

<!--
1.  📊 This emoji represents the addition of a new function for formatting percentage changes and its use in the plots. It conveys the idea of data visualization and analysis.
2.  🌟 This emoji represents the improvement of the formatting and visibility of the text labels in the inequality impact plot. It conveys the idea of enhancement and quality.
3.  ♻️ This emoji represents the refactoring of the formatting of percentage changes in the poverty impact component. It conveys the idea of code optimization and reuse.
-->
This pull request adds a new function `formatPercentageChange` to the `language.js` module and uses it to improve the consistency and readability of the percentage changes in the inequality and poverty impact plots. It also adjusts the text size and mode in the inequality impact plot.

> _Sing, O Muse, of the skillful coder who devised_
> _A cunning function `formatPercentageChange` to show_
> _The shifting fortunes of the poor and rich, and how_
> _He beautified the plots with labels clear and wise._

### Walkthrough
*  Add a new function `formatPercentageChange` to format percentage changes with a sign and one significant digit ([link](https://github.com/PolicyEngine/policyengine-app/pull/632/files?diff=unified&w=0#diff-77a1d7924c7e86c45476b6d602f1891a692c24c0f5d85a55f3b7df008d6803b3R44-R50))
* Use the new function to format the text labels for the bars in the inequality and poverty impact plots ([link](https://github.com/PolicyEngine/policyengine-app/pull/632/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L42-R44), [link](https://github.com/PolicyEngine/policyengine-app/pull/632/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L64-R66))
* Use the new function to format the poverty rate change in the summary card below the poverty impact plot ([link](https://github.com/PolicyEngine/policyengine-app/pull/632/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L137-R134))
* Import the new function from the `language.js` module in the `InequalityImpact.jsx` and `PovertyImpact.jsx` components ([link](https://github.com/PolicyEngine/policyengine-app/pull/632/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L4-R4), [link](https://github.com/PolicyEngine/policyengine-app/pull/632/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L4-R4))
* Change the `uniformtext` mode from `hide` to `show` in the inequality impact plot to ensure the text labels are always visible ([link](https://github.com/PolicyEngine/policyengine-app/pull/632/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L61-R58))


