### PR TITLE
Fix width of switch element

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -242,9 +242,6 @@ function HouseholdVariableEntityInput(props) {
   } else if (variable.valueType === "bool") {
     control = (
       <Switch
-        style={{
-          width: mobile ? 150 : 200,
-        }}
         checked={defaultValue}
         checkedChildren="Yes"
         unCheckedChildren="No"


### PR DESCRIPTION
Fixes #930. This bug was introduced in #892 by (incorrectly) assigning the same style to the switch, select, and input number components. The error should have been caught with more testing in #892.

copilot:all
