### PR TITLE
Shrink vertical spacing of the bottom text in Reproduce in Python page

### DIFF
--- a/src/layout/ResultsPanel.jsx
+++ b/src/layout/ResultsPanel.jsx
@@ -21,7 +21,11 @@ const ResultsPanel = forwardRef((props, ref) => {
         {props.children}
       </div>
       {/* <div style={{ paddingTop: 0, paddingBottom: 150 }}>{props.children}</div> */}
-      <h5>{props.description}</h5>
+      <h5 style={{
+            paddingTop: mobile ? 5 : 20, 
+            paddingBottom: mobile ? 5 : 40
+            }}>{props.description}
+      </h5>
     </div>
   );
   // }

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -172,7 +172,8 @@ export default function HouseholdReproducibility(props) {
         style={{
           display: "flex",
           justifyContent: "center",
-          paddingTop: 30
+          paddingTop: 30,
+          paddingBottom: 20
         }}
       >
         <Button

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -173,7 +173,7 @@ export default function HouseholdReproducibility(props) {
           display: "flex",
           justifyContent: "center",
           paddingTop: 30,
-          marginBottom: 30,
+          //marginBottom: 30,
         }}
       >
         <Button

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -172,8 +172,7 @@ export default function HouseholdReproducibility(props) {
         style={{
           display: "flex",
           justifyContent: "center",
-          paddingTop: 30,
-          paddingBottom: 20
+          paddingTop: 30
         }}
       >
         <Button

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -172,8 +172,7 @@ export default function HouseholdReproducibility(props) {
         style={{
           display: "flex",
           justifyContent: "center",
-          paddingTop: 30,
-          //marginBottom: 30,
+          paddingTop: 30
         }}
       >
         <Button


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at be218b0</samp>

### Summary
📱🛠️🔥

<!--
1.  📱 - This emoji represents the mobile device and the change that affects the `h5` element based on the `mobile` variable.
2.  🛠️ - This emoji represents the padding adjustment that improves the layout of the `h5` element on different screen sizes.
3.  🔥 - This emoji represents the removal of the unnecessary `marginBottom` property that creates extra space at the bottom of the page.
-->
Improved the layout and spacing of the results panel on different devices. Removed unnecessary margin from the `HouseholdReproducibility` component that uses the results panel.

> _`h5` gets padding_
> _results panel looks better_
> _no more `marginBottom`_

### Walkthrough
*  Add padding to the results panel description to improve layout on different screen sizes ([link](https://github.com/PolicyEngine/policyengine-app/pull/901/files?diff=unified&w=0#diff-81eca4ebc9235127e803c4dfa8d48afb99b24d5c7a75051db308bfdf9cc22fd1L24-R28))
*  Remove extra margin at the bottom of the results panel in `HouseholdReproducibility` component ([link](https://github.com/PolicyEngine/policyengine-app/pull/901/files?diff=unified&w=0#diff-27695a8486f76672e2544cc7d9e8cb5f4548260da07d6954330c2c605fdca50dL176-R176))


Hi, I am new to OS so I tried this simple issue, I hope it helps.
Fixes #897 .
I made some small adjustment to the ResultsPanel.jsx file on line 24 and to the HouseholdReproducibility.jsx file on line 176 by changing the style. 
It seems to display less space between the copy button and the text below. 
Let me know if it needs to be modified further.
