### PR TITLE
Do not forget current household when clicking on policy display carousel

### DIFF
--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -140,7 +140,7 @@ function PolicyDisplay(props) {
   const { policy, metadata, region, timePeriod, closeDrawer, hideButtons } =
     props;
   const reformLength = Object.keys(policy.reform.data).length;
-  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   return (
     <div
       style={{
@@ -161,16 +161,12 @@ function PolicyDisplay(props) {
           <Carousel.Item
             key={parameterName}
             onClick={() => {
-              const country = metadata.countryId;
-              const newSearchParams = {};
-              newSearchParams.focus = parameterName;
-              newSearchParams.reform = policy.reform.id;
-              newSearchParams.region = region;
-              newSearchParams.timePeriod = timePeriod;
-              const newUrl = `/${country}/policy?${new URLSearchParams(
-                newSearchParams,
-              )}`;
-              navigate(newUrl);
+              const newSearchParams = copySearchParams(searchParams);
+              newSearchParams.set("focus", parameterName);
+              newSearchParams.set("reform", policy.reform.id);
+              newSearchParams.set("region", region);
+              newSearchParams.set("timePeriod", timePeriod);
+              setSearchParams(newSearchParams);
               hideButtons && closeDrawer();
             }}
           >

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -25,6 +25,10 @@ export default function ParameterEditor(props) {
   const currentYear = new Date().getFullYear();
   const [startDate, setStartDate] = useState(currentYear + "-01-01");
   const [endDate, setEndDate] = useState(currentYear + 5 + "-12-31");
+  const startValue = getParameterAtInstant(
+    getReformedParameter(parameter, policy.reform.data),
+    startDate,
+  );
 
   // change reform data using value and current startDate and endDate
   function newReforms(reforms, value) {
@@ -69,26 +73,21 @@ export default function ParameterEditor(props) {
     control = (
       <div style={{ padding: 10 }}>
         <Switch
-          defaultChecked={getParameterAtInstant(parameter, startDate)}
+          defaultChecked={startValue}
           onChange={(value) => onChange(!!value)}
         />
       </div>
     );
-  } else if (parameter.unit === "/1") {
-    let val = getParameterAtInstant(parameter, startDate);
-    let valInPercentage = formatVariableValue(parameter, val);
-    control = (
-      <InputField
-        placeholder={valInPercentage}
-        pattern={"%"}
-        onChange={(value) => onChange(parseFloat(value) / 100)}
-      />
-    );
   } else {
+    const isPercent = parameter.unit === "/1";
+    const scale = isPercent ? 100 : 1;
     control = (
       <InputField
-        placeholder={getParameterAtInstant(parameter, startDate)}
-        onChange={(value) => onChange(Number(value))}
+        placeholder={
+          isPercent ? formatVariableValue(parameter, startValue) : startValue
+        }
+        {...(isPercent ? { pattern: "%" } : {})}
+        onChange={(value) => onChange(parseFloat(value) / scale)}
       />
     );
   }
@@ -117,7 +116,7 @@ export default function ParameterEditor(props) {
   );
 
   const timePeriodSentence = parameter.period
-    ? `This parameter is ${parameter.period}ly.`
+    ? ` This parameter is ${parameter.period}ly.`
     : "";
 
   let description = parameter.description;


### PR DESCRIPTION
Fixed #485.

According to the bug reproduction video, the household got lost after clicking on the current reform item in the policy's right sidebar. I fixed the issue by copying the existing search parameters for the new URL instead of creating the new URL from scratch.

On carrying out the policy edits suggested by the reproduction video, I noticed that the placeholder in the parameter editor did not reflect the last edit. This was due to a bug introduced in pull request #839 where I ignored the reform when creating the placeholder text. This bug is also fixed here.

Finally, I have also added a space before the 'This parameter is yearly.' sentence.

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3ba1cf0</samp>

### Summary
🐛♻️📏

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this pull request. It conveys that the input field issue has been resolved and the user can now see the correct values for their policy parameters.
2.  ♻️ - This emoji represents a refactor, which is another aspect of this pull request. It conveys that the code for the `PolicyDisplay` component has been improved and simplified by using the `useSearchParams` hook.
3.  📏 - This emoji represents a layout or spacing improvement, which is a minor but noticeable change in this pull request. It conveys that the parameter description has been given more space and aligned with the input field.
-->
Fixed a bug and refactored some components in the policy input and display pages. Improved the input field value and rendering for `ParameterEditor.jsx` and the URL state management for `PolicyDisplay` in `PolicyRightSidebar.jsx`.

> _We are the masters of the policy display_
> _We fix the bugs and make the input obey_
> _We use the hooks to manage the URL state_
> _We refactor the code and make it great_

### Walkthrough
*  Fix a bug that caused the input field to show the wrong value for reformed parameters before the start date ([link](https://github.com/PolicyEngine/policyengine-app/pull/947/files?diff=unified&w=0#diff-9b745098fe616d3b484439547f6eed36ad068dab9723978c85b41095a0a0c92aR28-R31), [link](https://github.com/PolicyEngine/policyengine-app/pull/947/files?diff=unified&w=0#diff-9b745098fe616d3b484439547f6eed36ad068dab9723978c85b41095a0a0c92aL72-R90))
* Refactor the URL state management in `PolicyDisplay` component in `PolicyRightSidebar.jsx` ([link](https://github.com/PolicyEngine/policyengine-app/pull/947/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285L143-R143), [link](https://github.com/PolicyEngine/policyengine-app/pull/947/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285L164-R169))
* Add a space before the sentence that describes the period of the parameter in `ParameterEditor.jsx` ([link](https://github.com/PolicyEngine/policyengine-app/pull/947/files?diff=unified&w=0#diff-9b745098fe616d3b484439547f6eed36ad068dab9723978c85b41095a0a0c92aL120-R119))


