### PR TITLE
Restrict the y-axis of the Marginal Tax Rates chart to `[-200%, 200%]`.

### DIFF
--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -38,6 +38,9 @@ export default function MarginalTaxRates(props) {
   const [loading, setLoading] = useState(true);
   const [showDelta, setShowDelta] = useState(false);
   const mobile = useMobile();
+  // We don't want to show "large" values in this chart. See
+  // https://github.com/PolicyEngine/policyengine-app/issues/66.
+  const showValueOnYAxis = (value) => value >= -2 && value <= 2;
   let title;
 
   const currentEarnings = getValueFromHousehold(
@@ -133,7 +136,8 @@ export default function MarginalTaxRates(props) {
     const x2 = [currentEarnings];
     const y2 = [currentMtr];
     const xaxisValues = x1.concat(x2);
-    const yaxisValues = y1.concat(y2);
+    const yaxisValues = y1.filter(showValueOnYAxis).concat(y2);
+    // note that we do not filter currentMtr
     title = `Your current marginal tax rate is ${formatVariableValue(
       { unit: "/1" },
       currentMtr,
@@ -270,7 +274,8 @@ export default function MarginalTaxRates(props) {
       const x2 = [currentEarnings];
       const y2 = [reformMtrValue - currentMtr];
       xaxisValues = x1.concat(x2);
-      yaxisValues = y1.concat(y2);
+      yaxisValues = y1.filter(showValueOnYAxis).concat(y2);
+      // note that we do not filter reformMtrValue - currentMtr
       data = [
         {
           x: x1,


### PR DESCRIPTION
Fix #66 by filtering function values that exceed `200%` or go under `-200%`.

Tested against [this household](https://policyengine.org/us/household?focus=householdOutput.mtr&household=38027).

View when current income is `0`:

<img width="743" alt="Screenshot 2023-12-18 at 10 25 23 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/341d9cc4-a907-4d06-832c-32567568be95">

View when current income is `14,000`:

<img width="743" alt="Screenshot 2023-12-18 at 10 26 52 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/fe93c639-f746-4a0d-bde9-d81f8556e925">

Thus, when the value corresponding to the current income does not lie in `[-200%, 200%]` the range on the y-axis is extended to include the value.