### PR TITLE
Format currency input with commas in household input

### DIFF
--- a/src/api/language.js
+++ b/src/api/language.js
@@ -48,14 +48,13 @@ export function cardinal(number) {
   return number + (suffixes[(rem - 20) % 10] || suffixes[rem] || suffixes[0]);
 }
 
-export function currencyString(number, metadata, maximumFractionDigits) {
-  return number.toLocaleString("en-US", {
-    style: "currency",
-    currency: metadata.countryId === "uk" ? "GBP" : "USD",
-    maximumFractionDigits: maximumFractionDigits,
-  });
+// returns the Unicode locale identifier for the country id in the metadata
+export function localeCode(countryId) {
+  return countryId === "uk" ? "en-GB" : "en-US";
 }
 
-export function localeString(metadata) {
-  return metadata.countryId === "uk" ? "en" : "en-US";
+// returns the ISO 4217 currency codes for the currency for the country id in
+// the metadata
+export function currencyCode(countryId) {
+  return countryId === "uk" ? "GBP" : "USD";
 }

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -1,5 +1,5 @@
 import { useSearchParams } from "react-router-dom";
-import { capitalize } from "../../../api/language";
+import { capitalize, localeCode } from "../../../api/language";
 import {
   currencyMap,
   getNewHouseholdId,
@@ -232,7 +232,11 @@ function HouseholdVariableEntityInput(props) {
           width: mobile ? 150 : 200,
         }}
         addonBefore={isCurrency ? currencyMap[variable.unit] : undefined}
-        min={isCurrency ? 0 : undefined}
+        formatter={
+          isCurrency
+            ? (value) => (+value).toLocaleString(localeCode(metadata.countryId))
+            : undefined
+        }
         precision={variable.valueType === "float" ? 2 : undefined}
         defaultValue={defaultValue}
         autoFocus={true}

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -223,6 +223,7 @@ function HouseholdVariableEntityInput(props) {
     }
   }
   const mobile = useMobile();
+  const precision = 2;
   let control;
   if (variable.valueType === "float" || variable.valueType === "int") {
     const isCurrency = Object.keys(currencyMap).includes(variable.unit);
@@ -231,15 +232,18 @@ function HouseholdVariableEntityInput(props) {
         style={{
           width: mobile ? 150 : 200,
         }}
-        addonBefore={isCurrency ? currencyMap[variable.unit] : undefined}
-        formatter={
-          isCurrency
-            ? (value) => (+value).toLocaleString(localeCode(metadata.countryId))
-            : undefined
-        }
-        precision={variable.valueType === "float" ? 2 : undefined}
+        {...(isCurrency
+          ? {
+              addonBefore: currencyMap[variable.unit],
+              formatter: (value) =>
+                (+value).toLocaleString(localeCode(metadata.countryId), {
+                  maximumFractionDigits: precision,
+                }),
+            }
+          : {})}
+        {...(variable.valueType === "float" ? { precision: precision } : {})}
         defaultValue={defaultValue}
-        autoFocus={true}
+        autoFocus
         onChange={submitValue}
       />
     );

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -238,13 +238,13 @@ function HouseholdVariableEntityInput(props) {
           : {})}
         {...(variable.valueType === "float"
           ? {
-              formatter: (value) =>
+              formatter: (value, {userTyping}) =>
                 (+value).toLocaleString(localeCode(metadata.countryId), {
-                  maximumFractionDigits: 16,
+                  minimumFractionDigits: !userTyping && 2,
+                  maximumFractionDigits: 2,
                 }),
             }
           : {})}
-        precision={2}
         defaultValue={defaultValue}
         autoFocus
         onChange={submitValue}

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -240,10 +240,11 @@ function HouseholdVariableEntityInput(props) {
           ? {
               formatter: (value) =>
                 (+value).toLocaleString(localeCode(metadata.countryId), {
-                  maximumFractionDigits: 2,
+                  maximumFractionDigits: 16,
                 }),
             }
           : {})}
+        precision={2}
         defaultValue={defaultValue}
         autoFocus
         onChange={submitValue}

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -223,7 +223,6 @@ function HouseholdVariableEntityInput(props) {
     }
   }
   const mobile = useMobile();
