### PR TITLE
Add initialLocations in Research page in order to filter the initial posts

### DIFF
--- a/src/posts/autumn-statement-2023.md
+++ b/src/posts/autumn-statement-2023.md
@@ -68,8 +68,8 @@ Our estimates exceed those from HM Treasury by about 12%, disproportionately due
 
 | Reform                             | HM Treasury | PolicyEngine | Relative difference | PolicyEngine link                                                                                                           |
 | ---------------------------------- | ----------- | ------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Lower Class 1 NICs from 12% to 10% | 8.72       | 9.69         | 11.3%               | [#28973](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=28973&region=uk&timePeriod=2024&baseline=1) |
-| Lower Class 4 NICs from 9% to 8%   | 0.35       | 0.44         | 26.9%               | [#37642](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=37642&region=uk&timePeriod=2024&baseline=1) |
+| Lower Class 1 NICs from 12% to 10% | 8.72        | 9.69         | 11.3%               | [#28973](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=28973&region=uk&timePeriod=2024&baseline=1) |
+| Lower Class 4 NICs from 9% to 8%   | 0.35        | 0.44         | 26.9%               | [#37642](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=37642&region=uk&timePeriod=2024&baseline=1) |
 | Abolish Class 2 NICs               | 0.38        | 0.42         | 9.4%                | [#37665](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=37665&region=uk&timePeriod=2024&baseline=1) |
 | Total                              | 9.44        | 10.54        | 11.8%               | [#37636](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=37636&region=uk&timePeriod=2024&baseline=1) |
 

--- a/src/redesign/components/Research.jsx
+++ b/src/redesign/components/Research.jsx
@@ -60,18 +60,23 @@ function ResearchExplorer() {
     if (pathSegments.length > 0) {
       return pathSegments[0];
     }
-  }
+  };
+
   const initialLocations = locationTags.filter(
-    (location) => location === extractCountryIdFromPathname() || location === "global"
+    (location) =>
+      location === extractCountryIdFromPathname() ||
+      location.startsWith(extractCountryIdFromPathname() + "-") ||
+      location === "global"
   );
-    
+
+  
   const [filteredTopics, setFilteredTopics] = useState(
     searchParams.get("topics")?.split(",") || topicTags
   );
   const [filteredLocations, setFilteredLocations] = useState(
     searchParams.get("locations")?.split(",") || initialLocations
   );
- 
+
   const [filteredAuthors, setFilteredAuthors] = useState(
     searchParams.get("authors")?.split(",") || authorKeys
   );

--- a/src/redesign/components/Research.jsx
+++ b/src/redesign/components/Research.jsx
@@ -69,7 +69,6 @@ function ResearchExplorer() {
       location === "global"
   );
 
-  
   const [filteredTopics, setFilteredTopics] = useState(
     searchParams.get("topics")?.split(",") || topicTags
   );

--- a/src/redesign/components/Research.jsx
+++ b/src/redesign/components/Research.jsx
@@ -66,18 +66,18 @@ function ResearchExplorer() {
     (location) =>
       location === extractCountryIdFromPathname() ||
       location.startsWith(extractCountryIdFromPathname() + "-") ||
-      location === "global"
+      location === "global",
   );
 
   const [filteredTopics, setFilteredTopics] = useState(
-    searchParams.get("topics")?.split(",") || topicTags
+    searchParams.get("topics")?.split(",") || topicTags,
   );
   const [filteredLocations, setFilteredLocations] = useState(
-    searchParams.get("locations")?.split(",") || initialLocations
+    searchParams.get("locations")?.split(",") || initialLocations,
   );
 
   const [filteredAuthors, setFilteredAuthors] = useState(
-    searchParams.get("authors")?.split(",") || authorKeys
+    searchParams.get("authors")?.split(",") || authorKeys,
   );
   const filterFunction = (post) => {
     let hasMetAtLeastOneFilteredTopic = false;

--- a/src/redesign/components/Research.jsx
+++ b/src/redesign/components/Research.jsx
@@ -54,14 +54,26 @@ function ResearchExplorer() {
     }
     scrollTo(0, 0);
   };
+
+  const extractCountryIdFromPathname = () => {
+    const pathSegments = window.location.pathname.split("/").filter(Boolean);
+    if (pathSegments.length > 0) {
+      return pathSegments[0];
+    }
+  }
+  const initialLocations = locationTags.filter(
+    (location) => location === extractCountryIdFromPathname() || location === "global"
+  );
+    
   const [filteredTopics, setFilteredTopics] = useState(
-    searchParams.get("topics")?.split(",") || topicTags,
+    searchParams.get("topics")?.split(",") || topicTags
   );
   const [filteredLocations, setFilteredLocations] = useState(
-    searchParams.get("locations")?.split(",") || locationTags,
+    searchParams.get("locations")?.split(",") || initialLocations
   );
+ 
   const [filteredAuthors, setFilteredAuthors] = useState(
-    searchParams.get("authors")?.split(",") || authorKeys,
+    searchParams.get("authors")?.split(",") || authorKeys
   );
   const filterFunction = (post) => {
     let hasMetAtLeastOneFilteredTopic = false;


### PR DESCRIPTION
resolve #825 

Add initialLocations in Research page in order to filter the posts shown by default

This solution filters the initial posts by initialising the `filteredLocations` state with the `const InitialLocations` in order to use the same filters as the home page.

I only used the function `extractCountryIdFromPathname` used in the `useCountryId` hook to extract the country id and not the entire hook since it's not possible to call a hook inside another hook.

For the U.S. the filtered locations include the general _United States_ tag and all individual states tags since all state related posts also include the general tag.

(On a slightly unrelated note, I'm not the most experienced developer and I haven't been contributing to open source for a very long time, so please feel free to let me know if my PRs are not following best practices or to provide feedback on my code if necessary)