### PR TITLE
Re-add monthly and eternity variables

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -41,7 +41,7 @@ export default function VariableEditor(props) {
   const entityPlural = metadata.entities[variable.entity].plural;
   const isSimulated = !variable.isInputVariable;
   const possibleEntities = Object.keys(householdInput[entityPlural]).filter(
-    (entity) => householdInput[entityPlural][entity][variable.name],
+    (entity) => householdInput[entityPlural][entity][variable.name]
   );
 
   // Add the variable to the relevant portions of the household input object
@@ -49,7 +49,7 @@ export default function VariableEditor(props) {
     const newHouseholdInput = addVariable(
       householdInput,
       variable,
-      entityPlural,
+      entityPlural
     );
     setHouseholdInput(newHouseholdInput);
   }, [variable]);
@@ -122,7 +122,7 @@ function HouseholdVariableEntity(props) {
     setEdited,
   } = props;
   const possibleTimePeriods = Object.keys(
-    householdInput[entityPlural][entityName][variable.name],
+    householdInput[entityPlural][entityName][variable.name]
   );
   return (
     <>
@@ -181,7 +181,7 @@ function HouseholdVariableEntityInput(props) {
           let newSearch = new URLSearchParams(window.location.search);
           newSearch.set("household", householdId);
           setSearchParams(newSearch);
-        },
+        }
       );
     }
     setEdited(true);
@@ -192,14 +192,14 @@ function HouseholdVariableEntityInput(props) {
     timePeriod,
     entityName,
     householdBaseline,
-    metadata,
+    metadata
   );
   const inputValue = getValueFromHousehold(
     variable.name,
     timePeriod,
     entityName,
     householdInput,
-    metadata,
+    metadata
   );
   const reformValue = householdReform
     ? getValueFromHousehold(
@@ -207,7 +207,7 @@ function HouseholdVariableEntityInput(props) {
         timePeriod,
         entityName,
         householdReform,
-        metadata,
+        metadata
       )
     : null;
   const mobile = useMobile();
@@ -305,7 +305,7 @@ export function addVariable(householdInput, variable, entityPlural) {
   let possibleEntities = null;
 
   // If the variable is defined as occurring over a year...
-  if (variable.definitionPeriod === "year") {
+  if (["year", "eternity"].includes(variable.definitionPeriod)) {
     // If plural entity term is in household situation...
     if (entityPlural in householdInput) {
       // Pull all individual entities stored within the umbrella entity

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -41,7 +41,7 @@ export default function VariableEditor(props) {
   const entityPlural = metadata.entities[variable.entity].plural;
   const isSimulated = !variable.isInputVariable;
   const possibleEntities = Object.keys(householdInput[entityPlural]).filter(
-    (entity) => householdInput[entityPlural][entity][variable.name]
+    (entity) => householdInput[entityPlural][entity][variable.name],
   );
 
   // Add the variable to the relevant portions of the household input object
@@ -49,7 +49,7 @@ export default function VariableEditor(props) {
     const newHouseholdInput = addVariable(
       householdInput,
       variable,
-      entityPlural
+      entityPlural,
     );
     setHouseholdInput(newHouseholdInput);
   }, [variable]);
@@ -122,7 +122,7 @@ function HouseholdVariableEntity(props) {
     setEdited,
   } = props;
   const possibleTimePeriods = Object.keys(
-    householdInput[entityPlural][entityName][variable.name]
+    householdInput[entityPlural][entityName][variable.name],
   );
   return (
     <>
@@ -181,7 +181,7 @@ function HouseholdVariableEntityInput(props) {
           let newSearch = new URLSearchParams(window.location.search);
           newSearch.set("household", householdId);
           setSearchParams(newSearch);
-        }
+        },
       );
     }
     setEdited(true);
@@ -192,14 +192,14 @@ function HouseholdVariableEntityInput(props) {
     timePeriod,
     entityName,
     householdBaseline,
-    metadata
+    metadata,
   );
   const inputValue = getValueFromHousehold(
     variable.name,
     timePeriod,
     entityName,
     householdInput,
-    metadata
+    metadata,
   );
   const reformValue = householdReform
     ? getValueFromHousehold(
@@ -207,7 +207,7 @@ function HouseholdVariableEntityInput(props) {
         timePeriod,
         entityName,
         householdReform,
-        metadata
+        metadata,
       )
     : null;
   const mobile = useMobile();

--- a/src/pages/household/output/EarningsVariation.jsx
+++ b/src/pages/household/output/EarningsVariation.jsx
@@ -32,7 +32,7 @@ export default function EarningsVariation(props) {
   const possibleEntities = Object.keys(
     householdInput[
       metadata.entities[metadata.variables[variable].entity].plural
-    ]
+    ],
   );
   // eslint-disable-next-line
   const [selectedEntity, setSelectedEntity] = useState(possibleEntities[0]);
@@ -48,8 +48,8 @@ export default function EarningsVariation(props) {
         ];
       validVariables = validVariables.concat(
         Object.keys(firstEntity).filter((variable) =>
-          Array.isArray(firstEntity[variable][2023])
-        )
+          Array.isArray(firstEntity[variable][2023]),
+        ),
       );
     }
   }
@@ -65,7 +65,7 @@ export default function EarningsVariation(props) {
       "2023",
       "you",
       householdInput,
-      metadata
+      metadata,
     );
     householdData.axes = [
       [
@@ -75,7 +75,7 @@ export default function EarningsVariation(props) {
           min: 0,
           max: Math.max(
             metadata.countryId == "ng" ? 1_200_000 : 200_000,
-            2 * currentEarnings
+            2 * currentEarnings,
           ),
           count: 401,
         },
@@ -94,7 +94,7 @@ export default function EarningsVariation(props) {
         })
         .catch((err) => {
           setError(err);
-        })
+        }),
     );
     if (reformPolicyId) {
       requests.push(
@@ -108,7 +108,7 @@ export default function EarningsVariation(props) {
           })
           .catch((err) => {
             setError(err);
-          })
+          }),
       );
     }
     Promise.all(requests).then(() => setLoading(false));

