### PR TITLE
Fix GCloud GH actions authentication

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,8 +23,11 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: policyengine-app
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          create_credentials_file: true
       - name: Install dependencies
         run: make install
       - name: Deploy

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,8 +23,8 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: policyengine-app
-      - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
+      - name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
           create_credentials_file: true


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2836d1b</samp>

### Summary
🔁🔒📄

<!--
1.  🔁 - This emoji represents the replacement of one action with another, indicating a change in the tool or method used to achieve a goal.
2.  🔒 - This emoji represents the increased security and flexibility of the new action, indicating a benefit or improvement for the users.
3.  📄 - This emoji represents the creation of a credentials file, indicating a new output or artifact that can be used by other actions or tools.
-->
Updated the GitHub workflow for pushing to Google Cloud to use a more secure and flexible authentication action. Removed unnecessary inputs and added one to create a credentials file for Google Cloud tools.

> _`setup-gcloud` gone_
> _`auth` action is secure_
> _spring cleaning the code_

### Walkthrough
* Replace `setup-gcloud` action with `auth` action for more secure and flexible authentication to Google Cloud ([link](https://github.com/PolicyEngine/policyengine-app/pull/813/files?diff=unified&w=0#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L26-R30))


