### PR TITLE
Fix Redirect /blog/slug links to /research/slug #743

### DIFF
--- a/src/redesign/components/PolicyEngine.jsx
+++ b/src/redesign/components/PolicyEngine.jsx
@@ -227,6 +227,12 @@ export default function PolicyEngine({ pathname }) {
           element={metadata ? policyPage : error ? errorPage : loadingPage}
         />
 
+        {/* redirect from /countryId/blog/slug to /countryId/research/slug */}
+        <Route
+          path="/:countryId/blog/:slug"
+          element={<Navigate to={`/${countryId}/research/${pathParts[3]}`} />}
+        />
+
         {/* Redirect for unrecognized paths */}
         <Route path="*" element={<Navigate to={`/${countryId}`} />} />
       </Routes>


### PR DESCRIPTION
Fixes #743

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 06b4020</samp>

### Summary
🚚📚🔗

<!--
1.  🚚 This emoji represents the act of moving or redirecting something from one place to another, which is what the route component does for the old blog URLs.
2.  📚 This emoji represents the research section of the app, where the blog posts are now located and categorized as research articles.
3.  🔗 This emoji represents the links that are preserved and updated by the route component, ensuring that users can still access the content they are looking for.
-->
Add route component to redirect old blog URLs to new research URLs in `PolicyEngine.jsx`. This improves the user experience and consistency of the PolicyEngine app.

> _Old blog route is gone_
> _`/:countryId/research` now_
> _Autumn of content_

### Walkthrough
* Add a route component to redirect old blog URLs to new research URLs ([link](https://github.com/PolicyEngine/policyengine-app/pull/744/files?diff=unified&w=0#diff-e30e417fc83ec5700443c56bd7a183339e16b3094194b57c61fdbd596eb7d2d8R230-R235))


