### PR TITLE
Make you are here on household charts a point instead of line

### DIFF
--- a/src/__tests__/BaselineAndReformChart.test.js
+++ b/src/__tests__/BaselineAndReformChart.test.js
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import BaselineAndReformChart from "pages/household/output/EarningsVariation/BaselineAndReformChart";
+import {
+    formatVariableValue,
+    getValueFromHousehold,
+  } from "api/variables.js";
+
+jest.mock("react-plotly.js", () => jest.fn());
+jest.mock("../api/variables.js", () => ({
+    getValueFromHousehold: jest.fn(),
+    getPlotlyAxisFormat: jest.fn()
+}));
+
+const metadata = {
+    variables: {
+        employment_income: {
+            unit: "currency-USD"
+        },
+        household_net_income: {
+            unit: "currency-USD"
+        },
+        "abc": {
+            unit: "currency-USD"
+        },
+    }
+};
+
+describe("Test Render Output", () => {
+    test("Should render toggle", () => {
+        getValueFromHousehold.mockImplementation(() => {
+            const testResult = [1,2,3];
+            return testResult;
+        });
+        render(
+            <BaselineAndReformChart metadata={metadata} variable={"abc"} />
+        )
+
+        fireEvent.click(screen.getByRole('radio', { name: /difference/i }));
+
+        const diffButton = screen.getByRole('radio', { name: /difference/i });
+
+        expect(diffButton).toHaveProperty("checked", true);
+    });
+
+    //TODO: Add tests for actual plot components BaselineAndReformTogetherPlot & BaselineReformDeltaPlot
+});

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -145,6 +145,7 @@ function BaselineAndReformTogetherPlot(props) {
     variableLabel,
     metadata,
     variable,
+    baselineValue
   } = props;
   let data = [
     ...(variable === "household_net_income"
@@ -174,15 +175,27 @@ function BaselineAndReformTogetherPlot(props) {
       hoverinfo: "none",
     },
     {
-      x: [currentEarnings, currentEarnings],
-      y: [0, currentValue],
-      type: "line",
-      name: `Your current ${variableLabel}`,
+      x: [currentEarnings],
+      y: [currentValue],
+      type: "scatter",
+      mode: "markers",
+      name: `Your reform ${variableLabel}`,
+      line: {
+        color: style.colors.BLUE,
+      },
+      hoverinfo: "none",
+    },
+    {
+      x: [currentEarnings],
+      y: [baselineValue],
+      type: "scatter",
+      mode: "markers",
+      name: `Your baseline ${variableLabel}`,
       line: {
         color: style.colors.MEDIUM_DARK_GRAY,
       },
       hoverinfo: "none",
-    },
+    }
   ];
   const plotObject = (
     <Plot
@@ -229,7 +242,7 @@ function BaselineAndReformTogetherPlot(props) {
             metadata.currency,
             data.points[0].x
           );
-          const message = `If you earn ${employmentIncome}, your reform ${variableLabel} will be ${variableLabelAmount}.`;
+          const message = `If you earn ${employmentIncome}, your ${data.points[0].data.name.toLocaleLowerCase().includes("reform") ? "reform" : "baseline"} ${variableLabel} will be ${variableLabelAmount}.`;
           setHoverCard({
             title: data.points[0].data.name,
             body: message,

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -301,12 +301,12 @@ function BaselineReformDeltaPlot(props) {
       hoverinfo: "none",
     },
     {
-      x: [currentEarnings, currentEarnings],
-      y: [0, currentValue - baselineValue],
-      type: "line",
+      x: [currentEarnings],
+      y: [currentValue - baselineValue],
+      type: "scatter",
       name: `Your current change in ${variableLabel}`,
       line: {
-        color: style.colors.MEDIUM_DARK_GRAY,
+        color: style.colors.BLUE,
       },
       hoverinfo: "none",
     },

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -304,6 +304,7 @@ function BaselineReformDeltaPlot(props) {
       x: [currentEarnings],
       y: [currentValue - baselineValue],
       type: "scatter",
+      mode: "markers",
       name: `Your current change in ${variableLabel}`,
       line: {
         color: style.colors.BLUE,

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -75,12 +75,13 @@ export default function BaselineOnlyChart(props) {
               hoverinfo: "none",
             },
             {
-              x: [currentEarnings, currentEarnings],
-              y: [0, currentNetIncome],
+              x: [currentEarnings],
+              y: [currentNetIncome],
               type: "line",
+              mode: "markers",
               name: `Your current ${variableLabel}`,
               line: {
-                color: style.colors.MEDIUM_DARK_GRAY,
+                color: style.colors.BLUE,
               },
               hoverinfo: "none",
             },


### PR DESCRIPTION
Fixes #611
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e7e3b65</samp>

### Summary
🧪📊🛠️

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the addition of a new test file or a test case.
2. 📊 - This emoji represents charts, graphs, or data visualization, and can be used to indicate the update of the BaselineAndReformChart component and its children to improve the plot appearance and functionality.
3. 🛠️ - This emoji represents tools, fixing, or construction, and can be used to indicate the modification of the hover card message or the prop for the baseline value.
-->
This pull request enhances the BaselineAndReformChart component, which shows the impact of policy reforms on a household's income. It adds a baseline prop, switches to scatter traces, and updates the hover card. It also adds a test file for the component, which checks the toggle button.

> _`BaselineAndReformChart` shows us the fate_
> _Of the households under different policies_
> _We mock the api and the plotly trace_
> _To test the toggle and the hover messages_

### Walkthrough
*  Add a new prop `baselineValue` to `BaselineAndReformTogetherPlot` component to show the baseline value on the chart ([link](https://github.com/PolicyEngine/policyengine-app/pull/652/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bR148))
*  Replace line traces with scatter traces for the current and baseline values of the variable in `BaselineAndReformTogetherPlot` component to improve the plot appearance and clarity ([link](https://github.com/PolicyEngine/policyengine-app/pull/652/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL177-R198))
*  Adjust the hover card message for the points on `BaselineAndReformTogetherPlot` component to indicate whether they belong to the reform or the baseline scenario ([link](https://github.com/PolicyEngine/policyengine-app/pull/652/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL232-R245))
*  Replace line trace with scatter trace for the change in the variable value in `BaselineReformDeltaPlot` component to improve the plot appearance and clarity ([link](https://github.com/PolicyEngine/policyengine-app/pull/652/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL291-R309))
*  Add a test file `BaselineAndReformChart.test.js` for the `BaselineAndReformChart` component, which checks the toggle button functionality using a mock metadata object and api functions ([link](https://github.com/PolicyEngine/policyengine-app/pull/652/files?diff=unified&w=0#diff-ea82f6e985b4405746178eb385dfa12dba2ec298d08ea4e73718a83dc0f5eee3L1-R45))



Changed the baseline and reform comparison charts to have separate points for baseline and reform based on current variable value.

They appear in the legend by default so I left them in for now but can take out if not needed.

![baseline-reform](https://github.com/PolicyEngine/policyengine-app/assets/49796873/f7d31c37-4efc-4ae7-a930-12834bf563c8)
![delta](https://github.com/PolicyEngine/policyengine-app/assets/49796873/568f17bd-b083-46fc-ba2b-18d1ddb31a0d)

Also added test cases.
