### PR TITLE
chore: enable recommended ESLint plugin rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,40 +2,49 @@
   "env": {
     "browser": true,
     "node": true,
-    "es2021": true,
-    "jest/globals": true
+    "es2021": true
   },
   "extends": [
     "eslint:recommended",
-    "plugin:react/recommended"
-    //"plugin:prettier/recommended"
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:jsx-a11y/recommended",
+    "plugin:prettier/recommended"
   ],
-  "globals": {
-    "process": true
-  },
   "overrides": [
     {
-      "files": ["test/**"],
-      "plugins": ["jest"],
+      "files": ["**/*test.js"],
       "extends": [
         "eslint:recommended",
-        "plugin:jest/recommended"
-        //"plugin:prettier/recommended"
+        "plugin:jest/recommended",
+        "plugin:prettier/recommended"
       ],
-      "rules": { "jest/prefer-expect-assertions": "off" }
+      "rules": { "jest/prefer-expect-assertions": "off" },
+      "env": {
+        "jest": true
+      }
     }
   ],
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react", "react-hooks", "jest", "jsx-a11y"],
   "rules": {
     // suppress errors for missing 'import React' in files
     "react/react-in-jsx-scope": "off",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    // suppress currently failing recommended rules
+    "jsx-a11y/alt-text": "off",
+    "jsx-a11y/anchor-is-valid": "off",
+    "jsx-a11y/click-events-have-key-events": "off",
+    "jsx-a11y/iframe-has-title": "off",
+    "jsx-a11y/mouse-events-have-key-events": "off",
+    "jsx-a11y/no-autofocus": "off",
+    "jsx-a11y/no-noninteractive-element-interactions": "off",
+    "jsx-a11y/no-static-element-interactions": "off",
+    "react-hooks/exhaustive-deps": "off",
+    "react-hooks/rules-of-hooks": "off"
   },
-  "ignorePatterns": ["**/*.css", "**/*.scss"],
   "settings": {
     "react": {
       "pragma": "React", // Pragma to use, default to "React"

--- a/package.json
+++ b/package.json
@@ -61,12 +61,6 @@
     "fix": "eslint --fix --ext js,jsx . && prettier -w .",
     "lint": "eslint --ext js,jsx . && prettier -c ."
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/__tests__/Buttons.test.js
+++ b/src/__tests__/Buttons.test.js
@@ -12,7 +12,7 @@ jest.mock("react-router-dom", () => ({
 }));
 
 describe("Test button types", () => {
-  test("Test that Button renders and fires onClick properly", () => {
+  test("that Button renders and fires onClick properly", () => {
     const mockOnClick = jest.fn();
 
     const testButton = <Button text="Test Button" onClick={mockOnClick()} />;
@@ -22,7 +22,7 @@ describe("Test button types", () => {
     fireEvent.click(getByText("Test Button"));
     expect(mockOnClick).toHaveBeenCalledTimes(1);
   });
-  test("Test that LinkButton renders properly and properly navigates to internal link", () => {
+  test("that LinkButton renders properly and properly navigates to internal link", () => {
     const testButton = <LinkButton text="Test Button" link="/test" />;
 
     const { getByText } = render(testButton);

--- a/src/__tests__/Dialogs.test.js
+++ b/src/__tests__/Dialogs.test.js
@@ -18,7 +18,7 @@ jest.mock("react-router-dom", () => {
 });
 
 describe("Test cookie consent pop-up", () => {
-  test("Test that pop-up appears without cookie existing", async () => {
+  test("that pop-up appears without cookie existing", async () => {
     // Launch CookieConsent
     const { getByText } = render(<CookieConsent />);
 
@@ -31,7 +31,7 @@ describe("Test cookie consent pop-up", () => {
     });
   });
 
-  test("Test that pop-up does not appear if cookies have been accepted", async () => {
+  test("that pop-up does not appear if cookies have been accepted", async () => {
     // Mock cookie that matches desired
     Object.defineProperty(window.document, "cookie", {
       configurable: true,
@@ -56,7 +56,7 @@ describe("Test cookie consent pop-up", () => {
   });
 });
 describe("Test PoliciesModelledPopup", () => {
-  test("Test that pop-up appears after beginning calculations", () => {
+  test("that pop-up appears after beginning calculations", () => {
     const testProps = {
       policy: {
         reform: {


### PR DESCRIPTION
Turn on the recommended set of rules for the current plugins and turn off the currently failing rules. The rules should be enabled/fixed later.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b950006</samp>

### Summary
:wrench::sparkles::recycle:

<!--
1.  :wrench: - This emoji represents a tool or configuration change, which is appropriate for modifying the `package.json` and `.eslintrc.json` files.
2.  :sparkles: - This emoji represents a new feature or improvement, which is appropriate for enhancing the linting of React and accessibility code, and fixing some issues with the Jest plugin and test files.
3.  :recycle: - This emoji represents a refactor or code improvement, which is appropriate for reducing duplication and enabling gradual code quality improvement.
-->
This pull request improves the linting configuration for the project by updating the `.eslintrc.json` file and removing the `eslintConfig` property from the `package.json` file. These changes enhance the code quality, accessibility, and testing of the React app.

> _To make our code linting more pleasant_
> _We removed `eslintConfig` from `package.json`_
> _And updated `.eslintrc.json` with care_
> _To fix some issues and make rules more fair_
> _Now our code quality is more consistent_

### Walkthrough
*  Configure ESLint for React, React Hooks, and accessibility rules ([link](https://github.com/PolicyEngine/policyengine-app/pull/681/files?diff=unified&w=0#diff-6884918dc8291219be508e05e28965b958c734def85324f3b53858ea4702090fL5-R16))
*  Move Jest plugin settings to test file overrides ([link](https://github.com/PolicyEngine/policyengine-app/pull/681/files?diff=unified&w=0#diff-6884918dc8291219be508e05e28965b958c734def85324f3b53858ea4702090fL25-R25), [link](https://github.com/PolicyEngine/policyengine-app/pull/681/files?diff=unified&w=0#diff-6884918dc8291219be508e05e28965b958c734def85324f3b53858ea4702090fL5-R16))
*  Simplify plugin loading and disable some recommended rules ([link](https://github.com/PolicyEngine/policyengine-app/pull/681/files?diff=unified&w=0#diff-6884918dc8291219be508e05e28965b958c734def85324f3b53858ea4702090fL32-R45))
*  Remove redundant `eslintConfig` property from `package.json` ([link](https://github.com/PolicyEngine/policyengine-app/pull/681/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L58-L63))


