### PR TITLE
Do not show legend for cliffs

### DIFF
--- a/src/pages/household/output/EarningsVariation/cliffs.jsx
+++ b/src/pages/household/output/EarningsVariation/cliffs.jsx
@@ -57,7 +57,7 @@ export function getCliffs(
           }),
       opacity: 0.1,
       line_width: 0,
-      showlegend: true,
+      showlegend: false,
       type: "scatter",
       line: {
         color: style.colors.DARK_GRAY,


### PR DESCRIPTION
Fix #348.

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 308e700</samp>

### Summary
🚫📈🧐

<!--
1.  🚫 - This emoji can be used to indicate that something was removed or hidden, such as the legend entry for the cliff trace.
2.  📈 - This emoji can be used to represent the plot or the data visualization aspect of the change, as it is a common symbol for graphs and charts.
3.  🧐 - This emoji can be used to convey the idea of improving the readability and clarity of the plot, as it suggests a sense of scrutiny or attention to detail. Alternatively, one could use 🤓 or 🤗 to express a similar sentiment.
-->
Hid the legend entry for the `cliff` trace in the earnings variation plot to avoid redundancy and overlap. This change affects the file `src/pages/household/output/EarningsVariation/cliffs.jsx`.

> _`showlegend` false_
> _cliff trace hides in the plot_
> _autumn leaves fall clear_

### Walkthrough
*  Hide legend entry for cliff area in earnings variation plot ([link](https://github.com/PolicyEngine/policyengine-app/pull/945/files?diff=unified&w=0#diff-e9aee0428eb7b10a32690830888ea77958aba3a52c271388eb8b5586ca64c1efL60-R60)) to improve readability and clarity


