### PR TITLE
Add Federal to Tax revenues when budgetary impacts are split out

### DIFF
--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -29,7 +29,14 @@ export default function BudgetaryImpact(props) {
     "Net impact",
   ];
   let mobileLabels = ["Federal taxes", "State taxes", "Benefits", "Net"];
-  if (region == "us" || region == "ca") {
+  let usInitials = [
+    "al", "ak", "az", "ar", "ca", "co", "ct", "de", "fl", "ga", "hi", "id", "il",
+    "in", "ia", "ks", "ky", "la", "me", "md", "ma", "mi", "mn", "ms", "mo", "mt",
+    "ne", "nv", "nh", "nj", "nm", "ny", "nc", "nd", "oh", "ok", "or", "pa", "ri",
+    "sc", "sd", "tn", "tx", "ut", "vt", "va", "wa", "wv", "wi", "wy", "dc","us"
+  ];
+  
+  if (!(usInitials.includes(region))){
     desktopLabels[0] = "Tax revenues";
     mobileLabels[0] = "Taxes";
   }

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -29,7 +29,7 @@ export default function BudgetaryImpact(props) {
     "Net impact",
   ];
   let mobileLabels = ["Federal taxes", "State taxes", "Benefits", "Net"];
-  if (!window.location.pathname.includes("/us/")){
+  if (!window.location.pathname.includes("/us/")) {
     desktopLabels[0] = "Tax revenues";
     mobileLabels[0] = "Taxes";
   }

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -29,7 +29,7 @@ export default function BudgetaryImpact(props) {
     "Net impact",
   ];
   let mobileLabels = ["Federal taxes", "State taxes", "Benefits", "Net"];
-  if (region !== "us" && region !== "ca") {
+  if (region == "us" || region == "ca") {
     desktopLabels[0] = "Tax revenues";
     mobileLabels[0] = "Taxes";
   }

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -29,14 +29,7 @@ export default function BudgetaryImpact(props) {
     "Net impact",
   ];
   let mobileLabels = ["Federal taxes", "State taxes", "Benefits", "Net"];
-  let usInitials = [
-    "al", "ak", "az", "ar", "ca", "co", "ct", "de", "fl", "ga", "hi", "id", "il",
-    "in", "ia", "ks", "ky", "la", "me", "md", "ma", "mi", "mn", "ms", "mo", "mt",
-    "ne", "nv", "nh", "nj", "nm", "ny", "nc", "nd", "oh", "ok", "or", "pa", "ri",
-    "sc", "sd", "tn", "tx", "ut", "vt", "va", "wa", "wv", "wi", "wy", "dc","us"
-  ];
-  
-  if (!(usInitials.includes(region))){
+  if (!window.location.pathname.includes("/us/")){
     desktopLabels[0] = "Tax revenues";
     mobileLabels[0] = "Taxes";
   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c46b641</samp>

### Summary
🐛🌐🛠️

<!--
1.  🐛 - This emoji represents a bug fix, since the original condition was incorrect and caused unexpected behavior for non-US and non-Canada regions. Using this emoji can help convey that the change was not a new feature or enhancement, but a correction of an existing problem.
2.  🌐 - This emoji represents internationalization, since the change affects how the app displays tax information for different regions. Using this emoji can help convey that the change was related to supporting multiple languages and locales, and not to other aspects of the app's functionality or design.
3.  🛠️ - This emoji represents a tool or a fix, since the change involves modifying the logic of a function that generates the labels for the tax columns. Using this emoji can help convey that the change was a technical or code-related improvement, and not a user-facing or aesthetic one.
-->
Fix tax column labels for non-US/Canada regions in `BudgetaryImpact.jsx`. This improves the app's internationalization and consistency.

> _`tax` labels change_
> _only for US and Canada_
> _autumn leaves fall_

### Walkthrough
* Fix the logic for changing the tax column labels based on the region ([link](https://github.com/PolicyEngine/policyengine-app/pull/678/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L32-R32))


