### PR TITLE
Editing one policy parameter affects other displayed parameters

### DIFF
--- a/src/__tests__/InputField.test.js
+++ b/src/__tests__/InputField.test.js
@@ -1,10 +1,19 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import InputField from "../controls/InputField";
+import { useSearchParams } from "react-router-dom";
 
 const testProps = {
   placeholder: "Test Placeholder",
   onChange: jest.fn(),
 };
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useSearchParams: jest.fn(),
+  };
+});
 const patternProp = { pattern: "%" };
 const testInput = "Test Input";
 
@@ -18,22 +27,32 @@ const setup = (props) => {
   };
 };
 
-test("Should handle non-percent input & submit on blur", () => {
-  const { input } = setup(testProps);
-  fireEvent.change(input, { target: { value: testInput } });
-  expect(input.value).toBe(testInput);
-  expect(testProps.onChange).not.toHaveBeenCalled();
+describe("Should take inputs", () => {
+  test("Should handle non-percent input & submit on blur", () => {
+    useSearchParams.mockImplementation(() => {
+      const get = () => "gov.irs.ald.loss.capital.max.HEAD_OF_HOUSEHOLD";
+      return [{ get }];
+    });
+    const { input } = setup(testProps);
+    fireEvent.change(input, { target: { value: testInput } });
+    expect(input.value).toBe(testInput);
+    expect(testProps.onChange).not.toHaveBeenCalled();
 
-  fireEvent.blur(input);
-  expect(testProps.onChange).toHaveBeenCalledWith(testInput);
-});
+    fireEvent.blur(input);
+    expect(testProps.onChange).toHaveBeenCalledWith(testInput);
+  });
 
-test("Should append '%' for percent pattern & submit on blur", () => {
-  const { input } = setup({ ...testProps, ...patternProp });
-  fireEvent.change(input, { target: { value: testInput } });
-  expect(input.value).toBe(testInput + "%");
-  expect(testProps.onChange).not.toHaveBeenCalled();
+  test("Should append '%' for percent pattern & submit on blur", () => {
+    useSearchParams.mockImplementation(() => {
+      const get = () => "gov.irs.ald.loss.capital.max.HEAD_OF_HOUSEHOLD";
+      return [{ get }];
+    });
+    const { input } = setup({ ...testProps, ...patternProp });
+    fireEvent.change(input, { target: { value: testInput } });
+    expect(input.value).toBe(testInput + "%");
+    expect(testProps.onChange).not.toHaveBeenCalled();
 
-  fireEvent.blur(input);
-  expect(testProps.onChange).toHaveBeenCalledWith(testInput + "%");
+    fireEvent.blur(input);
+    expect(testProps.onChange).toHaveBeenCalledWith(testInput + "%");
+  });
 });

--- a/src/controls/InputField.jsx
+++ b/src/controls/InputField.jsx
@@ -1,7 +1,8 @@
 import { motion } from "framer-motion";
 import useMobile from "../layout/Responsive";
 import style from "../style";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
 
 export default function InputField(props) {
   const {
@@ -14,7 +15,11 @@ export default function InputField(props) {
     value,
     placeholder,
   } = props;
+  //Saving placeholder as a state variable so it doesn't change if user types a value and deletes it
+  const [savedPlaceholder, setPlaceholder] = useState(placeholder);
   const [inputValue, setInputValue] = useState(value ? value : "");
+  const [searchParams] = useSearchParams();
+  const focus = searchParams.get("focus") || "";
   const mobile = useMobile();
   const re = /^[0-9\b]*[.]?[0-9\b]*?$/;
   const onInput = (e) => {
@@ -23,6 +28,13 @@ export default function InputField(props) {
       onChange(value);
     }
   };
+  //clears input field and resets placeholder if focus changes for use case of editing policy parameter
+  useEffect(() => {
+    if (!value) {
+      setInputValue("");
+      setPlaceholder(props.placeholder);
+    }
+  }, [focus]);
   return (
     <motion.input
       // On iOS, should show a keyboard with a blue "Go" button
@@ -76,7 +88,7 @@ export default function InputField(props) {
         setInputValue(e.target.value);
       }}
       value={inputValue}
-      placeholder={placeholder}
+      placeholder={savedPlaceholder}
     />
   );
 }


### PR DESCRIPTION
Fix [695](https://github.com/PolicyEngine/policyengine-app/issues/695)

Update input field to use useEffect to clear the input field when focus changes & keep placeholder in state so that it does not change when user deletes their entry.


https://github.com/PolicyEngine/policyengine-app/assets/49796873/8a3c9909-3ee1-432e-8221-633d1dd0e188

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1e5792e</samp>

### Summary
🧪🔎🔄

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the update of the tests for the `InputField` component.
2.  🔎 - This emoji represents magnifying, searching, or zooming, and can be used to indicate the use of the `useSearchParams` hook to control the focus of the input field based on the URL query parameters.
3.  🔄 - This emoji represents refreshing, reloading, or repeating, and can be used to indicate the enhancement of the `InputField` component to clear the input and reset the placeholder when the user changes the focus of the policy parameter to edit.
-->
This pull request improves the user experience and testing of the `InputField` component, which allows users to edit policy parameters. It uses the `useSearchParams` hook to control the focus and clear the input based on the URL query, and updates the tests to mock this hook. It also adds a `useEffect` hook to handle focus changes.

> _`useSearchParams` to control the field of doom_
> _Clear the input and reset the placeholder of gloom_
> _Run a side effect when the focus shifts_
> _`InputField` tests mock the hook that lifts_

### Walkthrough
*  Add `useSearchParams` hook to `InputField` component and test file ([link](https://github.com/PolicyEngine/policyengine-app/pull/705/files?diff=unified&w=0#diff-e217baee6f19e2e78342dc24d5d7a60120b6ef45e9466740f9d10fbec0af551cR3), [link](https://github.com/PolicyEngine/policyengine-app/pull/705/files?diff=unified&w=0#diff-10323c70aaa8c36a4d474a2c79df4d291dc1a09fbf1e17b0c4ddae37404abd29L4-R5))
*  Mock `useSearchParams` hook in `InputField` test file and simulate different query parameters ([link](https://github.com/PolicyEngine/policyengine-app/pull/705/files?diff=unified&w=0#diff-e217baee6f19e2e78342dc24d5d7a60120b6ef45e9466740f9d10fbec0af551cR9-R16), [link](https://github.com/PolicyEngine/policyengine-app/pull/705/files?diff=unified&w=0#diff-e217baee6f19e2e78342dc24d5d7a60120b6ef45e9466740f9d10fbec0af551cL21-R57))
*  Wrap existing tests in `InputField` test file in a `describe` block with a clear label ([link](https://github.com/PolicyEngine/policyengine-app/pull/705/files?diff=unified&w=0#diff-e217baee6f19e2e78342dc24d5d7a60120b6ef45e9466740f9d10fbec0af551cL21-R57))
*  Add `savedPlaceholder` state variable to `InputField` component to store the initial placeholder prop ([link](https://github.com/PolicyEngine/policyengine-app/pull/705/files?diff=unified&w=0#diff-10323c70aaa8c36a4d474a2c79df4d291dc1a09fbf1e17b0c4ddae37404abd29L17-R22))
*  Add `useEffect` hook to `InputField` component to clear the input field and reset the placeholder when the focus changes ([link](https://github.com/PolicyEngine/policyengine-app/pull/705/files?diff=unified&w=0#diff-10323c70aaa8c36a4d474a2c79df4d291dc1a09fbf1e17b0c4ddae37404abd29R31-R37))
*  Replace `placeholder` prop with `savedPlaceholder` state variable in `input` element of `InputField` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/705/files?diff=unified&w=0#diff-10323c70aaa8c36a4d474a2c79df4d291dc1a09fbf1e17b0c4ddae37404abd29L79-R91))


