### PR TITLE
Fix graph output by reverting to InputField

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -1,16 +1,18 @@
 import { useSearchParams } from "react-router-dom";
-import { capitalize, localeCode } from "../../../api/language";
+import { capitalize, /*localeCode*/ } from "../../../api/language";
 import {
-  currencyMap,
+  // currencyMap,
+  formatVariableValue,
   getNewHouseholdId,
   getValueFromHousehold,
 } from "../../../api/variables";
 import LoadingCentered from "../../../layout/LoadingCentered";
-import { InputNumber, Select, Switch } from "antd";
+import { /*InputNumber,*/ Select, Switch } from "antd";
 import useMobile from "../../../layout/Responsive";
 import SearchParamNavButton from "../../../controls/SearchParamNavButton";
 import gtag from "../../../api/analytics";
 import { useState, useEffect } from "react";
+import InputField from "controls/InputField";
 
 export default function VariableEditor(props) {
   const [searchParams] = useSearchParams();
@@ -223,10 +225,13 @@ function HouseholdVariableEntityInput(props) {
     }
   }
   const mobile = useMobile();
+
   let control;
+  const formatValue = (value) => formatVariableValue(variable, value);
   if (variable.valueType === "float" || variable.valueType === "int") {
-    const isCurrency = Object.keys(currencyMap).includes(variable.unit);
+    // const isCurrency = Object.keys(currencyMap).includes(variable.unit);
     control = (
+      /*
       <InputNumber
         style={{
           width: mobile ? 150 : 200,
@@ -248,6 +253,18 @@ function HouseholdVariableEntityInput(props) {
         defaultValue={defaultValue}
         autoFocus
         onChange={submitValue}
+      />
+      */
+      <InputField
+        onChange={submitValue}
+        placeholder={
+          reformValue !== null ?
+          `${formatValue(reformValue)}` :
+          formatValue(inputValue || simulatedValue)
+        }
+        autofocus
+        width={mobile && 150}
+        padding={mobile && 10}
       />
     );
   } else if (variable.valueType === "bool") {


### PR DESCRIPTION
Fixes #952. Our implementation of antd's InputValue component uses an overly eager onChange handler, creating numerous household creation requests and `get_household_under_policy` requests that sometimes don't sequence properly. When the output pages receive a version of the household that's one or two requests behind, the relevant piece of data is often one or more orders of magnitude too low, creating the strange difference between the line (which runs off of a `calculate` request) and the dot (from `get_household_under_policy`, using a stale household).

I will continue working on this bug. If I can get the antd implementation to work properly, I will withdraw this PR and open a new one for that.

Note: There's also a weirdly large amount of linting by `prettier`, hence the weirdly high number of files edited.

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9579116</samp>

### Summary
📝📊🐛

<!--
1.  📝 - This emoji can represent changes that improve the formatting, indentation, or style of the code, as well as changes that update documentation or comments.
2. 📊 - This emoji can represent changes that affect the rendering or display of charts, graphs, or tables, as well as changes that improve the data visualization or analysis.
3. 🐛 - This emoji can represent changes that fix bugs, errors, or broken links, as well as changes that improve the functionality or performance of the code.
-->
This pull request improves the formatting and readability of the code in various components that render charts, tables, and inputs for the policy engine app. It also updates the colab link for the US country to use the latest notebook version. The main change is to indent the nested ternary operators for consistency and clarity. The pull request affects the following files: `VariableEditor.jsx`, `AverageImpactByDecile.jsx`, `AverageImpactByWealthDecile.jsx`, `BudgetaryImpact.jsx`, `CliffImpact.jsx`, `DeepPovertyImpact.jsx`, `DeepPovertyImpactByGender.jsx`, `InequalityImpact.jsx`, `PovertyImpact.jsx`, `PovertyImpactByGender.jsx`, `PovertyImpactByRace.jsx`, `RelativeImpactByDecile.jsx`, `RelativeImpactByWealthDecile.jsx`, `Header.jsx`, `Posts.jsx`, `Analysis.jsx`, `PolicyReproducibility.jsx`, `PolicyRightSidebar.jsx`, `PolicyEngineCountry.jsx`, and `PolicyEngine.jsx`.

> _The pull request had many changes_
> _To indent the nested `? :` ranges_
> _The code became clearer_
> _The charts looked much neater_
> _And the colab link had some exchanges_

### Walkthrough
*  Replace `InputNumber` component with `InputField` component for more flexible input formatting and validation in `VariableEditor.jsx` ([link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L226-R234), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991R257-R268))
*  Update colab link for US country to point to latest notebook version in `PolicyReproducibility.jsx` ([link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-a8b57d575938866563fc948a07a9c528ee0065813510590a564112e3ebea93c5L131-R132))
*  Indent nested ternary operators for readability and consistency in various files ([link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-ba8020f07e0e8342911e79bf3646db148f6ffafd8c080eaee9390c2b690285d8L30-R37), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L214-R217), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-c75e6033e75a045bd80335e28a44c550877d3ea9388a54de8b7955e9b0508285L77-R78), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-78c96c0c3587fbba72cabf0efcaed19c96dd3f57fb702e6cb48540e8dc54b38eL171-R172), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L59-R69), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-ec16d5261d93e698e4741e7df864ae2f82625d02047ca9697db51ae269ee05a2L130-R140), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aL59-R69), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-f561e2313f626b35f5ba151c460ff2c4a2919ef88e0a5ba86fd61f60a0ac4b8aL130-R140), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L105-R111), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-af88a6bb0672282e83959a0a8317e5259f5e148af72f4901f431073ca751e7b3L178-R184), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L151-R154), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L217-R220), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-2a9a57cb3f930da94ecfd413c52afa6957eb4d07b639ab31d7bb11cc96f9f4c3L248-R251), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8L94-R100), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8L160-R166), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-06f27d7309a6d91cb25d3d1414889381cdcdc8a7800d0a909a4a917fc8ffc2a8L226-R227), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cL99-R102), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cL170-R173), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-542532ce614925fa12fb518ca5e9c503284edc9d0393b803294609058b3cd11cL238-R239), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L69-R79), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L93-R103), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L117-R127), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L187-R195), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L207-R215), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L227-R235), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L257-R258), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-fe27a57d57fd55796f24a1607682aea120c22c755b5843ee7dab9613a33a5c82L305-R306), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L92-R98), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L157-R163), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-477c61d506ee800a649da9f71364082f7d98c738c04b51a436633f2efef13e33L221-R222), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-04e2d157bf184eb210182f434c2f34a470a711a29e5aa61e626d0cabb949526fL94-R100), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-04e2d157bf184eb210182f434c2f34a470a711a29e5aa61e626d0cabb949526fL168-R174), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-04e2d157bf184eb210182f434c2f34a470a711a29e5aa61e626d0cabb949526fL238-R239), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-666b4a2954e170f5d63c511ffebea4d88b6f3ef1c2d7e836d4cfc6b6fe268bcbL118-R124), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-666b4a2954e170f5d63c511ffebea4d88b6f3ef1c2d7e836d4cfc6b6fe268bcbL196-R202), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-666b4a2954e170f5d63c511ffebea4d88b6f3ef1c2d7e836d4cfc6b6fe268bcbL266-R267), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-2b5717cbee57bbbc685fbb5310eb4f84ee1f0b60fc6215373dd876f733f47fb4L56-R64), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-2b5717cbee57bbbc685fbb5310eb4f84ee1f0b60fc6215373dd876f733f47fb4L122-R130), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-3479abe14967df8c0649d35cc8a385878b52956281431d871039601f975a133cL56-R64), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-3479abe14967df8c0649d35cc8a385878b52956281431d871039601f975a133cL122-R130), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-1487a7d7ccfc0c177b386c9a43d4c38a893dd2017a8489aa072d16488ccb098bL20-R23), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-1487a7d7ccfc0c177b386c9a43d4c38a893dd2017a8489aa072d16488ccb098bL40-R44), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-1487a7d7ccfc0c177b386c9a43d4c38a893dd2017a8489aa072d16488ccb098bL142-R145), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-e30e417fc83ec5700443c56bd7a183339e16b3094194b57c61fdbd596eb7d2d8L70-R77))
*  Comment out unused imports and variables in `VariableEditor.jsx` ([link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L2-R15), [link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-0b96b3d13d96221f5cb68df970385b96da6e895d2437c2fd666a3d052401b991L226-R234))
*  Break long description string into two lines in `Posts.jsx` ([link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-d7f968da73057074482e4a9ec4b1bb901b56c1487a4a6aebcc4d8648ea2ecc3aL720-R721))
*  Add comma at the end of object in `Posts.jsx` ([link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-d7f968da73057074482e4a9ec4b1bb901b56c1487a4a6aebcc4d8648ea2ecc3aL726-R727))
*  Add newline at the end of file in `Header.jsx` ([link](https://github.com/PolicyEngine/policyengine-app/pull/968/files?diff=unified&w=0#diff-1487a7d7ccfc0c177b386c9a43d4c38a893dd2017a8489aa072d16488ccb098bL382-R384))


