### PR TITLE
Reflect policy parameter changes in right hand pane and middle chart

### DIFF
--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -247,7 +247,7 @@ export function getPlotlyAxisFormat(
   precisionOverride,
   valueType,
 ) {
-  // Possible units: currency-GBP, currency-USD, /1
+  // Possible units: currency-GBP, currency-USD, /1, date
   // If values (an array) is passed, we need to calculate the
   // appropriate number of decimal places to use.
   let precision;
@@ -298,6 +298,25 @@ export function getPlotlyAxisFormat(
           Math.max(...values) * 1.5,
         ]),
       }),
+    };
+  } else if (unit === "date") {
+    let minYear, maxYear;
+    if (values.length) {
+      minYear = values.reduce(function (a, b) {
+        return a <= b ? a : b;
+      });
+      maxYear = values.reduce(function (a, b) {
+        return a >= b ? a : b;
+      });
+      minYear = Number(minYear.match(/\d+/)[0]);
+      maxYear = Number(maxYear.match(/\d+/)[0]);
+    } else {
+      const currentYear = new Date().getFullYear();
+      minYear = currentYear;
+      maxYear = currentYear;
+    }
+    return {
+      range: sortRange([minYear - 5 + "-01-01", maxYear + 5 + "-12-31"]),
     };
   } else if (valueType === "bool") {
     return {

--- a/src/controls/InputField.jsx
+++ b/src/controls/InputField.jsx
@@ -15,24 +15,19 @@ export default function InputField(props) {
     value,
     placeholder,
   } = props;
-  //Saving placeholder as a state variable so it doesn't change if user types a value and deletes it
-  const [savedPlaceholder, setPlaceholder] = useState(placeholder);
   const [inputValue, setInputValue] = useState(value ? value : "");
   const [searchParams] = useSearchParams();
   const focus = searchParams.get("focus") || "";
   const mobile = useMobile();
   const re = /^[0-9\b]*[.]?[0-9\b]*?$/;
   const onInput = (e) => {
-    let value = e.target.value;
-    if (value !== "") {
-      onChange(value);
-    }
+    let value = e.target.value === "" ? placeholder : e.target.value;
+    onChange(value);
   };
   //clears input field and resets placeholder if focus changes for use case of editing policy parameter
   useEffect(() => {
     if (!value) {
       setInputValue("");
-      setPlaceholder(props.placeholder);
     }
   }, [focus]);
   return (
@@ -88,7 +83,7 @@ export default function InputField(props) {
         setInputValue(e.target.value);
       }}
       value={inputValue}
-      placeholder={savedPlaceholder}
+      placeholder={placeholder}
     />
   );
 }

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -43,9 +43,12 @@ export default function ParameterOverTime(props) {
     reformedY.push(reformedY[reformedY.length - 1]);
   }
 
+  let xForRange = reformedX ? x.concat(reformedX) : x;
+  xForRange = xForRange.filter((e) => e !== "0000-01-01" && e !== "2099-12-31");
+  let xAxisFormat = getPlotlyAxisFormat("date", xForRange);
   let yAxisFormat = getPlotlyAxisFormat(
     parameter.unit,
-    Object.values(parameter.values),
+    reformedY ? y.concat(reformedY) : y,
   );
   let yAxisTickVals;
   let yAxisTickLabels;
@@ -65,6 +68,7 @@ export default function ParameterOverTime(props) {
             type: "line",
             line: {
               shape: "hv",
+              dash: "dot",
             },
             marker: {
               color: style.colors.GRAY,
@@ -87,9 +91,7 @@ export default function ParameterOverTime(props) {
           .reverse()
           .filter((x) => x)}
         layout={{
-          xaxis: {
-            range: ["2000-01-01", "2025-01-01"],
-          },
+          xaxis: xAxisFormat,
           yaxis: {
             ...yAxisFormat,
             tickvals: yAxisTickVals || null,


### PR DESCRIPTION
## Description

Fixes #53 and #17. The issues are about accurately reflecting changes made through the policy editor inputs (dates, value) in the right sidebar and parameter-over-time chart.

## Strategy for fix

The policy right sidebar (#53) and the parameter-over-time chart (#17) display the information in policy.reform.data, directly or via the getReformedParameter() function. I have modified getReformedParameter() so that the end date is also inserted into the reformed parameter, and I have used getReformedParameter() to construct new policy objects (see newReforms() in ParameterEditor.jsx). These changes ensure that the correct information is available to the right sidebar and the chart.

I have modified the input field component so that it does not store unnecessary state and calls the onChange function with the placeholder when the value is deleted from the field. This change was needed for #53.

I have added new logic for generating axis ranges for dates, and used it to update the parameter-over-time chart. This change helps with #17.

## Tests

I have checked the behavior of the sidebar and the chart for policy inputs of different types (bool, %, numeric).

copilot:all
