### PR TITLE
Fix CEC app

### DIFF
--- a/src/redesign/components/CitizensEconomicCouncil.jsx
+++ b/src/redesign/components/CitizensEconomicCouncil.jsx
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import Header from "./Header";
+
+export default function CitizensEconomicCouncil() {
+  // Update the title to be "CEC reform simulator | PolicyEngine")
+  useEffect(() => {
+    document.title = "CEC reform simulator | PolicyEngine";
+  }, []);
+
+  return (
+    <>
+      <Header />
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+        }}
+      >
+        <iframe
+          src="https://policyengine-cec-simulator.streamlit.app?embedded=true"
+          title="Citizens' Economic Council reform simulator"
+          height="800"
+          width="800"
+          style={{ overflow: "hidden" }}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/redesign/components/PolicyEngine.jsx
+++ b/src/redesign/components/PolicyEngine.jsx
@@ -18,6 +18,7 @@ import ErrorPage from "../../layout/Error";
 import Header from "./Header";
 import Testimonials from "./Testimonials";
 import CalculatorInterstitial from "./CalculatorInterstitial";
+import CitizensEconomicCouncil from "./CitizensEconomicCouncil";
 
 const PolicyPage = lazy(() => import("../../pages/PolicyPage"));
 const HouseholdPage = lazy(() => import("../../pages/HouseholdPage"));
@@ -226,6 +227,7 @@ export default function PolicyEngine({ pathname }) {
           path="/:countryId/policy/*"
           element={metadata ? policyPage : error ? errorPage : loadingPage}
         />
+        <Route path="/uk/cec" element={<CitizensEconomicCouncil />} />
 
         {/* redirect from /countryId/blog/slug to /countryId/research/slug */}
         <Route


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3e4efe0</samp>

### Summary
🏛️🖥️🛠️

<!--
1.  🏛️ - This emoji represents the Citizens' Economic Council project, which is a civic engagement initiative that aims to involve citizens in deliberating and shaping economic policy. The emoji also conveys the idea of a reform simulator, which allows users to explore different scenarios and trade-offs for economic reform.
2.  🖥️ - This emoji represents the iframe component that renders the reform simulator app, which is a web-based interactive tool that uses data and visualizations to illustrate the impacts of various policy options. The emoji also conveys the idea of technology and innovation, which are central to the project's approach and goals.
3.  🛠️ - This emoji represents the new feature that is added to the app, which is a reform simulator for the Citizens' Economic Council project. The emoji also conveys the idea of building and improving, which are the intended outcomes of the project and the simulator.
-->
This pull request adds a new page to the PolicyEngine app for the Citizens' Economic Council project. It creates a new component `CitizensEconomicCouncil` that embeds the reform simulator app in an iframe.

> _To simulate reforms for the UK_
> _A new component was added today_
> _It renders an iframe_
> _With the `CitizensEconomicCouncil` name_
> _And imports the `Header` by the way_

### Walkthrough
*  Add a new component `CitizensEconomicCouncil` to display the Citizens' Economic Council reform simulator app in an iframe ([link](https://github.com/PolicyEngine/policyengine-app/pull/769/files?diff=unified&w=0#diff-184678d24e83dab3ff4bf8cac5c75d9e2e72d81f977377b0e0a3b5e8ffaa13aaR1-R29))
* Import the `CitizensEconomicCouncil` component in the `PolicyEngine` component, which is the main entry point for the app ([link](https://github.com/PolicyEngine/policyengine-app/pull/769/files?diff=unified&w=0#diff-e30e417fc83ec5700443c56bd7a183339e16b3094194b57c61fdbd596eb7d2d8R21))
* Create a new route `/uk/cec` in the `PolicyEngine` component, which renders the `CitizensEconomicCouncil` component as the page element ([link](https://github.com/PolicyEngine/policyengine-app/pull/769/files?diff=unified&w=0#diff-e30e417fc83ec5700443c56bd7a183339e16b3094194b57c61fdbd596eb7d2d8R230))


