### PR TITLE
Increase logo size and adjust container width

### DIFF
--- a/src/redesign/components/HomeUsedBy.jsx
+++ b/src/redesign/components/HomeUsedBy.jsx
@@ -41,10 +41,11 @@ export default function HomeUsedBy() {
           style={{
             display: "flex",
             justifyContent: {
-              mobile: "center",
-              tablet: "center",
-              desktop: "center",
+              mobile: "space-around",
+              tablet: "space-around",
+              desktop: "space-around",
             }[displayCategory],
+            flexWrap: "wrap",
             marginBottom: 30,
             marginTop: 20,
           }}
@@ -61,15 +62,15 @@ export default function HomeUsedBy() {
 function IndividualOrg({ name, logo, link }) {
   const displayCategory = useDisplayCategory();
   const size = {
-    mobile: 80,
-    tablet: 100,
-    desktop: 60,
+    mobile: 100,
+    tablet: 120,
+    desktop: 120,
   }[displayCategory];
   return (
     <a href={link}>
       <div
         style={{
-          width: size,
+          maxWidth: size,
           display: "flex",
           flexDirection: {
             mobile: "row",


### PR DESCRIPTION
**Title:**
Enhance Logo Size and Layout in "Trusted Across the US" Section (#760)

Description:
Refined the sizing and distribution of logos within the "Trusted Across the US" section to address concerns about their scale compared to the UK site.

**Changes:**

- Enlarged logos for enhanced visibility and uniformity with the UK site.
- Applied space-around in the flex container for better spacing on wider screens.
- Shifted to a max-width approach for dynamic logo size adjustment.

**Visuals:**
**Before Change for US Site:**
![image](https://github.com/PolicyEngine/policyengine-app/assets/113239008/d73147d2-f759-4fdb-9601-b4802542ae2f)

**After Change for US Site:**
![image](https://github.com/PolicyEngine/policyengine-app/assets/113239008/c1d2befe-f639-40cb-975e-c2ebae29a18e)

**Before Change for UK Site:**
![image](https://github.com/PolicyEngine/policyengine-app/assets/113239008/ec7bb0ec-f317-4298-a2e8-a0015d7d971b)

**After Change for UK Site:**
![image](https://github.com/PolicyEngine/policyengine-app/assets/113239008/a23c0b4c-40a2-4602-b0d6-010ddeccf045)

**Discussion Point:**
While addressing the issue of the smaller logos on the US site, I also observed that the logos appear smaller on the UK site too. So, I have done resizing universaally and they look ok to me. Should our adjustments be universally applied across both sites for consistency, or should we consider separate sizing strategies for each site based on logo sizes for both the countries? 
