### PR TITLE
Remove x-axis title for poverty charts.

### DIFF
--- a/src/pages/policy/output/DeepPovertyImpact.jsx
+++ b/src/pages/policy/output/DeepPovertyImpact.jsx
@@ -105,9 +105,6 @@ export default function DeepPovertyImpact(props) {
           },
         ]}
         layout={{
-          xaxis: {
-            title: "Age group",
-          },
           yaxis: {
             title: "Relative change",
             tickformat: "+,.1%",

--- a/src/pages/policy/output/DeepPovertyImpactByGender.jsx
+++ b/src/pages/policy/output/DeepPovertyImpactByGender.jsx
@@ -107,9 +107,6 @@ export default function DeepPovertyImpactByGender(props) {
           },
         ]}
         layout={{
-          xaxis: {
-            title: "Sex",
-          },
           yaxis: {
             title: "Relative change",
             tickformat: "+,.1%",

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -103,9 +103,6 @@ export default function PovertyImpact(props) {
           },
         ]}
         layout={{
-          xaxis: {
-            title: "Age group",
-          },
           yaxis: {
             title: "Relative change",
             tickformat: "+,.1%",

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -105,9 +105,6 @@ export default function PovertyImpactByGender(props) {
           },
         ]}
         layout={{
-          xaxis: {
-            title: "Sex",
-          },
           yaxis: {
             title: "Relative change",
             tickformat: "+,.1%",

--- a/src/pages/policy/output/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/PovertyImpactByRace.jsx
@@ -129,9 +129,6 @@ export default function PovertyImpactByRace(props) {
           },
         ]}
         layout={{
-          xaxis: {
-            title: "Race",
-          },
           yaxis: {
             title: "Relative change",
             tickformat: "+,.1%",


### PR DESCRIPTION
Fixes #463 by removing x-axis titles from the following charts

- Poverty impact by age
- Deep poverty impact by age
- Poverty impact by sex
- Deep poverty impact by sex
- Poverty impact by race and ethnicity

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f954aba</samp>

### Summary

Remove x-axis titles from various poverty impact plots in `src/pages/policy/output/`. This simplifies the plot appearance and avoids repeating information from the x-axis labels.

> _`x-axis` titles_
> _gone from poverty plots_
> _autumn leaves fall_

### Walkthrough
* The affected files are `DeepPovertyImpact.jsx`, `DeepPovertyImpactByGender.jsx`, `PovertyImpact.jsx`, `PovertyImpactByGender.jsx`, and `PovertyImpactByRace.jsx` in the `src/pages/policy/output` directory


