### PR TITLE
Disable microsim output temporarily

### DIFF
--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -3,26 +3,27 @@ import { useSearchParams } from "react-router-dom";
 import {
   createDefaultHousehold,
   getDefaultHouseholdId,
-  findInTree,
-  getNewHouseholdId,
+  // findInTree,
+  // getNewHouseholdId,
 } from "../api/variables";
 import { copySearchParams, countryApiCall } from "../api/call";
 import { useEffect, useState } from "react";
-import VariableEditor from "./household/input/VariableEditor";
-import LoadingCentered from "../layout/LoadingCentered";
-import MaritalStatus from "./household/input/MaritalStatus";
-import CountChildren from "./household/input/CountChildren";
+// import VariableEditor from "./household/input/VariableEditor";
+// import LoadingCentered from "../layout/LoadingCentered";
+import ErrorPage from "layout/Error";
+// import MaritalStatus from "./household/input/MaritalStatus";
+// import CountChildren from "./household/input/CountChildren";
 import HouseholdRightSidebar from "./household/HouseholdRightSidebar";
-import HouseholdOutput from "./household/output/HouseholdOutput";
+// import HouseholdOutput from "./household/output/HouseholdOutput";
 import useMobile from "../layout/Responsive";
-import FolderPage from "../layout/FolderPage";
+// import FolderPage from "../layout/FolderPage";
 import StackedMenu from "../layout/StackedMenu";
-import HouseholdIntro from "./household/HouseholdIntro";
+// import HouseholdIntro from "./household/HouseholdIntro";
 import HOUSEHOLD_OUTPUT_TREE from "./household/output/tree";
 import VariableSearch from "./household/VariableSearch";
-import MobileHouseholdPage from "./household/MobileHouseholdPage";
+// import MobileHouseholdPage from "./household/MobileHouseholdPage";
 import RecreateHouseholdPopup from "./household/output/RecreateHouseholdPopup.jsx";
