### PR TITLE
Make state dropdown box searchable again

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -251,6 +251,8 @@ function HouseholdVariableEntityInput(props) {
   } else if (variable.valueType === "Enum") {
     control = (
       <Select
+        showSearch
+        optionFilterProp="label"
         style={{ width: mobile ? 150 : 200 }}
         options={variable.possibleValues}
         defaultValue={defaultValue}


### PR DESCRIPTION
Fix #954.

This regression was introduced in pull request #892. I have been trying to use ant-design components directly instead of the existing wrappers in the app such as `SearchOptions` because the ant-design components have better interfaces and documentation than the wrappers in the app. Usually, well-designed components provided by a UX framework do not need wrappers and should be used directly. I will be more careful with switching components in the future.

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cbe6d5b</samp>

### Summary
🔎🏷️🚀

<!--
1.  🔎 - This emoji represents the search functionality, as it is commonly used to indicate a magnifying glass or a search icon.
2.  🏷️ - This emoji represents the option filtering by label, as it is commonly used to indicate a tag or a label that can be applied to categorize or identify something.
3.  🚀 - This emoji represents the improvement in user experience, as it is commonly used to indicate something fast, exciting, or innovative.
-->
Added search and filter functionality to the variable selector in `VariableEditor.jsx`. This makes it easier to find and choose a variable from the policy engine.

> _`Select` component_
> _Search and filter by label_
> _Autumn leaves the rest_

### Walkthrough
*  Enable searching and filtering variables by label in the editor ([link](https://github.com/PolicyEngine/policyengine-app/pull/955/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991R254-R255))