-  const precision = 2;
   let control;
   if (variable.valueType === "float" || variable.valueType === "int") {
     const isCurrency = Object.keys(currencyMap).includes(variable.unit);
@@ -235,13 +234,16 @@ function HouseholdVariableEntityInput(props) {
         {...(isCurrency
           ? {
               addonBefore: currencyMap[variable.unit],
+            }
+          : {})}
+        {...(variable.valueType === "float"
+          ? {
               formatter: (value) =>
                 (+value).toLocaleString(localeCode(metadata.countryId), {
-                  maximumFractionDigits: precision,
+                  maximumFractionDigits: 2,
                 }),
             }
           : {})}
-        {...(variable.valueType === "float" ? { precision: precision } : {})}
         defaultValue={defaultValue}
         autoFocus
         onChange={submitValue}

--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
-import { cardinal, currencyString, localeString } from "../../../api/language";
+import { cardinal, localeCode, currencyCode } from "../../../api/language";
 import { formatVariableValue } from "../../../api/variables";
 import HoverCard, { HoverCardContext } from "../../../layout/HoverCard";
 import useMobile from "../../../layout/Responsive";
@@ -33,7 +33,13 @@ export default function AverageImpactByDecile(props) {
                 value < 0 ? style.colors.DARK_GRAY : style.colors.BLUE,
               ),
             },
-            text: yArray.map((value) => currencyString(value, metadata, 0)),
+            text: yArray.map((value) =>
+              value.toLocaleString(localeCode(metadata.countryId), {
+                style: "currency",
+                currency: currencyCode(metadata.countryId),
+                maximumFractionDigits: 0,
+              }),
+            ),
             textangle: 0,
             ...(useHoverCard
               ? {
@@ -102,7 +108,7 @@ export default function AverageImpactByDecile(props) {
         config={{
           displayModeBar: false,
           responsive: true,
-          locale: localeString(metadata),
+          locale: localeCode(metadata.countryId),
         }}
         style={{
           width: "100%",

--- a/src/pages/policy/output/AverageImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByWealthDecile.jsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
-import { cardinal, currencyString, localeString } from "../../../api/language";
+import { cardinal, localeCode, currencyCode } from "../../../api/language";
 import { formatVariableValue } from "../../../api/variables";
 import HoverCard, { HoverCardContext } from "../../../layout/HoverCard";
 import useMobile from "../../../layout/Responsive";
@@ -33,7 +33,13 @@ export default function AverageImpactByWealthDecile(props) {
                 value < 0 ? style.colors.DARK_GRAY : style.colors.BLUE,
               ),
             },
-            text: yArray.map((value) => currencyString(value, metadata, 0)),
+            text: yArray.map((value) =>
+              value.toLocaleString(localeCode(metadata.countryId), {
+                style: "currency",
+                currency: currencyCode(metadata.countryId),
+                maximumFractionDigits: 0,
+              }),
+            ),
             textangle: 0,
             ...(useHoverCard
               ? {
@@ -102,7 +108,7 @@ export default function AverageImpactByWealthDecile(props) {
         config={{
           displayModeBar: false,
           responsive: true,
-          locale: localeString(metadata),
+          locale: localeCode(metadata.countryId),
         }}
         style={{
           width: "100%",

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
-import { aggregateCurrency, localeString } from "../../../api/language";
+import { aggregateCurrency, localeCode } from "../../../api/language";
 import HoverCard, { HoverCardContext } from "../../../layout/HoverCard";
 import useMobile from "../../../layout/Responsive";
 import DownloadableScreenshottable from "./DownloadableScreenshottable";
@@ -156,7 +156,7 @@ export default function BudgetaryImpact(props) {
         config={{
           displayModeBar: false,
           responsive: true,
-          locale: localeString(metadata),
+          locale: localeCode(metadata.countryId),
         }}
         style={{
           width: "100%",

--- a/src/pages/policy/output/DetailedBudgetaryImpact.jsx
+++ b/src/pages/policy/output/DetailedBudgetaryImpact.jsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
-import { aggregateCurrency, localeString } from "../../../api/language";
+import { aggregateCurrency, localeCode } from "../../../api/language";
 import HoverCard, { HoverCardContext } from "../../../layout/HoverCard";
 import useMobile from "../../../layout/Responsive";
 import Screenshottable from "../../../layout/Screenshottable";
@@ -129,7 +129,7 @@ export default function DetailedBudgetaryImpact(props) {
         config={{
           displayModeBar: false,
           responsive: true,
-          locale: localeString(metadata),
+          locale: localeCode(metadata.countryId),
         }}
         style={{
           width: "100%",

--- a/src/plotly_locales/locale-en-gb.js
+++ b/src/plotly_locales/locale-en-gb.js
@@ -4,7 +4,7 @@
 
 module.exports = {
   moduleType: "locale",
-  name: "en",
+  name: "en-GB",
   dictionary: {
     "Click to enter Colorscale title": "Click to enter Colourscale title",
   },

--- a/src/redesign/components/PolicyEngine.jsx
+++ b/src/redesign/components/PolicyEngine.jsx
@@ -20,7 +20,7 @@ import Header from "./Header";
 import Testimonials from "./Testimonials";
 import CalculatorInterstitial from "./CalculatorInterstitial";
 import CitizensEconomicCouncil from "./CitizensEconomicCouncil";
-import loc_en from "../../plotly_locales/locale-en.js";
+import loc_en_gb from "../../plotly_locales/locale-en-gb.js";
 import loc_en_us from "../../plotly_locales/locale-en-us.js";
 import APIDocumentationPage from "./APIDocumentationPage";
 import CookieConsent from "layout/CookieConsent";
@@ -40,7 +40,7 @@ function ScrollToTop() {
 
 export default function PolicyEngine({ pathname }) {
   var Plotly = require("plotly.js/dist/plotly.js");
-  Plotly.register(loc_en);
+  Plotly.register(loc_en_gb);
   Plotly.register(loc_en_us);
   const COUNTRIES = ["us", "uk", "ca", "ng", "il"];
 


### PR DESCRIPTION
Fixed #178 by using the formatter property in ant-design InputNumber component. Renamed locale en to en-GB, the standard Unicode identifier for the English language in the UK region (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale for details). Improved the interface for locale-related functions with better names and documentation.

Tested in UK and US locales to verify that currencies are displayed properly in inputs and charts.
<img width="720" alt="Screenshot 2023-12-07 at 11 41 45 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/c46c4a55-ac76-4019-bc90-fde9021d27b3">

<img width="759" alt="Screenshot 2023-12-07 at 11 44 44 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/40cd10c7-79d3-4d5f-a347-ee372e8f6262">


<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 63f4416</samp>

### Summary
🌐💷📊

<!--
1.  🌐 - This emoji represents the concept of localization and internationalization, which is the main theme of the pull request.
2. 💷 - This emoji represents the currency symbol for the British pound, which is one of the currencies affected by the pull request.
3. 📊 - This emoji represents the charts and graphs that are improved by the pull request.
-->
This pull request improves the localization of currency values and plotly charts in the policy engine app. It introduces two new functions, `localeCode` and `currencyCode`, to get the appropriate codes for a given country. It also updates the `VariableEditor` component and the output charts to use these functions and the native `toLocaleString` method of numbers. It also renames and updates the UK English plotly locale module.

> _Oh, we're the jolly coders of the policy engine_
> _We format currencies and locales with ease_
> _We use `localeCode` and `currencyCode` to make it clean_
> _And we heave away on the pull request with a breeze_

### Walkthrough
*  Replace `currencyString` and `localeString` functions with `localeCode` and `currencyCode` functions in `src/api/language.js` to return locale and currency codes for a given country id ([link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-77a1d7924c7e86c45476b6d602f1891a692c24c0f5d85a55f3b7df008d6803b3L51-R59))
  - In `src/pages/household/input/VariableEditor.jsx`, update the `formatter` prop of the `InputNumber` component in the `HouseholdVariableEntityInput` function ([link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L2-R2), [link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L235-R239))
  - In `src/pages/policy/output/AverageImpactByDecile.jsx`, update the `text` prop of the `bar` trace in the `AverageImpactByDecilePlot` function ([link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L4-R4), [link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L36-R42))
  - In `src/pages/policy/output/AverageImpactByWealthDecile.jsx`, update the `text` prop of the `bar` trace in the `AverageImpactByWealthDecilePlot` function ([link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aL4-R4), [link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aL36-R42))
  - In `src/pages/policy/output/AverageImpactByDecile.jsx`, update the `locale` prop of the `Plot` component in the `AverageImpactByDecilePlot` function ([link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L105-R111))
  - In `src/pages/policy/output/AverageImpactByWealthDecile.jsx`, update the `locale` prop of the `Plot` component in the `AverageImpactByWealthDecilePlot` function ([link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aL105-R111))
  - In `src/pages/policy/output/BudgetaryImpact.jsx`, update the `locale` prop of the `Plot` component in the `BudgetaryImpactPlot` function ([link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L4-R4), [link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L159-R159))
  - In `src/pages/policy/output/DetailedBudgetaryImpact.jsx`, update the `locale` prop of the `Plot` component in the `DetailedBudgetaryImpactPlot` function ([link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-d50bb4f3433b375516906846f34ac9a1d86d9d361680f9d47cf9cf58f4a44cf5L4-R4), [link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-d50bb4f3433b375516906846f34ac9a1d86d9d361680f9d47cf9cf58f4a44cf5L132-R132))
* Rename `src/plotly_locales/locale-en.js` to `src/plotly_locales/locale-en-gb.js` and change the `name` property of the `loc_en` module to `en-GB` to reflect the correct locale code for the UK English plotly locale ([link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-453d87bff954264f9dbeea0da5ea8c8791a7236c303799ff647303f93ebb23d6L7-R7))
* Update the import and registration of the UK English plotly locale in `src/redesign/components/PolicyEngine.jsx` to use the renamed `loc_en_gb` module ([link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-e30e417fc83ec5700443c56bd7a183339e16b3094194b57c61fdbd596eb7d2d8L23-R23), [link](https://github.com/PolicyEngine/policyengine-app/pull/941/files?diff=unified&w=0#diff-e30e417fc83ec5700443c56bd7a183339e16b3094194b57c61fdbd596eb7d2d8L43-R43))


