### PR TITLE
Fix y-axis format issues in charts such as the UK NI LEL parameter chart

### DIFF
--- a/src/__tests__/MarginalTaxRates.test.js
+++ b/src/__tests__/MarginalTaxRates.test.js
@@ -64,7 +64,7 @@ describe("Test Render Output", () => {
     );
     expect(
       screen.getByText(
-        "This chart shows how your net income changes under different earnings. It is based on your household's current situation.",
+        "This chart shows how your marginal tax rate changes under different earnings. It is based on your household's current situation.",
       ),
     ).toBeTruthy();
   });

--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -217,19 +217,19 @@ export function formatVariableValue(variable, value, precision = 2) {
   }
 }
 
-export function getPlotlyAxisFormat(
-  unit,
-  values,
-  precisionOverride,
-  valueType,
-) {
+export function getPlotlyAxisFormat(unit, values, precisionOverride) {
   // Possible units: currency-GBP, currency-USD, currency-CAD, currency-ILS,
   // currency-NGN, /1, date
 
   const range = () => {
-    return values
-      ? [Math.min(0, ...values) * 1.5, Math.max(0, ...values) * 1.5]
-      : [0, 0];
+    return values ? [Math.min(0, ...values), Math.max(0, ...values)] : [0, 0];
+  };
+
+  const paddedRange = () => {
+    const r = range();
+    const d = r[1] - r[0];
+    const p = d * 0.1;
+    return [r[0] - p, r[1] + p];
   };
 
   const precision = () => {
@@ -237,10 +237,9 @@ export function getPlotlyAxisFormat(
       return precisionOverride;
     }
     const r = range();
-    const d = r[1] - r[0];
     const s = unit === "/1" ? 100 : 1;
-    const n = d === 0 ? 0 : 1 - Math.round(Math.log(d * s));
-    return Math.max(0, n);
+    const d = (r[1] - r[0]) * s;
+    return d > 10 ? 0 : d === 0 ? 1 : 1 - Math.round(Math.log10(d));
   };
 
   if (Object.keys(currencyMap).includes(unit)) {
@@ -248,14 +247,14 @@ export function getPlotlyAxisFormat(
       tickformat: `,.${precision()}f`,
       tickprefix: currencyMap[unit],
       ...(values && {
-        range: range(),
+        range: paddedRange(),
       }),
     };
   } else if (unit === "/1") {
     return {
       tickformat: `,.${precision()}%`,
       ...(values && {
-        range: range(),
+        range: paddedRange(),
       }),
     };
   } else if (unit === "date") {
@@ -277,10 +276,10 @@ export function getPlotlyAxisFormat(
     return {
       range: [minYear - 5 + "-01-01", maxYear + 5 + "-12-31"],
     };
-  } else if (valueType === "bool") {
+  } else if (unit === "bool" || unit === "abolition") {
     return {
       tickvals: [0, 1],
-      ticktext: ["No", "Yes"],
+      ticktext: ["False", "True"],
     };
   }
 }

--- a/src/layout/forms/FormContext.jsx
+++ b/src/layout/forms/FormContext.jsx
@@ -113,7 +113,7 @@ export default function FormContext(props) {
         style={{
           position: "relative",
           width: "100%",
-          height: "2em"
+          height: "2em",
         }}
       >
         <p
@@ -124,7 +124,7 @@ export default function FormContext(props) {
             top: 0,
             left: 0,
             wordWrap: "normal",
-            width: "100%"
+            width: "100%",
           }}
         >
           {submitMsg || <br />}

--- a/src/pages/household/output/EarningsVariation.jsx
+++ b/src/pages/household/output/EarningsVariation.jsx
@@ -177,8 +177,8 @@ export default function EarningsVariation(props) {
 
   return (
     <ResultsPanel
-      title="How your net income changes with your earnings"
-      description="This chart shows how your net income changes under different earnings. It is based on your household's current situation."
+      title={`How your ${variableLabel} changes with your earnings`}
+      description={`This chart shows how your ${variableLabel} changes under different earnings. It is based on your household's current situation.`}
     >
       {loading ? (
         <div style={{ height: 300 }}>

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -148,16 +148,32 @@ function BaselineAndReformTogetherPlot(props) {
     baselineValue,
     useHoverCard = false,
   } = props;
-  let data = [
-    ...(variable === "household_net_income"
+  const cliffs1 =
+    variable === "household_net_income"
       ? getCliffs(baselineArray, earningsArray, false, "$", useHoverCard)
-      : []),
-    ...(variable === "household_net_income"
+      : [];
+  const cliffs2 =
+    variable === "household_net_income"
       ? getCliffs(reformArray, earningsArray, true, "$", useHoverCard)
-      : []),
+      : [];
+  const x1 = cliffs1.reduce((p, cliff) => p.concat(cliff.x), []);
+  const y1 = cliffs1.reduce((p, cliff) => p.concat(cliff.y), []);
+  const x2 = cliffs2.reduce((p, cliff) => p.concat(cliff.x), []);
+  const y2 = cliffs2.reduce((p, cliff) => p.concat(cliff.y), []);
+  const x3 = earningsArray;
+  const y3 = baselineArray;
+  const y4 = reformArray;
+  const x4 = [currentEarnings];
+  const y5 = [currentValue];
+  const y6 = [baselineValue];
+  const xaxisValues = x1.concat(x2, x3, x4);
+  const yaxisValues = y1.concat(y2, y3, y4, y5, y6);
+  let data = [
+    ...cliffs1,
+    ...cliffs2,
     {
-      x: earningsArray,
-      y: baselineArray,
+      x: x3,
+      y: y3,
       type: "line",
       name: `Baseline ${variableLabel}`,
       line: {
@@ -176,8 +192,8 @@ function BaselineAndReformTogetherPlot(props) {
           }),
     },
     {
-      x: earningsArray,
-      y: reformArray,
+      x: x3,
+      y: y4,
       type: "line",
       name: `Reform ${variableLabel}`,
       line: {
@@ -196,8 +212,8 @@ function BaselineAndReformTogetherPlot(props) {
           }),
     },
     {
-      x: [currentEarnings],
-      y: [currentValue],
+      x: x4,
+      y: y5,
       type: "scatter",
       mode: "markers",
       name: `Your reform ${variableLabel}`,
@@ -217,8 +233,8 @@ function BaselineAndReformTogetherPlot(props) {
           }),
     },
     {
-      x: [currentEarnings],
-      y: [baselineValue],
+      x: x4,
+      y: y6,
       type: "scatter",
       mode: "markers",
       name: `Your baseline ${variableLabel}`,
@@ -248,18 +264,16 @@ function BaselineAndReformTogetherPlot(props) {
             title: "Household head employment income",
             ...getPlotlyAxisFormat(
               metadata.variables.employment_income.unit,
-              0,
+              xaxisValues,
             ),
-            tickformat: ",.0f",
             uirevision: metadata.variables.employment_income.unit,
           },
           yaxis: {
             title: capitalize(variableLabel),
             ...getPlotlyAxisFormat(
-              metadata.variables.household_net_income.unit,
-              0,
+              metadata.variables[variable].unit,
+              yaxisValues,
             ),
-            tickformat: ",.0f",
             uirevision: metadata.variables.household_net_income.unit,
           },
           ...(useHoverCard
@@ -359,10 +373,16 @@ function BaselineReformDeltaPlot(props) {
     variable,
     useHoverCard = false,
   } = props;
+  const x1 = earningsArray;
+  const y1 = reformArray.map((value, index) => value - baselineArray[index]);
+  const x2 = [currentEarnings];
+  const y2 = [currentValue - baselineValue];
+  const xaxisValues = x1.concat(x2);
+  const yaxisValues = y1.concat(y2);
   let data = [
     {
-      x: earningsArray,
-      y: reformArray.map((value, index) => value - baselineArray[index]),
+      x: x1,
+      y: y1,
       type: "line",
       name: `Change in ${variableLabel}`,
       line: {
@@ -381,8 +401,8 @@ function BaselineReformDeltaPlot(props) {
           }),
     },
     {
-      x: [currentEarnings],
-      y: [currentValue - baselineValue],
+      x: x2,
+      y: y2,
       type: "scatter",
       mode: "markers",
       name: `Your current change in ${variableLabel}`,
@@ -414,20 +434,16 @@ function BaselineReformDeltaPlot(props) {
             title: "Household head employment income",
             ...getPlotlyAxisFormat(
               metadata.variables.employment_income.unit,
-              0,
+              xaxisValues,
             ),
-            tickformat: ",.0f",
             uirevision: metadata.variables.employment_income.unit,
           },
           yaxis: {
             title: `Change in ${variableLabel}`,
             ...getPlotlyAxisFormat(
               metadata.variables[variable].unit,
-              0,
-              null,
-              metadata.variables[variable].valueType,
+              yaxisValues,
             ),
-            tickformat: ",.0f",
             uirevision: metadata.variables[variable].unit,
           },
           ...(useHoverCard

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -128,6 +128,12 @@ export default function MarginalTaxRates(props) {
       baselineMtr,
       metadata,
     );
+    const x1 = earningsArray;
+    const y1 = mtrArray;
+    const x2 = [currentEarnings];
+    const y2 = [currentMtr];
+    const xaxisValues = x1.concat(x2);
+    const yaxisValues = y1.concat(y2);
     title = `Your current marginal tax rate is ${formatVariableValue(
       { unit: "/1" },
       currentMtr,
@@ -140,8 +146,8 @@ export default function MarginalTaxRates(props) {
           <Plot
             data={[
               {
-                x: earningsArray,
-                y: mtrArray,
+                x: x1,
+                y: y1,
                 type: "line",
                 name: "Marginal tax rate",
                 line: {
@@ -155,8 +161,8 @@ export default function MarginalTaxRates(props) {
                   `<extra></extra>`,
               },
               {
-                x: [currentEarnings],
-                y: [currentMtr],
+                x: x2,
+                y: y2,
                 type: "scatter",
                 name: "Your current MTR",
                 mode: "markers",
@@ -175,8 +181,8 @@ export default function MarginalTaxRates(props) {
                 title: "Household head employment income",
                 ...getPlotlyAxisFormat(
                   metadata.variables.employment_income.unit,
+                  xaxisValues,
                 ),
-                tickformat: ",.0f",
               },
               margin: {
                 t: 0,
@@ -185,8 +191,8 @@ export default function MarginalTaxRates(props) {
                 title: "Marginal tax rate",
                 ...getPlotlyAxisFormat(
                   metadata.variables.marginal_tax_rate.unit,
+                  yaxisValues,
                 ),
-                tickformat: ".1%",
               },
               hoverlabel: {
                 align: "left",
@@ -255,14 +261,20 @@ export default function MarginalTaxRates(props) {
       title = `${policyLabel} doesn't change your marginal tax rate`;
     }
     // Add the main line, then add a 'you are here' points
-    let data;
+    let data, xaxisValues, yaxisValues;
     if (showDelta) {
+      const x1 = earningsArray;
+      const y1 = reformMtrArray.map(
+        (value, index) => value - baselineMtrArray[index],
+      );
+      const x2 = [currentEarnings];
+      const y2 = [reformMtrValue - currentMtr];
+      xaxisValues = x1.concat(x2);
+      yaxisValues = y1.concat(y2);
       data = [
         {
-          x: earningsArray,
-          y: reformMtrArray.map(
-            (value, index) => value - baselineMtrArray[index],
-          ),
+          x: x1,
+          y: y1,
           type: "line",
           name: "MTR difference",
           line: {
@@ -276,8 +288,8 @@ export default function MarginalTaxRates(props) {
             `<extra></extra>`,
         },
         {
-          x: [currentEarnings],
-          y: [reformMtrValue - currentMtr],
+          x: x2,
+          y: y2,
           type: "scatter",
           name: "Your current MTR difference",
           mode: "markers",
@@ -292,10 +304,18 @@ export default function MarginalTaxRates(props) {
         },
       ];
     } else {
+      const x1 = earningsArray;
+      const y1 = reformMtrArray;
+      const y2 = baselineMtrArray;
+      const x2 = [currentEarnings];
+      const y3 = [currentMtr];
+      const y4 = [reformMtrValue];
+      xaxisValues = x1.concat(x2);
+      yaxisValues = y1.concat(y2, y3, y4);
       data = [
         {
-          x: earningsArray,
-          y: reformMtrArray,
+          x: x1,
+          y: y1,
           type: "line",
           name: "Reform MTR",
           line: {
@@ -309,8 +329,8 @@ export default function MarginalTaxRates(props) {
             `<extra></extra>`,
         },
         {
-          x: earningsArray,
-          y: baselineMtrArray,
+          x: x1,
+          y: y2,
           type: "line",
           name: "Baseline MTR",
           line: {
@@ -324,8 +344,8 @@ export default function MarginalTaxRates(props) {
             `<extra></extra>`,
         },
         {
-          x: [currentEarnings],
-          y: [currentMtr],
+          x: x2,
+          y: y3,
           type: "scatter",
           name: "Your baseline MTR",
           mode: "markers",
@@ -339,8 +359,8 @@ export default function MarginalTaxRates(props) {
             `<extra></extra>`,
         },
         {
-          x: [currentEarnings],
-          y: [reformMtrValue],
+          x: x2,
+          y: y4,
           type: "scatter",
           name: "Your reform MTR",
           mode: "markers",
@@ -366,7 +386,6 @@ export default function MarginalTaxRates(props) {
       },
     ];
     const onDelta = ({ target: { value } }) => {
-      console.log("checked", value);
       setShowDelta(value);
     };
     plot = (
@@ -393,17 +412,15 @@ export default function MarginalTaxRates(props) {
                 title: "Household head employment income",
                 ...getPlotlyAxisFormat(
                   metadata.variables.employment_income.unit,
-                  0,
+                  xaxisValues,
                 ),
-                tickformat: ",.0f",
               },
               yaxis: {
                 title: (showDelta ? "Change in m" : "M") + "arginal tax rate",
                 ...getPlotlyAxisFormat(
                   metadata.variables.marginal_tax_rate.unit,
-                  0,
+                  yaxisValues,
                 ),
-                tickformat: (showDelta ? "+" : "") + ".0%",
               },
               hoverlabel: {
                 align: "left",

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -454,7 +454,7 @@ export default function MarginalTaxRates(props) {
   return (
     <ResultsPanel
       title={title}
-      description="This chart shows how your net income changes under different earnings. It is based on your household's current situation."
+      description="This chart shows how your marginal tax rate changes under different earnings. It is based on your household's current situation."
     >
       {loading ? (
         <div style={{ height: 300 }}>

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -23,12 +23,16 @@ export default function ParameterOverTime(props) {
       return obj;
     }, {});
 
+  // Extend the last value to 2099 so that the line appears to extend to +inf in
+  // the chart
+  const extendForDisplay = (x, y) => {
+    x.push("2099-12-31");
+    y.push(y[y.length - 1]);
+  };
+
   let x = Object.keys(values);
   let y = Object.values(values);
-  // Extend the last value to 2099.
-  x.push("2099-12-31");
-  y.push(y[y.length - 1]);
-
+  extendForDisplay(x, y);
   let reformedX;
   let reformedY;
 
@@ -39,8 +43,7 @@ export default function ParameterOverTime(props) {
     ).values;
     reformedX = Object.keys(reformedValues);
     reformedY = Object.values(reformedValues);
-    reformedX.push("2099-12-31");
-    reformedY.push(reformedY[reformedY.length - 1]);
+    extendForDisplay(reformedX, reformedY);
   }
 
   let xForRange = reformedX ? x.concat(reformedX) : x;

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -46,20 +46,11 @@ export default function ParameterOverTime(props) {
     extendForDisplay(reformedX, reformedY);
   }
 
-  let xForRange = reformedX ? x.concat(reformedX) : x;
-  xForRange = xForRange.filter((e) => e !== "0000-01-01" && e !== "2099-12-31");
-  let xAxisFormat = getPlotlyAxisFormat("date", xForRange);
-  let yAxisFormat = getPlotlyAxisFormat(
-    parameter.unit,
-    reformedY ? y.concat(reformedY) : y,
+  let xaxisValues = reformedX ? x.concat(reformedX) : x;
+  xaxisValues = xaxisValues.filter(
+    (e) => e !== "0000-01-01" && e !== "2099-12-31",
   );
-  let yAxisTickVals;
-  let yAxisTickLabels;
-  if (parameter.unit === "bool" || parameter.unit === "abolition") {
-    yAxisFormat = null;
-    yAxisTickVals = [0, 1];
-    yAxisTickLabels = ["False", "True"];
-  }
+  const yaxisValues = reformedY ? y.concat(reformedY) : y;
 
   return (
     <>
@@ -94,12 +85,8 @@ export default function ParameterOverTime(props) {
           .reverse()
           .filter((x) => x)}
         layout={{
-          xaxis: xAxisFormat,
-          yaxis: {
-            ...yAxisFormat,
-            tickvals: yAxisTickVals || null,
-            ticktext: yAxisTickLabels || null,
-          },
+          xaxis: getPlotlyAxisFormat("date", xaxisValues),
+          yaxis: getPlotlyAxisFormat(parameter.unit, yaxisValues),
           legend: {
             // Position above the plot
             y: 1.1,


### PR DESCRIPTION
## Description

Fixed #854 by changing the calculation of the axis format in `getPlotlyAxisFormat`. This pull request also has implications for #425 and #66: the format issues for MTR should go away and the range of the y-axis should rarely exceed 100%.

## Method for fix

* Change `getPlotlyAxisFormat`
  * Remove unnecessary arguments.
  * Calculate the number of fractional digits to be displayed in a more sophisticated manner.
* Display the variable label in `EarningsVariation` chart's title and description.
* Fix the `MarginalTaxRates` description.
* In `EarningsVariation` and `MarginalTaxRates` charts,
  * Do not forcibly set precision using `tickformat`.
  * Instead depend on passing all `x` and `y` values to `getPlotlyAxisFormat`.

## Tests

I have checked that the axes in `EarningsVariation`, `MarginalTaxRates`, and `ParameterOverTime` charts are displayed properly.

<img width="755" alt="Screenshot 2023-12-07 at 9 09 18 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/2e2a7816-5e93-40a3-b13c-c50b274c4cd3">

<img width="785" alt="Screenshot 2023-12-07 at 9 11 34 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/0b978c9b-790f-4f1b-9381-ebe6209f3e08">

<img width="750" alt="Screenshot 2023-12-07 at 9 16 47 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/df57e5e7-5fba-42aa-a166-104069495a19">

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 53c7ce3</samp>

### Summary
📊💰🧹

<!--
1.  📊 - This emoji represents the changes related to the plotly charts and axes, as well as the dynamic title and description of the `ResultsPanel` component. It conveys the idea of data visualization and analysis.
2.  💰 - This emoji represents the changes related to the currency units and formatting, as well as the marginal tax rate chart. It conveys the idea of money and taxation.
3.  🧹 - This emoji represents the changes related to the refactoring and simplification of the code, as well as the trailing commas. It conveys the idea of cleaning and tidying up the code.
-->
This pull request improves the data formatting and presentation of various plotly charts in the app. It refactors the code to use a common function `getPlotlyAxisFormat` for determining the best axis format for different types of variables. It also makes some minor style and naming changes, and makes the `ResultsPanel` component more flexible for different variables.

> _The `ResultsPanel` got a makeover_
> _With dynamic titles and axes to show for_
> _The data was refactored_
> _The style was adapted_
> _And the code became cleaner and lower_

### Walkthrough
*  Refactor `getPlotlyAxisFormat` function to handle different currency units, precision, and range based on the values passed as an argument, and to handle boolean or binary variables ([link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-b5951a72ed1475216756f45c9a54ea34fb15cce384284eb48b32a30c5c0bf58bL220-R257), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-b5951a72ed1475216756f45c9a54ea34fb15cce384284eb48b32a30c5c0bf58bL295-R282))
* Replace hardcoded or fixed values with dynamic values based on the `variableLabel` prop, the `xaxisValues` and `yaxisValues` arrays, and the `getPlotlyAxisFormat` function calls in the `ResultsPanel` and chart components for earnings variation, marginal tax rates, and parameter over time ([link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-31d25016a1cb4e96f8c2752f8f09fff24d1917b85c379be5008c6dd494596efaL180-R181), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL151-R176), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL179-R196), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL199-R216), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL220-R237), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL251-R268), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL259-R276), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL362-R385), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL384-R405), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL417-R438), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-2d2999e2b861d5ecd207303d30de01038af3b1635fca08bdd0d821159476f39bL426-R446), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98R62-R74), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98L69-R85), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98L99-R105), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98L125-R131), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98L135-R141), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9R131-R136), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L143-R150), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L158-R165), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L178-R185), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L188-R195), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L258-R277), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L279-R292), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L295-R318), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L312-R333), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L327-R348), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L342-R363), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L396-R416), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L404-R423), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L440-R457), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-b668174e6bcd7b963e980d1a5951bb5209b5fc87dfa52c8dfe35588442c77691L26-R35), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-b668174e6bcd7b963e980d1a5951bb5209b5fc87dfa52c8dfe35588442c77691L42-R53), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-b668174e6bcd7b963e980d1a5951bb5209b5fc87dfa52c8dfe35588442c77691L94-R89))
* Rename variables to reflect the actual data they contain and to be consistent with the other components in the `BaselineOnlyChart`, `MarginalTaxRates`, and `ParameterOverTime` components ([link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98L35-R35), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-7b9bb2a68257e29011e5df68ce37c70dd3747090a38aeef8e27570c7eccdfc98L50-R50), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-43f598ac8f8928c8be5adb376f0f5e8d25a5f61fb6dea523f1157c84d2517ed9L369), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-b668174e6bcd7b963e980d1a5951bb5209b5fc87dfa52c8dfe35588442c77691L42-R53))
* Add trailing commas to the style objects for the `FormHelperText` and `Typography` components, to follow the code style convention and improve readability ([link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-0b81874428a27ccaf5252b5162021f2e5cb92ef0dd9b47834bbcfab1eac56ed6L116-R116), [link](https://github.com/PolicyEngine/policyengine-app/pull/939/files?diff=unified&w=0#diff-0b81874428a27ccaf5252b5162021f2e5cb92ef0dd9b47834bbcfab1eac56ed6L127-R127))