-import { Result } from "antd";
+// import { Result } from "antd";
 
 export default function HouseholdPage(props) {
   document.title = "Household | PolicyEngine";
@@ -30,18 +31,19 @@ export default function HouseholdPage(props) {
     metadata,
     householdId,
     policy,
-    hasShownHouseholdPopup,
-    setHasShownHouseholdPopup,
+    // hasShownHouseholdPopup,
+    // setHasShownHouseholdPopup,
   } = props;
   const countryId = metadata.countryId;
   const [searchParams, setSearchParams] = useSearchParams();
   const mobile = useMobile();
   const [householdInput, setHouseholdInput] = useState(null);
   const [householdBaseline, setHouseholdBaseline] = useState(null);
+  // eslint-disable-next-line no-unused-vars
   const [householdReform, setHouseholdReform] = useState(null);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [autoCompute, setAutoCompute] = useState(false);
+  const [/*error,*/ setError] = useState(null);
+  const [autoCompute, /*setAutoCompute*/] = useState(false);
   const [isRHPOpen, setIsRHPOpen] = useState(false);
 
   let middle;
@@ -211,6 +213,8 @@ export default function HouseholdPage(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [countryId, householdId, policy.reform, metadata]);
 
+  middle=<ErrorPage />;
+  /*
   if (!householdInput || !metadata) {
     middle = <LoadingCentered />;
   } else if (
@@ -333,6 +337,7 @@ export default function HouseholdPage(props) {
       />
     );
   }
+  */
   return (
     <>
       <RecreateHouseholdPopup

--- a/src/pages/PolicyPage.jsx
+++ b/src/pages/PolicyPage.jsx
@@ -1,23 +1,24 @@
-import { BookOutlined, CloseOutlined, SearchOutlined } from "@ant-design/icons";
-import { Drawer } from "antd";
-import { useEffect, useState } from "react";
+// import { BookOutlined, CloseOutlined, SearchOutlined } from "@ant-design/icons";
+// import { Drawer } from "antd";
+import { useEffect, /*useState*/ } from "react";
 import { useSearchParams } from "react-router-dom";
 import { copySearchParams } from "../api/call";
-import { findInTree } from "../api/variables";
-import Button from "../controls/Button";
-import SearchParamNavButton from "../controls/SearchParamNavButton";
+// import { findInTree } from "../api/variables";
+// import Button from "../controls/Button";
+// import SearchParamNavButton from "../controls/SearchParamNavButton";
 import SearchOptions from "../controls/SearchOptions";
-import FolderPage from "../layout/FolderPage";
-import LoadingCentered from "../layout/LoadingCentered";
-import useMobile from "../layout/Responsive";
+// import FolderPage from "../layout/FolderPage";
+// import LoadingCentered from "../layout/LoadingCentered";
+import ErrorPage from "layout/Error";
+// import useMobile from "../layout/Responsive";
 import StackedMenu from "../layout/StackedMenu";
 import ThreeColumnPage from "../layout/ThreeColumnPage";
-import style from "../style";
-import ParameterEditor from "./policy/input/ParameterEditor";
-import PolicyOutput from "./policy/output/PolicyOutput";
+// import style from "../style";
+// import ParameterEditor from "./policy/input/ParameterEditor";
+// import PolicyOutput from "./policy/output/PolicyOutput";
 import PolicyRightSidebar from "./policy/PolicyRightSidebar";
 import getPolicyOutputTree from "./policy/output/tree";
-import { capitalize } from "../api/language";
+// import { capitalize } from "../api/language";
 
 function ParameterSearch(props) {
   const { metadata } = props;
@@ -71,6 +72,7 @@ function PolicyLeftSidebar(props) {
   );
 }
 
+/*
 function MobileMiddleBar(props) {
   const { metadata } = props;
   const [searchMode, setSearchMode] = useState(false);
@@ -121,7 +123,9 @@ function MobileMiddleBar(props) {
     </div>
   );
 }
+*/
 
+/*
 function MobileTreeNavigationHolder(props) {
   const { metadata } = props;
   const POLICY_OUTPUT_TREE = getPolicyOutputTree(metadata.countryId);
@@ -215,7 +219,9 @@ function MobileTreeNavigationHolder(props) {
     </div>
   );
 }
+*/
 
+/*
 function MobileBottomMenu(props) {
   const { metadata, policy } = props;
   const [searchParams] = useSearchParams();
@@ -318,7 +324,9 @@ function MobileBottomMenu(props) {
     </div>
   );
 }
+*/
 
+/*
 function MobilePolicyPage(props) {
   const { mainContent, metadata, policy } = props;
   const [searchParams] = useSearchParams();
@@ -343,6 +351,7 @@ function MobilePolicyPage(props) {
     </>
   );
 }
+*/
 
 export default function PolicyPage(props) {
   document.title = "Policy | PolicyEngine";
@@ -350,11 +359,11 @@ export default function PolicyPage(props) {
     metadata,
     policy,
     setPolicy,
-    hasShownPopulationImpactPopup,
-    setHasShownPopulationImpactPopup,
+    // hasShownPopulationImpactPopup,
+    // setHasShownPopulationImpactPopup,
   } = props;
-  const POLICY_OUTPUT_TREE = getPolicyOutputTree(metadata.countryId);
-  const mobile = useMobile();
+  // const POLICY_OUTPUT_TREE = getPolicyOutputTree(metadata.countryId);
+  // const mobile = useMobile();
 
   const [searchParams, setSearchParams] = useSearchParams();
   const focus = searchParams.get("focus") || "";
@@ -381,7 +390,9 @@ export default function PolicyPage(props) {
   }, [!!policy.reform.data]);
 
   let middle = null;
+  middle = <ErrorPage />
 
+  /*
   if (!policy.reform.data) {
     middle = <LoadingCentered />;
   } else if (
@@ -431,6 +442,7 @@ export default function PolicyPage(props) {
       />
     );
   }
+  */
 
   return (
     <ThreeColumnPage


### PR DESCRIPTION
An unfortunate temporary PR that disables all microsim output temporarily until we can diagnose an underlying issue. This PR returns the error page for both policy and household output. Temporarily fixes (?) policyengine-us [#3471](https://github.com/PolicyEngine/policyengine-us/issues/3471). The code commenting was necessary due to the linter.

copilot:all
