### PR TITLE
Remove space after hyperlinked text in blog posts

### DIFF
--- a/src/redesign/style/App.css
+++ b/src/redesign/style/App.css
@@ -68,7 +68,6 @@ a.highlighted-link {
   box-shadow: inset 0 0 0 0 #227773;
   color: #2c6496;
   padding-top: 5px;
-  padding-right: 10px;
   padding-bottom: 5px;
   transition:
     color 0.2s ease-in-out,
@@ -79,8 +78,6 @@ a.highlighted-link {
 a.highlighted-link:hover {
   box-shadow: inset 800px 0 0 0 #2c6496;
   color: white;
-  padding-left: 5px;
-  padding-right: 5px;
 }
 
 :target {


### PR DESCRIPTION
fixes #752

changes:
* remove `padding-right: 10px;` from `a.highlighted-link {`
* remove `padding-left: 5px;
  padding-right: 5px;` from `a.highlighted-link:hover {`

npm test:
No tests found related to files changed since last commit.
