### PR TITLE
Capture research filters in URL

### DIFF
--- a/src/redesign/components/About.jsx
+++ b/src/redesign/components/About.jsx
@@ -22,7 +22,7 @@ export default function About() {
         <TeamMember member={founders.nikhil_woodruff} />
         <TeamMember member={founders.pavel_makarchuk} />
       </Section>
-      <div style={{ display:"none" }}>
+      <div style={{ display: "none" }}>
         <Section backgroundColor={style.colors.BLUE_PRIMARY}>
           <h2 style={{ color: style.colors.WHITE }}>Advisory board</h2>
           <Advisor member={advisors.george_sadowsky} />

--- a/src/redesign/components/Research.jsx
+++ b/src/redesign/components/Research.jsx
@@ -60,21 +60,21 @@ function ResearchExplorer() {
   useEffect(() => {
     searchParams.set("topics", filteredTopics.join(', '));
     setSearchParams(searchParams)
-  },[filteredTopics]);
+  }, [filteredTopics]);
   const [filteredLocations, setFilteredLocations] = useState(
     searchParams.get("locations")?.split(",") || locationTags,
   );
   useEffect(() => {
     searchParams.set("locations", filteredLocations.join(', '));
     setSearchParams(searchParams)
-  },[filteredLocations]);
+  }, [filteredLocations]);
   const [filteredAuthors, setFilteredAuthors] = useState(
     searchParams.get("authors")?.split(",") || authorKeys,
   );
   useEffect(() => {
     searchParams.set("authors", filteredAuthors.join(', '));
     setSearchParams(searchParams)
-  },[filteredAuthors]);
+  }, [filteredAuthors]);
   const filterFunction = (post) => {
     let hasMetAtLeastOneFilteredTopic = false;
     for (const tag of filteredTopics) {
@@ -108,10 +108,10 @@ function ResearchExplorer() {
   const searchField = searchParams.get("search");
   const filteredPosts = searchField
     ? fuse
-        .search(searchField, {
-          distance: 10,
-        })
-        .map((result) => result.item)
+      .search(searchField, {
+        distance: 10,
+      })
+      .map((result) => result.item)
     : preFilteredPosts;
 
   const searchTools = (
@@ -397,7 +397,7 @@ function Expandable({ title, children }) {
       animate={{
         maxHeight: expanded
           ? contentRef.current?.getBoundingClientRect().height +
-            titleRef.current?.getBoundingClientRect().height
+          titleRef.current?.getBoundingClientRect().height
           : titleRef.current?.getBoundingClientRect().height,
       }}
       transition={{

--- a/src/redesign/components/Research.jsx
+++ b/src/redesign/components/Research.jsx
@@ -16,7 +16,7 @@ import {
 import { MediumBlogPreview } from "./HomeBlogPreview";
 import Fuse from "fuse.js";
 import { useSearchParams } from "react-router-dom";
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import FontIcon from "./FontIcon";
 import { authorKeys, authorKeyToLabel } from "redesign/data/Authors";
@@ -57,12 +57,24 @@ function ResearchExplorer() {
   const [filteredTopics, setFilteredTopics] = useState(
     searchParams.get("topics")?.split(",") || topicTags,
   );
+  useEffect(() => {
+    searchParams.set("topics", filteredTopics.join(', '));
+    setSearchParams(searchParams)
+  },[filteredTopics]);
   const [filteredLocations, setFilteredLocations] = useState(
     searchParams.get("locations")?.split(",") || locationTags,
   );
+  useEffect(() => {
+    searchParams.set("locations", filteredLocations.join(', '));
+    setSearchParams(searchParams)
+  },[filteredLocations]);
   const [filteredAuthors, setFilteredAuthors] = useState(
     searchParams.get("authors")?.split(",") || authorKeys,
   );
+  useEffect(() => {
+    searchParams.set("authors", filteredAuthors.join(', '));
+    setSearchParams(searchParams)
+  },[filteredAuthors]);
   const filterFunction = (post) => {
     let hasMetAtLeastOneFilteredTopic = false;
     for (const tag of filteredTopics) {

--- a/src/redesign/components/Research.jsx
+++ b/src/redesign/components/Research.jsx
@@ -58,22 +58,22 @@ function ResearchExplorer() {
     searchParams.get("topics")?.split(",") || topicTags,
   );
   useEffect(() => {
-    searchParams.set("topics", filteredTopics.join(', '));
-    setSearchParams(searchParams)
+    searchParams.set("topics", filteredTopics.join(", "));
+    setSearchParams(searchParams);
   }, [filteredTopics]);
   const [filteredLocations, setFilteredLocations] = useState(
     searchParams.get("locations")?.split(",") || locationTags,
   );
   useEffect(() => {
-    searchParams.set("locations", filteredLocations.join(', '));
-    setSearchParams(searchParams)
+    searchParams.set("locations", filteredLocations.join(", "));
+    setSearchParams(searchParams);
   }, [filteredLocations]);
   const [filteredAuthors, setFilteredAuthors] = useState(
     searchParams.get("authors")?.split(",") || authorKeys,
   );
   useEffect(() => {
-    searchParams.set("authors", filteredAuthors.join(', '));
-    setSearchParams(searchParams)
+    searchParams.set("authors", filteredAuthors.join(", "));
+    setSearchParams(searchParams);
   }, [filteredAuthors]);
   const filterFunction = (post) => {
     let hasMetAtLeastOneFilteredTopic = false;
@@ -108,10 +108,10 @@ function ResearchExplorer() {
   const searchField = searchParams.get("search");
   const filteredPosts = searchField
     ? fuse
-      .search(searchField, {
-        distance: 10,
-      })
-      .map((result) => result.item)
+        .search(searchField, {
+          distance: 10,
+        })
+        .map((result) => result.item)
     : preFilteredPosts;
 
   const searchTools = (
@@ -397,7 +397,7 @@ function Expandable({ title, children }) {
       animate={{
         maxHeight: expanded
           ? contentRef.current?.getBoundingClientRect().height +
-          titleRef.current?.getBoundingClientRect().height
+            titleRef.current?.getBoundingClientRect().height
           : titleRef.current?.getBoundingClientRect().height,
       }}
       transition={{


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ba7d812</samp>

### Summary
:sparkles::wrench::mag:

<!--
1.  :sparkles: - This emoji can be used to indicate that a new feature or functionality was added to the project, in this case the URL search parameter update.
2.  :wrench: - This emoji can be used to indicate that some improvement or adjustment was made to the existing code or logic, in this case the use of the `useEffect` hook to sync the state and the URL.
3.  :mag: - This emoji can be used to indicate that something related to search or filtering was modified or enhanced, in this case the research filters that affect the URL.
-->
Improved the user experience of the research page by enabling URL-based filtering. Used React hooks to manage the state of the `Research.jsx` component and the URL search parameters.

> _We search for the truth in the dark web of doom_
> _We sync our filters with the URL of gloom_
> _We use the `useEffect` hook to unleash our power_
> _We update the parameters with every hour_

### Walkthrough
* Import `useEffect` hook from `react` to update URL search parameters based on filter state ([link](https://github.com/PolicyEngine/policyengine-app/pull/830/files?diff=unified&w=0#diff-71f865a56ce955f365d81caa675f4663e0035dec19630b8b4ebcab816844f9caL19-R19))
* Use `useEffect` hook to set `topics`, `locations`, and `authors` search parameters when `filteredTopics`, `filteredLocations`, and `filteredAuthors` change in `src/redesign/components/Research.jsx` ([link](https://github.com/PolicyEngine/policyengine-app/pull/830/files?diff=unified&w=0#diff-71f865a56ce955f365d81caa675f4663e0035dec19630b8b4ebcab816844f9caL60-R77))


Fixes #823

On filter change , now the url also changes