### PR TITLE
fix: nested tag a by using stretched link

### DIFF
--- a/src/posts/autumn-statement-2023.md
+++ b/src/posts/autumn-statement-2023.md
@@ -68,9 +68,9 @@ Our estimates exceed those from HM Treasury by about 12%, disproportionately due
 
 | Reform                             | HM Treasury | PolicyEngine | Relative difference | PolicyEngine link                                                                                                           |
 | ---------------------------------- | ----------- | ------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Lower Class 1 NICs from 12% to 10% | 8.72        |  9.69        | 11.2%               | [#28973](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=28973&region=uk&timePeriod=2024&baseline=1) |
-| Lower Class 4 NICs from 9% to 8%   | 0.35        |  0.44        | 26.9%               | [#37642](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=37642&region=uk&timePeriod=2024&baseline=1) |
-| Abolish Class 2 NICs               | 0.38        |  0.41        |  8.8%               | [#37665](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=37665&region=uk&timePeriod=2024&baseline=1) |
+| Lower Class 1 NICs from 12% to 10% | 8.72        | 9.69         | 11.2%               | [#28973](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=28973&region=uk&timePeriod=2024&baseline=1) |
+| Lower Class 4 NICs from 9% to 8%   | 0.35        | 0.44         | 26.9%               | [#37642](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=37642&region=uk&timePeriod=2024&baseline=1) |
+| Abolish Class 2 NICs               | 0.38        | 0.41         | 8.8%                | [#37665](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=37665&region=uk&timePeriod=2024&baseline=1) |
 | Total                              | 9.44        | 10.54        | 11.7%               | [#37636](https://policyengine.org/uk/policy?focus=policyOutput.netIncome&reform=37636&region=uk&timePeriod=2024&baseline=1) |
 
 ### Distributional impacts

--- a/src/redesign/components/EmphasisedLink.jsx
+++ b/src/redesign/components/EmphasisedLink.jsx
@@ -1,6 +1,6 @@
 import FontIcon from "./FontIcon";
 
-export default function EmphasisedLink({ text, url, size }) {
+export default function EmphasisedLink({ text, url, size, isStretched }) {
   const fontSize = size || 15;
   return (
     <a
@@ -12,6 +12,7 @@ export default function EmphasisedLink({ text, url, size }) {
         fontSize,
       }}
       href={url}
+      className={`${isStretched ? "stretched-link" : ""}`}
     >
       {text}
       <FontIcon name="arrow_forward" size={fontSize} />

--- a/src/redesign/components/HomeBlogPreview.jsx
+++ b/src/redesign/components/HomeBlogPreview.jsx
@@ -7,7 +7,6 @@ import moment from "moment";
 import { useState } from "react";
 import useCountryId from "./useCountryId";
 import EmphasisedLink from "./EmphasisedLink";
-import { Link } from "react-router-dom";
 
 export default function HomeBlogPreview() {
   const countryId = useCountryId();
@@ -81,6 +80,9 @@ function ReadMore() {
 }
 
 function DesktopBlogPreview({ featuredPosts, allPosts }) {
+  const rightColumnPosts = allPosts?.slice(0, 4);
+  const firstRowPosts = allPosts?.slice(6, 9);
+
   return (
     <SectionBottom backgroundColor={style.colors.LIGHT_GRAY}>
       <div
@@ -108,15 +110,12 @@ function DesktopBlogPreview({ featuredPosts, allPosts }) {
             justifyContent: "space-between",
             width: "40%",
             marginLeft: 20,
+            gap: 20,
           }}
         >
-          <SmallBlogPreview blog={allPosts[0]} />
-          <div style={{ height: 20 }} />
-          <SmallBlogPreview blog={allPosts[1]} />
-          <div style={{ height: 20 }} />
-          <SmallBlogPreview blog={allPosts[2]} />
-          <div style={{ height: 20 }} />
-          <SmallBlogPreview blog={allPosts[3]} />
+          {rightColumnPosts?.map((post) => (
+            <SmallBlogPreview key={post.slug} blog={post} />
+          ))}
         </div>
       </div>
       <div
@@ -125,13 +124,12 @@ function DesktopBlogPreview({ featuredPosts, allPosts }) {
           flexDirection: "row",
           justifyContent: "space-between",
           marginTop: 40,
+          gap: 40,
         }}
       >
-        <MediumBlogPreview blog={allPosts[6]} />
-        <div style={{ width: 40 }} />
-        <MediumBlogPreview blog={allPosts[7]} />
-        <div style={{ width: 40 }} />
-        <MediumBlogPreview blog={allPosts[8]} />
+        {firstRowPosts?.map((post) => (
+          <MediumBlogPreview key={post.slug} blog={post} />
+        ))}
       </div>
       <ReadMore />
     </SectionBottom>
@@ -249,41 +247,37 @@ function BlogBox({
   bottomRight,
   noBorder,
   style,
-  link,
 }) {
-  link;
   return (
-    <Link to={link}>
+    <div
+      style={{
+        display: "flex",
+        border: noBorder ? null : `1px solid black`,
+        ...style,
+        flexDirection: "row",
+      }}
+    >
+      <div style={{ display: "flex" }}>{left}</div>
       <div
-        style={{
-          display: "flex",
-          border: noBorder ? null : `1px solid black`,
-          ...style,
-          flexDirection: "row",
-        }}
+        style={{ display: "flex", flexDirection: "column", width: "100%" }}
       >
-        <div style={{ display: "flex" }}>{left}</div>
+        <div style={{ display: "flex", justifyContent: "space-between" }}>
+          <div>{topLeft}</div>
+          <div>{topRight}</div>
+        </div>
+        {children}
         <div
-          style={{ display: "flex", flexDirection: "column", width: "100%" }}
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            marginTop: "auto",
+          }}
         >
-          <div style={{ display: "flex", justifyContent: "space-between" }}>
-            <div>{topLeft}</div>
-            <div>{topRight}</div>
-          </div>
-          {children}
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              marginTop: "auto",
-            }}
-          >
-            <div>{bottomLeft}</div>
-            <div>{bottomRight}</div>
-          </div>
+          <div>{bottomLeft}</div>
+          <div>{bottomRight}</div>
         </div>
       </div>
-    </Link>
+    </div>
   );
 }
 
@@ -328,13 +322,19 @@ export function FeaturedBlogPreview({ blogs, width, imageHeight }) {
     ? require("../images/posts/" + currentBlog.image)
     : require("../images/placeholder.png");
   const countryId = useCountryId();
+  const link = `/${countryId}/research/${currentBlog.slug}`;
   return (
     <div
       style={{
         width: width || "100%",
+        border: `1px solid ${style.colors.BLACK}`,
       }}
     >
-      <Link to={`/${countryId}/research/${currentBlog.slug}`}>
+      <div
+        style={{
+          position: "relative",
+        }}
+      >
         <img
           src={imageUrl}
           alt={currentBlog.coverAltText || `{blog.title} cover image`}
@@ -342,23 +342,15 @@ export function FeaturedBlogPreview({ blogs, width, imageHeight }) {
           height={imageHeight || (displayCategory === "desktop" ? 450 : 400)}
           style={{
             objectFit: "cover",
-            border: `1px solid ${style.colors.BLACK}`,
-            borderBottom: "none",
+            borderBottom: `1px solid ${style.colors.BLACK}`,
           }}
         />
-      </Link>
-      <div
-        style={{
-          border: `1px solid ${style.colors.BLACK}`,
-        }}
-      >
         <BlogBox
           noBorder
           topLeft={<BlogTags tags={currentBlog.tags || []} />}
-          link={`/${countryId}/research/${currentBlog.slug}`}
           bottomRight={
             <div style={{ margin: 10 }}>
-              <EmphasisedLink text="Read" url="/" size={14} />
+              <EmphasisedLink text="Read" url={link} size={14} isStretched />
             </div>
           }
           style={{
@@ -374,12 +366,12 @@ export function FeaturedBlogPreview({ blogs, width, imageHeight }) {
             <p>{currentBlog.description}</p>
           </div>
         </BlogBox>
-        <Carousel
-          current={currentBlogIndex}
-          total={blogs.length}
-          setCurrent={setCurrentBlogIndex}
-        />
       </div>
+      <Carousel
+        current={currentBlogIndex}
+        total={blogs.length}
+        setCurrent={setCurrentBlogIndex}
+      />
     </div>
   );
 }
@@ -393,51 +385,50 @@ export function MediumBlogPreview({ blog, minHeight }) {
   const slug = blog.filename.split(".")[0];
   const link = `/${countryId}/research/${slug}`;
   return (
-    <Link to={link} style={{ flex: 1 }}>
-      <div
-        style={{
-          height: "100%",
-        }}
-      >
-        <div>
-          <img
-            src={imageUrl}
-            alt={blog.coverAltText || `{blog.title} cover image`}
-            height={300}
-            width="100%"
-            style={{
-              objectFit: "cover",
-              border: `1px solid ${style.colors.BLACK}`,
-              borderBottom: "none",
-            }}
-          />
-        </div>
-        <BlogBox
-          link={link}
+    <div
+      style={{
+        height: "100%",
+        flex: 1,
+        position: "relative",
+      }}
+    >
+      <div>
+        <img
+          src={imageUrl}
+          alt={blog.coverAltText || `{blog.title} cover image`}
+          height={300}
+          width="100%"
           style={{
-            backgroundColor: blog.tags.includes(["in-the-news"])
-              ? style.colors.BLUE_LIGHT
-              : style.colors.LIGHT_GRAY,
-            minHeight: minHeight || (displayCategory === "mobile" ? 460 : 430),
-            maxHeight: displayCategory === "mobile" ? 400 : null,
+            objectFit: "cover",
+            border: `1px solid ${style.colors.BLACK}`,
+            borderBottom: "none",
           }}
-          topLeft={<BlogTags tags={blog.tags} />}
-          bottomRight={
-            <div style={{ margin: 30 }}>
-              <EmphasisedLink text="Read" url="/" size={14} />
-            </div>
-          }
-        >
-          <div style={{ padding: 20 }}>
-            <p style={{ textTransform: "uppercase", fontFamily: "Roboto" }}>
-              {moment(blog.date).format("MMMM D, YYYY")}
-            </p>
-            <h4>{blog.title}</h4>
-            <p>{blog.description}</p>
-          </div>
-        </BlogBox>
+        />
       </div>
-    </Link>
+      <BlogBox
+        style={{
+          backgroundColor: blog.tags.includes(["in-the-news"])
+            ? style.colors.BLUE_LIGHT
+            : style.colors.LIGHT_GRAY,
+          minHeight: minHeight || (displayCategory === "mobile" ? 460 : 430),
+          maxHeight: displayCategory === "mobile" ? 400 : null,
+        }}
+        topLeft={<BlogTags tags={blog.tags} />}
+        bottomRight={
+          <div style={{ margin: 30 }}>
+            <EmphasisedLink text="Read" url={link} size={14} isStretched />
+          </div>
+        }
+      >
+        <div style={{ padding: 20 }}>
+          <p style={{ textTransform: "uppercase", fontFamily: "Roboto" }}>
+            {moment(blog.date).format("MMMM D, YYYY")}
+          </p>
+          <h4>{blog.title}</h4>
+          <p>{blog.description}</p>
+        </div>
+      </BlogBox>
+    </div>
   );
 }
 
@@ -498,12 +489,12 @@ export function SmallBlogPreview({ blog }) {
   }
 
   const slug = blog.filename.split(".")[0];
+  const link = `/${countryId}/research/${slug}`;
 
   return (
     <BlogBox
       topLeft={topLeft}
       left={left}
-      link={`/${countryId}/research/${slug}`}
       topRight={
         <p
           style={{
@@ -519,7 +510,7 @@ export function SmallBlogPreview({ blog }) {
       }
       bottomRight={
         <div style={{ marginRight: 10, marginBottom: 10 }}>
-          <EmphasisedLink text="Read" url="/" size={14} />
+          <EmphasisedLink text="Read" url={link} size={14} isStretched />
         </div>
       }
       style={{
@@ -527,6 +518,7 @@ export function SmallBlogPreview({ blog }) {
           ? style.colors.BLUE_LIGHT
           : style.colors.LIGHT_GRAY,
         height: "100%",
+        position: "relative",
       }}
     >
       <div

--- a/src/redesign/components/HomeBlogPreview.jsx
+++ b/src/redesign/components/HomeBlogPreview.jsx
@@ -258,9 +258,7 @@ function BlogBox({
       }}
     >
       <div style={{ display: "flex" }}>{left}</div>
-      <div
-        style={{ display: "flex", flexDirection: "column", width: "100%" }}
-      >
+      <div style={{ display: "flex", flexDirection: "column", width: "100%" }}>
         <div style={{ display: "flex", justifyContent: "space-between" }}>
           <div>{topLeft}</div>
           <div>{topRight}</div>


### PR DESCRIPTION
Fixed #768 and fixed #859 . Fix the nested tag <a> warning by using the [stretched link](https://getbootstrap.com/docs/5.3/helpers/stretched-link/). Besides, I've enhanced some posts rendering with `map` function and spacing content with `gap` css property.

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a295817</samp>

### Summary
🆕♻️🖱️

<!--
1.  🆕 - This emoji can be used to indicate the addition of a new feature or prop to the component.
2.  ♻️ - This emoji can be used to indicate the refactoring or improvement of the existing code or logic of the component.
3.  🖱️ - This emoji can be used to indicate the enhancement of the user interface or interaction of the component.
-->
Enhanced the `EmphasisedLink` component to support stretching over its parent element and applied it to the blog preview components on the home page. Simplified the rendering logic of the blog preview components by using array slicing and mapping.

> _Sing, O Muse, of the skillful coder who refined_
> _The blog preview components with a clever mind,_
> _And added a new prop to `EmphasisedLink`, the splendid_
> _To stretch the link and cover its parent, as intended._

### Walkthrough
*  Add `isStretched` prop to `EmphasisedLink` component to create links that fill the space of their parent elements ([link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-7876b4ade9dbad8d7abf9588ed22ee1c1d19b7e3d7b74aa393970007ef486d0fL3-R3), [link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-7876b4ade9dbad8d7abf9588ed22ee1c1d19b7e3d7b74aa393970007ef486d0fR15))
*  Refactor `DesktopBlogPreview` component to use `map` functions and sliced arrays of blog posts to render `SmallBlogPreview` and `MediumBlogPreview` components dynamically ([link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bR83-R85), [link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bL111-R118), [link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bL128-R132))
*  Remove `Link` import and `link` prop from `HomeBlogPreview` and its child components, and use `EmphasisedLink` component with `isStretched` prop instead to create consistent link effects ([link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bL10), [link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bL252-R280), [link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bL331-R337), [link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bL345-R353), [link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bL396-R431), [link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bR492), [link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bL506), [link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bL522-R513))
*  Add border and `position: relative` styles to outer `div` elements of blog preview components to match design and support `stretched-link` class ([link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bL331-R337), [link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bL396-R431), [link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bR521))
*  Move `Carousel` component outside of link area in `FeaturedBlogPreview` component to prevent unwanted interaction ([link](https://github.com/PolicyEngine/policyengine-app/pull/891/files?diff=unified&w=0#diff-4599ae4e53957a839e2b7ecad2d0be20efa1ad187ed873f07877e8c9a3891e5bL377-R374))