--- a/src/pages/household/output/EarningsVariation.jsx
+++ b/src/pages/household/output/EarningsVariation.jsx
@@ -32,7 +32,7 @@ export default function EarningsVariation(props) {
   const possibleEntities = Object.keys(
     householdInput[
       metadata.entities[metadata.variables[variable].entity].plural
-    ],
+    ]
   );
   // eslint-disable-next-line
   const [selectedEntity, setSelectedEntity] = useState(possibleEntities[0]);
@@ -48,8 +48,8 @@ export default function EarningsVariation(props) {
         ];
       validVariables = validVariables.concat(
         Object.keys(firstEntity).filter((variable) =>
-          Array.isArray(firstEntity[variable][2023]),
-        ),
+          Array.isArray(firstEntity[variable][2023])
+        )
       );
     }
   }
@@ -59,14 +59,13 @@ export default function EarningsVariation(props) {
 
   useEffect(() => {
     let householdData = JSON.parse(JSON.stringify(householdInput));
-    console.log(householdInput);
-    householdData.people.you.employment_income["2023"] = null;
+    householdData.people.you["employment_income"] = { 2023: null };
     const currentEarnings = getValueFromHousehold(
       "employment_income",
       "2023",
       "you",
       householdInput,
-      metadata,
+      metadata
     );
     householdData.axes = [
       [
@@ -76,7 +75,7 @@ export default function EarningsVariation(props) {
           min: 0,
           max: Math.max(
             metadata.countryId == "ng" ? 1_200_000 : 200_000,
-            2 * currentEarnings,
+            2 * currentEarnings
           ),
           count: 401,
         },
@@ -95,7 +94,7 @@ export default function EarningsVariation(props) {
         })
         .catch((err) => {
           setError(err);
-        }),
+        })
     );
     if (reformPolicyId) {
       requests.push(
@@ -109,7 +108,7 @@ export default function EarningsVariation(props) {
           })
           .catch((err) => {
             setError(err);
-          }),
+          })
       );
     }
     Promise.all(requests).then(() => setLoading(false));


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0e91b94</samp>

### Summary
🐛🧹💵

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the second pull request and also a part of the first one.
2. 🧹 - This emoji represents a code cleanup or style improvement, which is the main purpose of the first pull request and also a part of the second one.
3. 💵 - This emoji represents money or income, which is the domain of the `EarningsVariation.jsx` component that is modified by the second pull request.
-->
This pull request improves code style and fixes bugs in the household input and output components of the app. It removes unnecessary trailing commas from arrays and function calls, and aligns parentheses for readability. It also fixes the handling of `"eternity"` variables and the variation of employment income for 2023.

> _Sing, O Muse, of the code that was refined_
> _By the skillful coder, who removed the commas_
> _That trailed like the tail of a serpent behind_
> _The arrays and functions, causing much drama._

### Walkthrough
*  Fix a bug that prevented some variables from being added to the household input by adding `"eternity"` to the year check condition ([link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L308-R308))
* Fix a bug that caused an error when trying to vary the earnings of the household by modifying the way the `householdData` object is updated for the year 2023 ([link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-31d25016a1cb4e96f8c2752f8f09fff24d1917b85c379be5008c6dd494596efaL62-R62))
* Remove trailing commas from various array and function calls to improve code style consistency ([link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L44-R44), [link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L52-R52), [link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L125-R125), [link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L195-R195), [link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L202-R202), [link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L210-R210), [link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-31d25016a1cb4e96f8c2752f8f09fff24d1917b85c379be5008c6dd494596efaL35-R35), [link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-31d25016a1cb4e96f8c2752f8f09fff24d1917b85c379be5008c6dd494596efaL51-R52), [link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-31d25016a1cb4e96f8c2752f8f09fff24d1917b85c379be5008c6dd494596efaL69-R68), [link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-31d25016a1cb4e96f8c2752f8f09fff24d1917b85c379be5008c6dd494596efaL79-R78), [link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-31d25016a1cb4e96f8c2752f8f09fff24d1917b85c379be5008c6dd494596efaL98-R97), [link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-31d25016a1cb4e96f8c2752f8f09fff24d1917b85c379be5008c6dd494596efaL112-R111))
* Move the closing parenthesis of the `setSearchParams` function call to the next line to improve readability ([link](https://github.com/PolicyEngine/policyengine-app/pull/756/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L184-R184))


