### PR TITLE
Add Federal to Tax revenues when budgetary impacts are split out 

### DIFF
--- a/src/api/language.js
+++ b/src/api/language.js
@@ -41,6 +41,13 @@ export function percent(number) {
   );
 }
 
+export function formatPercentageChange(number) {
+  const changePercentage = (number * 100).toFixed(6); 
+  const roundedPercentage = parseFloat(changePercentage);
+  const significantDigits = roundedPercentage.toPrecision(1);
+  return `${significantDigits}%`;
+}
+
 export function cardinal(number) {
   // E.g. 1 -> 'first', 2 -> 'second', 3 -> 'third'
   const suffixes = ["th", "st", "nd", "rd"];

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -29,7 +29,7 @@ export default function BudgetaryImpact(props) {
     "Net impact",
   ];
   let mobileLabels = ["Federal taxes", "State taxes", "Benefits", "Net"];
-  if (region !== "us" && region !== "ca") {
+  if (region == "us" || region == "ca") {
     desktopLabels[0] = "Tax revenues";
     mobileLabels[0] = "Taxes";
   }

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
-import { percent } from "../../../api/language";
+import { percent, formatPercentageChange } from "../../../api/language";
 import HoverCard, {HoverCardContext} from "../../../layout/HoverCard";
 import useMobile from "../../../layout/Responsive";
 import DownloadableScreenshottable from "./DownloadableScreenshottable";
@@ -39,12 +39,9 @@ export default function InequalityImpact(props) {
                 value < 0 ? style.colors.DARK_GREEN : style.colors.DARK_GRAY
               ),
             },
-            text: metricChanges.map(
-              (value) =>
-                (value >= 0 ? "+" : "") +
-                (value * 100).toFixed(1).toString() +
-                "%"
-            ),
+            text: metricChanges.map((value) => {
+              return formatPercentageChange(value);
+            }),
             textangle: 0,
             hoverinfo: "none",
           },
@@ -58,7 +55,7 @@ export default function InequalityImpact(props) {
             tickformat: ",.1%",
           },
           uniformtext: {
-            mode: "hide",
+            mode: "show",
             minsize: 12,
           },
           ...ChartLogo(mobile ? 0.97 : 0.97, mobile ? -0.25 : -0.15),

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect } from 'react';
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
-import { percent } from "../../../api/language";
+import { percent, formatPercentageChange } from "../../../api/language";
 import HoverCard, {HoverCardContext} from "../../../layout/HoverCard";
 import useMobile from "../../../layout/Responsive";
 import DownloadableScreenshottable from "./DownloadableScreenshottable";
@@ -61,12 +61,9 @@ export default function PovertyImpact(props) {
                 value < 0 ? style.colors.DARK_GREEN : style.colors.DARK_GRAY
               ),
             },
-            text: povertyChanges.map(
-              (value) =>
-                (value >= 0 ? "+" : "") +
-                (value * 100).toFixed(1).toString() +
-                "%"
-            ),
+            text: povertyChanges.map((value) => {
+              return formatPercentageChange(value);
+            }),
             textangle: 0,
             hoverinfo: "none",
           },
@@ -134,7 +131,7 @@ export default function PovertyImpact(props) {
     );
   }
 
-  const povertyRateChange = percent(Math.abs(totalPovertyChange));
+  const povertyRateChange = formatPercentageChange(Math.abs(totalPovertyChange));
   const percentagePointChange =
     Math.round(
       Math.abs(


### PR DESCRIPTION
Fixes #667 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9e280ca</samp>

### Summary
:sparkles::bug::art:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or functionality, such as the `formatPercentageChange` function. It can also be used to indicate improvements or enhancements to existing features.
2. :bug: This emoji represents the fixing of a bug or an error, such as the logical error in the `BudgetaryImpact` component. It can also be used to indicate the resolution of an issue or a problem.
3. :art: This emoji represents the improvement of the format, layout, or design of the code or the user interface, such as the changes to the `InequalityImpact` and `PovertyImpact` components. It can also be used to indicate the refactoring or cleaning of the code.
-->
This pull request introduces a new function `formatPercentageChange` to standardize the formatting of percentage changes in various charts and components. It also updates the `InequalityImpact`, `PovertyImpact`, and `BudgetaryImpact` components to use the new function and fix some layout and logical errors.

> _Sing, O Muse, of the skillful coder who devised_
> _A cunning function `formatPercentageChange` to adorn_
> _The charts and texts with signs and digits well arranged_
> _And make the app more pleasing to the eye and mind._

### Walkthrough
*  Add a new function `formatPercentageChange` to standardize the formatting of percentage changes across the app ([link](https://github.com/PolicyEngine/policyengine-app/pull/672/files?diff=unified&w=0#diff-77a1d7924c7e86c45476b6d602f1891a692c24c0f5d85a55f3b7df008d6803b3R44-R50))
*  Fix a logical error in the `BudgetaryImpact` component to match the region with the correct tax revenue labels ([link](https://github.com/PolicyEngine/policyengine-app/pull/672/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L32-R32))
*  Use the new function `formatPercentageChange` to format the percentage changes in the `InequalityImpact` and `PovertyImpact` components ([link](https://github.com/PolicyEngine/policyengine-app/pull/672/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L4-R4), [link](https://github.com/PolicyEngine/policyengine-app/pull/672/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L42-R44), [link](https://github.com/PolicyEngine/policyengine-app/pull/672/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L4-R4), [link](https://github.com/PolicyEngine/policyengine-app/pull/672/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L64-R66), [link](https://github.com/PolicyEngine/policyengine-app/pull/672/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L137-R134))
*  Change the `uniformtext` mode to `show` in the `InequalityImpact` component to improve the readability of the text annotations in the chart ([link](https://github.com/PolicyEngine/policyengine-app/pull/672/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L61-R58))


