### PR TITLE
Revert "Capitalise rather than uppercase titles"

### DIFF
--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -138,7 +138,7 @@ export default function ParameterEditor(props) {
     <CenteredMiddleColumn
       marginTop="5%"
       marginBottom={0}
-      title={capitalize(parameter.label.toLowerCase())}
+      title={capitalize(parameter.label)}
       description={description + timePeriodSentence}
     >
       {editControl}


### PR DESCRIPTION
This reverts commit efae240e331e21fc8750a9046a4e04ee9ca4886b. This resolves #704 where parameter labels containing acronyms in all capital letters were being forced into proper case.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at da7752f</samp>

### Summary
🗑️🚫🛑

<!--
1.  🗑️ - This emoji means "wastebasket" and can be used to indicate that something was deleted or removed.
2.  🚫 - This emoji means "prohibited" and can be used to indicate that something was forbidden or prevented.
3.  🛑 - This emoji means "stop sign" and can be used to indicate that something was stopped or halted.
-->
Fixed a bug that caused some parameter labels to lose their capitalization in the policy input editor. Removed an unnecessary `toLowerCase()` method call from `ParameterEditor.jsx`.

> _`toLowerCase` gone_
> _Preserving acronyms_
> _A winter of case_

### Walkthrough
*  Remove `toLowerCase()` method from parameter labels to preserve original case ([link](https://github.com/PolicyEngine/policyengine-app/pull/738/files?diff=unified&w=0#diff-9b745098fe616d3b484439547f6eed36ad068dab9723978c85b41095a0a0c92aL141-R141))


