### PR TITLE
Update New Mexico blog post household links

### DIFF
--- a/src/posts/new-mexico-income-tax-launch.md
+++ b/src/posts/new-mexico-income-tax-launch.md
@@ -26,15 +26,15 @@ PolicyEngine now models these rules from 2021 to 2023 (as available).
 
 ## Example household
 
-To illustrate the New Mexico income tax, consider a single parent with two children, paying $1,000 per month in rent and $500 per month in childcare. If they earn $30,000, they will pay no state income tax and [receive $2,127 from four refundable tax credits](https://policyengine.org/us/household?focus=householdOutput.netIncome&household=33012).
+To illustrate the New Mexico income tax, consider a single parent with two children, paying $1,000 per month in rent and $500 per month in childcare. If they earn $30,000, they will pay no state income tax and [receive $2,127 from four refundable tax credits](https://policyengine.org/us/household?focus=householdOutput.netIncome&household=33113).
 
 ![](https://cdn-images-1.medium.com/max/2948/0*GfIZU3Qdmhw82mfM)
 
-This filer would have negative [net state tax liability](https://policyengine.org/us/household?focus=householdOutput.earnings&household=33012) if they earn $50,000 or less.
+This filer would have negative [net state tax liability](https://policyengine.org/us/household?focus=householdOutput.earnings&household=33113) if they earn $50,000 or less.
 
 ![](https://cdn-images-1.medium.com/max/3104/0*l58k4e3xc5HUKbBZ)
 
-To show the effect of the state’s income taxes on marginal tax rates, we can abolish New Mexico income taxes (separately as before refundable credits and refundable credits) and swap the baseline and reform. From there, view the [marginal tax rate chart](https://policyengine.org/us/household?focus=householdOutput.mtr&household=33012&region=us&timePeriod=2023&baseline=22176&reform=2) and select *Difference*.
+To show the effect of the state’s income taxes on marginal tax rates, we can abolish New Mexico income taxes (separately as before refundable credits and refundable credits) and swap the baseline and reform. From there, view the [marginal tax rate chart](https://policyengine.org/us/household?focus=householdOutput.mtr&household=33113&region=us&timePeriod=2023&baseline=22176&reform=2) and select *Difference*.
 
 ![](https://cdn-images-1.medium.com/max/3076/0*wC8StujJOgS34Kj4)
 


### PR DESCRIPTION
Fixes #655

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ec0d46e</samp>

### Summary
🆔🔗🧮

<!--
1.  🆔 - This emoji can represent the concept of an ID or identification, which is relevant to the change of the household ID in the PolicyEngine links. It can also suggest that the change is related to a specific or unique household scenario.
2.  🔗 - This emoji can represent the concept of a link or a connection, which is relevant to the change of the PolicyEngine links that point to the household scenario. It can also suggest that the change is related to the web-based nature of the PolicyEngine app and the blog article.
3.  🧮 - This emoji can represent the concept of a calculator or a computation, which is relevant to the change of the PolicyEngine links that show the accurate results of the New Mexico income tax policy. It can also suggest that the change is related to the numerical or analytical aspect of the PolicyEngine app and the blog article.
-->
Updated the household ID in the PolicyEngine links in `src/posts/new-mexico-income-tax-launch.md` to match the latest version of the app. This ensures that the links show the correct policy effects for the New Mexico income tax system.

> _`PolicyEngine` links_
> _Updated with new household ID_
> _Autumn of changes_

### Walkthrough
*  Update household ID in PolicyEngine links to match latest app version ([link](https://github.com/PolicyEngine/policyengine-app/pull/657/files?diff=unified&w=0#diff-31f4219057a46725b1ee159ab74aab21bedf0f471348efdbe80172e45ce7ae60L29-R37)). This ensures that the links show the correct household scenario and income tax results for New Mexico.


