### PR TITLE
Fix input field bug

### DIFF
--- a/src/controls/InputField.jsx
+++ b/src/controls/InputField.jsx
@@ -1,12 +1,20 @@
 import { motion } from "framer-motion";
 import useMobile from "../layout/Responsive";
 import style from "../style";
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 export default function InputField(props) {
-  const { onChange, padding, width, type, inputmode, pattern, value } = props;
+  const {
+    onChange,
+    padding,
+    width,
+    type,
+    inputmode,
+    pattern,
+    value,
+    placeholder,
+  } = props;
   const [inputValue, setInputValue] = useState(value ? value : "");
-  const placeholder = useRef(props.placeholder);
   const mobile = useMobile();
   const re = /^[0-9\b]*[.]?[0-9\b]*?$/;
   const onInput = (e) => {
@@ -68,7 +76,7 @@ export default function InputField(props) {
         setInputValue(e.target.value);
       }}
       value={inputValue}
-      placeholder={placeholder.current}
+      placeholder={placeholder}
     />
   );
 }

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -138,7 +138,7 @@ export default function ParameterEditor(props) {
     <CenteredMiddleColumn
       marginTop="5%"
       marginBottom={0}
-      title={capitalize(parameter.label)}
+      title={capitalize(parameter.label.toLowerCase())}
       description={description + timePeriodSentence}
     >
       {editControl}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at efae240</samp>

### Summary
🧹📝🛠️

<!--
1.  🧹 - This emoji can be used to indicate that some code was cleaned up or simplified, as in the case of the `InputField` component.
2.  📝 - This emoji can be used to indicate that some text or labels were edited or modified, as in the case of the `capitalize` function being applied to the `parameter.label.toLowerCase()`.
3.  🛠️ - This emoji can be used to indicate that some functionality or logic was fixed or improved, as in the case of the capitalization being more consistent and reliable.
-->
Improved the appearance and functionality of the input fields for policy parameters. Simplified the `InputField` component code and fixed the capitalization of the input field titles in `ParameterEditor`.

> _We are the masters of the input fields_
> _We shape the labels with the `capitalize` skill_
> _We purge the code of the unused and the weak_
> _We pass the `placeholder` with a metal will_

### Walkthrough
*  Simplify and fix the `placeholder` prop handling in the `InputField` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/699/files?diff=unified&w=0#diff-10323c70aaa8c36a4d474a2c79df4d291dc1a09fbf1e17b0c4ddae37404abd29L4-R17), [link](https://github.com/PolicyEngine/policyengine-app/pull/699/files?diff=unified&w=0#diff-10323c70aaa8c36a4d474a2c79df4d291dc1a09fbf1e17b0c4ddae37404abd29L71-R79))
* Apply the `capitalize` function to the lowercased `parameter.label` in the `ParameterEditor` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/699/files?diff=unified&w=0#diff-9b745098fe616d3b484439547f6eed36ad068dab9723978c85b41095a0a0c92aL141-R141))



Fixes #695 