### PR TITLE
Fix mobile subscribe button highlight on hover

### DIFF
--- a/src/redesign/components/HomeSubscribe.jsx
+++ b/src/redesign/components/HomeSubscribe.jsx
@@ -108,7 +108,7 @@ export function SubscribeToPolicyEngineMobile() {
           text="Subscribe"
           onClick={() => {}}
           width="100%"
-          size="500px"
+          size="768px"
         />
       </div>
     </div>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3463f7f</samp>

### Summary
📱📐📖

<!--
1.  📱 - This emoji represents the mobile devices that the component was optimized for, and suggests that the app is responsive and accessible on different screen sizes.
2.  📐 - This emoji represents the layout and design of the component, and suggests that the app is well-structured and visually appealing.
3.  📖 - This emoji represents the readability and content of the component, and suggests that the app is informative and easy to understand.
-->
Increased the size of the `SubscribeToPolicyEngine` component on the home page to enhance mobile responsiveness. This is part of a redesign of the home page to improve the app's usability and appeal.

> _`SubscribeToPolicyEngine`_
> _Larger on mobile screens_
> _A fresh home page blooms_

### Walkthrough
* Increase the size of the `SubscribeToPolicyEngine` component to improve mobile layout and readability ([link](https://github.com/PolicyEngine/policyengine-app/pull/838/files?diff=unified&w=0#diff-4a0c6068731e3abe16239431eb7c22403ce6459c7d377394aadddfce1e3e5a2fL111-R111))


Fixes #814
Allow ActionButton size for mobile subscribe button to be 768px (tablet breakpoint)
![Screenshot 2023-11-08 at 2 08 11 PM](https://github.com/PolicyEngine/policyengine-app/assets/12587760/109d835b-5467-48c4-84c0-f16a0f16e4be)

