### PR TITLE
Remove decimals from age input box

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -240,11 +240,14 @@ function HouseholdVariableEntityInput(props) {
           : {})}
         {...(variable.valueType === "float"
           ? {
-              formatter: (value, { userTyping }) =>
-                (+value).toLocaleString(localeCode(metadata.countryId), {
-                  minimumFractionDigits: !userTyping && 2,
-                  maximumFractionDigits: 2,
-                }),
+              formatter: (value, { userTyping }) => {
+                const n = +value;
+                const isInteger = Number.isInteger(n);
+                return n.toLocaleString(localeCode(metadata.countryId), {
+                  minimumFractionDigits: userTyping || isInteger ? 0 : 2,
+                  maximumFractionDigits: userTyping ? 16 : 2,
+                });
+              },
             }
           : {})}
         defaultValue={defaultValue}


### PR DESCRIPTION
Fix #928 by removing trailing zeros if the value is integral.

The change also allows the user to type a value with up to `16` fractional digits and truncates the value only on blur (`16` is chosen arbitrarily, of course). This is the more natural behavior because the inability to see the third fractional digit while it changes the second visible fractional digit is confusing. The simple ant-design `InputNumber` component with `precision = 2` also allows the user to enter many fractional digits and truncates the value on blur.


<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f0d7a9</samp>

### Summary
🐛🎨🚸

<!--
1.  🐛 - This emoji represents a bug fix, which is the main motivation for this change. The formatter function was not working as expected for integer values and user typing, so this emoji conveys that the change resolved an issue.
2.  🎨 - This emoji represents an improvement to the user interface or style, which is the broader goal of this change. The formatter function affects how the variable values are displayed and edited by the user, so this emoji conveys that the change enhanced the appearance and functionality of the component.
3.  🚸 - This emoji represents an improvement to the user experience or accessibility, which is another aspect of this change. The formatter function also affects how the user interacts with the variable values and how easy or intuitive it is to do so, so this emoji conveys that the change made the component more user-friendly and accessible.
-->
Fixed a formatting bug and improved user typing for float variables in the `VariableEditor` component. Modified the formatter function in `src/pages/household/input/VariableEditor.jsx`.

> _`float` formatter_
> _bug fixed with more logic_
> _spring cleaning the code_

### Walkthrough
*  Fixed a bug in the formatter function for float variables to handle integer values and user typing better ([link](https://github.com/PolicyEngine/policyengine-app/pull/962/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L241-R248)). This change improved the user interface and usability of the `VariableEditor` component, which allows users to edit the values of policy parameters and household characteristics in the `household` page.


