### PR TITLE
Remove MTR from variable list in EarningsVariation chart

### DIFF
--- a/src/pages/household/output/EarningsVariation.jsx
+++ b/src/pages/household/output/EarningsVariation.jsx
@@ -53,9 +53,14 @@ export default function EarningsVariation(props) {
       );
     }
   }
+  const forbiddenVariableNames = ["marginal_tax_rate"];
   validVariables = validVariables
     .map((variable) => metadata.variables[variable])
-    .filter((variable) => !variable.isInputVariable);
+    .filter(
+      (variable) =>
+        !variable.isInputVariable &&
+        !forbiddenVariableNames.includes(variable.name),
+    );
 
   useEffect(() => {
     let householdData = JSON.parse(JSON.stringify(householdInput));


### PR DESCRIPTION
Fix #425 by filtering out the marginal tax rate variable from the variable list in the `EarningsVariation` component.

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b5777c9</samp>

### Summary
🚫📊🧹

<!--
1.  🚫 - This emoji conveys the idea of filtering out or excluding something, which is what the code does with the `marginal_tax_rate` variable.
2.  📊 - This emoji represents the earnings variation chart, which is the main feature affected by the changes.
3.  🧹 - This emoji suggests the idea of cleaning up or refactoring the code, which is what the code does by introducing the `forbiddenVariableNames` constant and using it to simplify the logic.
-->
Exclude `marginal_tax_rate` from earnings variation chart and refactor code to use a constant for excluded variables. This improves the clarity and relevance of the chart output.

> _`marginal_tax_rate`_
> _filtered out from the chart - why?_
> _not meaningful here_

### Walkthrough
*  Exclude `marginal_tax_rate` from the earnings variation chart variables ([link](https://github.com/PolicyEngine/policyengine-app/pull/944/files?diff=unified&w=0#diff-31d25016a1cb4e96f8c2752f8f09fff24d1917b85c379be5008c6dd494596efaL56-R63))


