### PR TITLE
Use a less reactive version of `InputNumber` in variable editor

### DIFF
--- a/src/controls/StableInputNumber.jsx
+++ b/src/controls/StableInputNumber.jsx
@@ -1,0 +1,21 @@
+import { InputNumber } from "antd";
+import { useState } from "react";
+
+// The regular antd InputNumber is highly reactive: onChange is called whenever
+// the value is changed and on blur. In some situations (e.g., the
+// VariableEditor), we want to react to the new value only in response to
+// onPressEnter and onBlur events.
+export default function StableInputNumber(props) {
+  const { defaultValue, onChange, ...others } = props;
+  const [value, setValue] = useState(defaultValue);
+  const onPressEnter = () => onChange(value);
+  return (
+    <InputNumber
+      defaultValue={defaultValue}
+      onChange={setValue}
+      onPressEnter={onPressEnter}
+      onBlur={onPressEnter}
+      {...others}
+    />
+  );
+}

--- a/src/controls/StableInputNumber.jsx
+++ b/src/controls/StableInputNumber.jsx
@@ -1,20 +1,49 @@
 import { InputNumber } from "antd";
 import { useState } from "react";
 
-// The regular antd InputNumber is highly reactive: onChange is called whenever
-// the value is changed and on blur. In some situations (e.g., the
-// VariableEditor), we want to react to the new value only in response to
-// onPressEnter and onBlur events.
+/**
+ *
+ * The regular antd InputNumber is highly reactive: onChange is called whenever
+ * the value is changed through typing, scrolling, arrow keys, blur, etc. In
+ * some situations (e.g., in the VariableEditor), we want to react to the new
+ * value only in response to onPressEnter and onBlur events. This component is a
+ * thin wrapper over Ant Design's InputNumber component. Therefore, most
+ * properties for InputNumber are valid for StableInputNumber as well. There are
+ * a few differences:
+ *   1. The onPressEnter and onBlur callback functions have access to the
+ *      current value of the component.
+ *   2. The onChange handler is disabled.
+ *
+ * In the following toy example, a StableInputNumber component is created with
+ * initial value 10, and the current values in the field are logged to the
+ * console in response to the onPressEnter and onBlur events. The first argument
+ * in the handlers is the event and it is ignored in the example; the second
+ * argument is the current value.
+ *
+ * @example
+ * const component = <StableInputNumber
+ *  defaultValue={10}
+ *  onPressEnter={(_, value) => console.log(`you entered ${value}`)}
+ *  onBlur={(_, value) => console.log(`${value} was accepted due to blur`)}/>
+ *
+ * @param {number} defaultValue the initial value
+ * @param onPressEnter the callback function that is triggered when the Enter
+ * key is pressed
+ * @param onBlur the callback function that is triggered when the component
+ * loses focus
+ *
+ * @returns a StableInputNumber component
+ */
 export default function StableInputNumber(props) {
-  const { defaultValue, onChange, ...others } = props;
+  const { defaultValue, onPressEnter, onBlur, ...others } = props;
   const [value, setValue] = useState(defaultValue);
-  const onPressEnter = () => onChange(value);
+  delete others.onChange;
   return (
     <InputNumber
       defaultValue={defaultValue}
       onChange={setValue}
-      onPressEnter={onPressEnter}
-      onBlur={onPressEnter}
+      onPressEnter={(e) => onPressEnter(e, value)}
+      onBlur={(e) => onBlur(e, value)}
       {...others}
     />
   );

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -1,18 +1,17 @@
 import { useSearchParams } from "react-router-dom";
-import { capitalize, /*localeCode*/ } from "../../../api/language";
+import { capitalize, localeCode } from "../../../api/language";
 import {
-  // currencyMap,
-  formatVariableValue,
+  currencyMap,
   getNewHouseholdId,
   getValueFromHousehold,
 } from "../../../api/variables";
 import LoadingCentered from "../../../layout/LoadingCentered";
-import { /*InputNumber,*/ Select, Switch } from "antd";
+import { Select, Switch } from "antd";
 import useMobile from "../../../layout/Responsive";
 import SearchParamNavButton from "../../../controls/SearchParamNavButton";
 import gtag from "../../../api/analytics";
 import { useState, useEffect } from "react";
-import InputField from "controls/InputField";
+import StableInputNumber from "controls/StableInputNumber";
 
 export default function VariableEditor(props) {
   const [searchParams] = useSearchParams();
@@ -213,8 +212,8 @@ function HouseholdVariableEntityInput(props) {
     reformValue !== null
       ? reformValue
       : inputValue !== null
-      ? inputValue
-      : simulatedValue;
+        ? inputValue
+        : simulatedValue;
   if (defaultValue === null) {
     if (variable.valueType === "float" || variable.valueType === "int") {
       defaultValue = 0;
@@ -227,12 +226,10 @@ function HouseholdVariableEntityInput(props) {
   const mobile = useMobile();
 
   let control;
-  const formatValue = (value) => formatVariableValue(variable, value);
   if (variable.valueType === "float" || variable.valueType === "int") {
-    // const isCurrency = Object.keys(currencyMap).includes(variable.unit);
+    const isCurrency = Object.keys(currencyMap).includes(variable.unit);
     control = (
-      /*
-      <InputNumber
+      <StableInputNumber
         style={{
           width: mobile ? 150 : 200,
         }}
@@ -243,7 +240,7 @@ function HouseholdVariableEntityInput(props) {
           : {})}
         {...(variable.valueType === "float"
           ? {
-              formatter: (value, {userTyping}) =>
+              formatter: (value, { userTyping }) =>
                 (+value).toLocaleString(localeCode(metadata.countryId), {
                   minimumFractionDigits: !userTyping && 2,
                   maximumFractionDigits: 2,
@@ -253,18 +250,6 @@ function HouseholdVariableEntityInput(props) {
         defaultValue={defaultValue}
         autoFocus
         onChange={submitValue}
-      />
-      */
-      <InputField
-        onChange={submitValue}
-        placeholder={
-          reformValue !== null ?
-          `${formatValue(reformValue)}` :
-          formatValue(inputValue || simulatedValue)
-        }
-        autofocus
-        width={mobile && 150}
-        padding={mobile && 10}
       />
     );
   } else if (variable.valueType === "bool") {

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -249,7 +249,8 @@ function HouseholdVariableEntityInput(props) {
           : {})}
         defaultValue={defaultValue}
         autoFocus
-        onChange={submitValue}
+        onPressEnter={(_, value) => submitValue(value)}
+        onBlur={(_, value) => submitValue(value)}
       />
     );
   } else if (variable.valueType === "bool") {


### PR DESCRIPTION
Fix #946 by triggering the creation of new households only on blur and on enter.