### PR TITLE
Align 'Example input' with 'Output format' #869

### DIFF
--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -414,8 +414,8 @@ function APIEndpoint({
       <p>{description}</p>
 
       <div
-        style={{ 
-          display: "flex", 
+        style={{
+          display: "flex",
         }}
       >
         {hasInput && (

--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -401,46 +401,36 @@ function APIEndpoint({
   exampleInputJson,
   exampleOutputJson,
 }) {
+  const hasInput = Boolean(exampleInputJson);
+
   return (
     <Section>
+      <h3>{title}</h3>
+      <h5>
+        <code>
+          {method} {pattern}
+        </code>
+      </h5>
+      <p>{description}</p>
+
       <div
-        style={{
-          display: "flex",
+        style={{ 
+          display: "flex", 
         }}
       >
+        {hasInput && (
+          <div style={{ flex: 1 }}>
+            <h4>Example input</h4>
+            <JSONBlock json={exampleInputJson} />
+          </div>
+        )}
         <div
           style={{
-            position: "sticky",
-            top: 200,
-            height: "100%",
             flex: 1,
+            marginLeft: hasInput ? "50px" : "0",
           }}
         >
-          <h3>{title}</h3>
-          <h5>
-            <code>
-              {method} {pattern}
-            </code>
-          </h5>
-          <p>{description}</p>
-          {exampleInputJson && (
-            <div
-              style={{
-                width: "100%",
-              }}
-            >
-              <h4>Example input</h4>
-              <JSONBlock json={exampleInputJson} />
-            </div>
-          )}
-        </div>
-        <div
-          style={{
-            marginLeft: 50,
-            flex: 1,
-          }}
-        >
-          <h4>Output format</h4>
+          {<h4>Output format</h4>}
           <JSONBlock json={exampleOutputJson} />
         </div>
       </div>


### PR DESCRIPTION
**Title:**
Align Example Input with Output Format in API Documentation (Resolves #869  )

**Description:**
This PR addresses Issue #869 by introducing conditional rendering to the APIEndpoint component to align the "Example input" section with the "Output format" section when present, and ensuring the "Output format" aligns correctly with the "GET" title when the example input is absent.

**Changes:**

- Implemented conditional rendering within the API Endpoint component based on the presence of exampleInputJson.
- Ensured that the "Output format" title is consistently displayed whether the example input is present or not.
- Adjusted styling to maintain appropriate spacing and alignment between elements.
- The layout now dynamically adjusts, maintaining a clean and consistent structure within the API documentation, improving readability and the developer experience.


**Before Change:**
Here's how the API documentation looked before. Notice the misalignment of the "Example input" and "Output format" sections.

<img width="1039" alt="Before Change" src="https://github.com/PolicyEngine/policyengine-app/assets/113239008/57287467-d61f-4f0f-a5f3-987810a71037">


**After Change:**
With the proposed changes, "Example input" aligns correctly with "Output format" when present, and "Output format" aligns with the "GET" title when the example input is absent, providing a cleaner and more consistent layout.

<img width="1059" alt="After Change" src="https://github.com/PolicyEngine/policyengine-app/assets/113239008/c889d58c-4548-4dcd-821f-92d6ca46eafb">
