### PR TITLE
Extend the cliffs in the Earnings Variation chart to meet its horizontal borders

### DIFF
--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -228,7 +228,7 @@ export function getPlotlyAxisFormat(unit, values, precisionOverride) {
   const paddedRange = () => {
     const r = range();
     const d = r[1] - r[0];
-    const p = d * 0.1;
+    const p = d * 0.01;
     return [r[0] - p, r[1] + p];
   };
 

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -148,17 +148,9 @@ function BaselineAndReformTogetherPlot(props) {
     baselineValue,
     useHoverCard = false,
   } = props;
-  const x1 = earningsArray;
-  const y1 = baselineArray;
-  const y2 = reformArray;
-  const x2 = [currentEarnings];
-  const y3 = [currentValue];
-  const y4 = [baselineValue];
-  const xaxisValues = x1.concat(x2);
-  const yaxisValues = y1.concat(y2, y3, y4);
   const yaxisFormat = getPlotlyAxisFormat(
     metadata.variables[variable].unit,
-    yaxisValues,
+    baselineArray.concat(reformArray, currentValue, baselineValue),
   );
   const cliffs1 =
     variable === "household_net_income"
@@ -186,8 +178,8 @@ function BaselineAndReformTogetherPlot(props) {
     ...cliffs1,
     ...cliffs2,
     {
-      x: x1,
-      y: y1,
+      x: earningsArray,
+      y: baselineArray,
       type: "line",
       name: `Baseline ${variableLabel}`,
       line: {
@@ -206,8 +198,8 @@ function BaselineAndReformTogetherPlot(props) {
           }),
     },
     {
-      x: x1,
-      y: y2,
+      x: earningsArray,
+      y: reformArray,
       type: "line",
       name: `Reform ${variableLabel}`,
       line: {
@@ -226,8 +218,8 @@ function BaselineAndReformTogetherPlot(props) {
           }),
     },
     {
-      x: x2,
-      y: y3,
+      x: [currentEarnings],
+      y: [currentValue],
       type: "scatter",
       mode: "markers",
       name: `Your reform ${variableLabel}`,
@@ -247,8 +239,8 @@ function BaselineAndReformTogetherPlot(props) {
           }),
     },
     {
-      x: x2,
-      y: y4,
+      x: [currentEarnings],
+      y: [baselineValue],
       type: "scatter",
       mode: "markers",
       name: `Your baseline ${variableLabel}`,
@@ -278,7 +270,7 @@ function BaselineAndReformTogetherPlot(props) {
             title: "Household head employment income",
             ...getPlotlyAxisFormat(
               metadata.variables.employment_income.unit,
-              xaxisValues,
+              earningsArray.concat(currentEarnings),
             ),
             uirevision: metadata.variables.employment_income.unit,
           },
@@ -384,16 +376,14 @@ function BaselineReformDeltaPlot(props) {
     variable,
     useHoverCard = false,
   } = props;
-  const x1 = earningsArray;
-  const y1 = reformArray.map((value, index) => value - baselineArray[index]);
-  const x2 = [currentEarnings];
-  const y2 = [currentValue - baselineValue];
-  const xaxisValues = x1.concat(x2);
-  const yaxisValues = y1.concat(y2);
+  const deltaArray = reformArray.map(
+    (value, index) => value - baselineArray[index],
+  );
+  const currentDelta = [currentValue - baselineValue];
   let data = [
     {
-      x: x1,
-      y: y1,
+      x: earningsArray,
+      y: deltaArray,
       type: "line",
       name: `Change in ${variableLabel}`,
       line: {
@@ -412,8 +402,8 @@ function BaselineReformDeltaPlot(props) {
           }),
     },
     {
-      x: x2,
-      y: y2,
+      x: [currentEarnings],
+      y: [currentDelta],
       type: "scatter",
       mode: "markers",
       name: `Your current change in ${variableLabel}`,
@@ -445,7 +435,7 @@ function BaselineReformDeltaPlot(props) {
             title: "Household head employment income",
             ...getPlotlyAxisFormat(
               metadata.variables.employment_income.unit,
-              xaxisValues,
+              earningsArray.concat(currentEarnings),
             ),
             uirevision: metadata.variables.employment_income.unit,
           },
@@ -453,7 +443,7 @@ function BaselineReformDeltaPlot(props) {
             title: `Change in ${variableLabel}`,
             ...getPlotlyAxisFormat(
               metadata.variables[variable].unit,
-              yaxisValues,
+              deltaArray.concat(currentDelta),
             ),
             uirevision: metadata.variables[variable].unit,
           },

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -148,32 +148,46 @@ function BaselineAndReformTogetherPlot(props) {
     baselineValue,
     useHoverCard = false,
   } = props;
+  const x1 = earningsArray;
+  const y1 = baselineArray;
+  const y2 = reformArray;
+  const x2 = [currentEarnings];
+  const y3 = [currentValue];
+  const y4 = [baselineValue];
+  const xaxisValues = x1.concat(x2);
+  const yaxisValues = y1.concat(y2, y3, y4);
+  const yaxisFormat = getPlotlyAxisFormat(
+    metadata.variables[variable].unit,
+    yaxisValues,
+  );
   const cliffs1 =
     variable === "household_net_income"
-      ? getCliffs(baselineArray, earningsArray, false, "$", useHoverCard)
+      ? getCliffs(
+          baselineArray,
+          earningsArray,
+          yaxisFormat.range,
+          false,
+          "$",
+          useHoverCard,
+        )
       : [];
   const cliffs2 =
     variable === "household_net_income"
-      ? getCliffs(reformArray, earningsArray, true, "$", useHoverCard)
+      ? getCliffs(
+          reformArray,
+          earningsArray,
+          yaxisFormat.range,
+          true,
+          "$",
+          useHoverCard,
+        )
       : [];
-  const x1 = cliffs1.reduce((p, cliff) => p.concat(cliff.x), []);
-  const y1 = cliffs1.reduce((p, cliff) => p.concat(cliff.y), []);
-  const x2 = cliffs2.reduce((p, cliff) => p.concat(cliff.x), []);
-  const y2 = cliffs2.reduce((p, cliff) => p.concat(cliff.y), []);
-  const x3 = earningsArray;
-  const y3 = baselineArray;
-  const y4 = reformArray;
-  const x4 = [currentEarnings];
-  const y5 = [currentValue];
-  const y6 = [baselineValue];
-  const xaxisValues = x1.concat(x2, x3, x4);
-  const yaxisValues = y1.concat(y2, y3, y4, y5, y6);
   let data = [
     ...cliffs1,
     ...cliffs2,
     {
-      x: x3,
-      y: y3,
+      x: x1,
+      y: y1,
       type: "line",
       name: `Baseline ${variableLabel}`,
       line: {
@@ -192,8 +206,8 @@ function BaselineAndReformTogetherPlot(props) {
           }),
     },
     {
-      x: x3,
-      y: y4,
+      x: x1,
+      y: y2,
       type: "line",
       name: `Reform ${variableLabel}`,
       line: {
@@ -212,8 +226,8 @@ function BaselineAndReformTogetherPlot(props) {
           }),
     },
     {
-      x: x4,
-      y: y5,
+      x: x2,
+      y: y3,
       type: "scatter",
       mode: "markers",
       name: `Your reform ${variableLabel}`,
@@ -233,8 +247,8 @@ function BaselineAndReformTogetherPlot(props) {
           }),
     },
     {
-      x: x4,
-      y: y6,
+      x: x2,
+      y: y4,
       type: "scatter",
       mode: "markers",
       name: `Your baseline ${variableLabel}`,
@@ -270,10 +284,7 @@ function BaselineAndReformTogetherPlot(props) {
           },
           yaxis: {
             title: capitalize(variableLabel),
-            ...getPlotlyAxisFormat(
-              metadata.variables[variable].unit,
-              yaxisValues,
-            ),
+            ...yaxisFormat,
             uirevision: metadata.variables.household_net_income.unit,
           },
           ...(useHoverCard

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -59,12 +59,7 @@ export default function BaselineOnlyChart(props) {
     const setHoverCard = useContext(HoverCardContext);
     const mobile = useMobile();
     const { useHoverCard = false } = props;
-    const x1 = earningsArray;
-    const y1 = baselineArray;
-    const x2 = [currentEarnings];
-    const y2 = [currentBaseline];
-    const xaxisValues = x1.concat(x2);
-    const yaxisValues = y1.concat(y2);
+    const yaxisValues = baselineArray.concat(currentBaseline);
     const yaxisFormat = getPlotlyAxisFormat(
       metadata.variables[variable].unit,
       yaxisValues,
@@ -90,8 +85,8 @@ export default function BaselineOnlyChart(props) {
             data={[
               ...cliffs,
               {
-                x: x1,
-                y: y1,
+                x: earningsArray,
+                y: baselineArray,
                 type: "line",
                 name: capitalize(variableLabel),
                 line: {
@@ -110,8 +105,8 @@ export default function BaselineOnlyChart(props) {
                     }),
               },
               {
-                x: x2,
-                y: y2,
+                x: [currentEarnings],
+                y: [currentBaseline],
                 type: "line",
                 mode: "markers",
                 name: `Your current ${variableLabel}`,
@@ -136,7 +131,7 @@ export default function BaselineOnlyChart(props) {
                 title: "Household head employment income",
                 ...getPlotlyAxisFormat(
                   metadata.variables.employment_income.unit,
-                  xaxisValues,
+                  earningsArray.concat(currentEarnings),
                 ),
                 uirevision: metadata.variables.employment_income.unit,
               },

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -59,18 +59,27 @@ export default function BaselineOnlyChart(props) {
     const setHoverCard = useContext(HoverCardContext);
     const mobile = useMobile();
     const { useHoverCard = false } = props;
+    const x1 = earningsArray;
+    const y1 = baselineArray;
+    const x2 = [currentEarnings];
+    const y2 = [currentBaseline];
+    const xaxisValues = x1.concat(x2);
+    const yaxisValues = y1.concat(y2);
+    const yaxisFormat = getPlotlyAxisFormat(
+      metadata.variables[variable].unit,
+      yaxisValues,
+    );
     const cliffs =
       variable === "household_net_income"
-        ? getCliffs(baselineArray, earningsArray, false, "$", useHoverCard)
+        ? getCliffs(
+            baselineArray,
+            earningsArray,
+            yaxisFormat.range,
+            false,
+            "$",
+            useHoverCard,
+          )
         : [];
-    const x1 = cliffs.reduce((p, cliff) => p.concat(cliff.x), []);
-    const y1 = cliffs.reduce((p, cliff) => p.concat(cliff.y), []);
-    const x2 = earningsArray;
-    const y2 = baselineArray;
-    const x3 = [currentEarnings];
-    const y3 = [currentBaseline];
-    const xaxisValues = x1.concat(x2, x3);
-    const yaxisValues = y1.concat(y2, y3);
 
     // Add the main line, then add a 'you are here' line
     return (
@@ -81,8 +90,8 @@ export default function BaselineOnlyChart(props) {
             data={[
               ...cliffs,
               {
-                x: x2,
-                y: y2,
+                x: x1,
+                y: y1,
                 type: "line",
                 name: capitalize(variableLabel),
                 line: {
@@ -101,8 +110,8 @@ export default function BaselineOnlyChart(props) {
                     }),
               },
               {
-                x: x3,
-                y: y3,
+                x: x2,
+                y: y2,
                 type: "line",
                 mode: "markers",
                 name: `Your current ${variableLabel}`,
@@ -135,10 +144,7 @@ export default function BaselineOnlyChart(props) {
                 title: {
                   text: capitalize(variableLabel),
                 },
-                ...getPlotlyAxisFormat(
-                  metadata.variables[variable].unit,
-                  yaxisValues,
-                ),
+                ...yaxisFormat,
                 uirevision: metadata.variables[variable].unit,
               },
               ...(useHoverCard

--- a/src/pages/household/output/EarningsVariation/cliffs.jsx
+++ b/src/pages/household/output/EarningsVariation/cliffs.jsx
@@ -1,11 +1,10 @@
 import style from "../../../../style";
 import { convertToCurrencyString } from "./convertToCurrencyString";
 
-const ROUNDING_FACTOR = 50000;
-
 export function getCliffs(
   netIncomeArray,
   earningsArray,
+  range,
   isReform = false,
   currency = "$",
   useHoverCard = false,
@@ -31,14 +30,10 @@ export function getCliffs(
     }
   }
 
-  const maxNetIncome = Math.max(...netIncomeArray);
-  const maxCliffShadingHeight =
-    Math.ceil(maxNetIncome / ROUNDING_FACTOR) * ROUNDING_FACTOR;
-
   return cliffs.map((points, i) => {
     return {
       x: [points[0], points[0], points[1], points[1], points[0]],
-      y: [0, maxCliffShadingHeight, maxCliffShadingHeight, 0, 0],
+      y: [range[0], range[1], range[1], range[0], range[0]],
       fill: "toself",
       mode: "lines",
       fillcolor: style.colors.DARK_GRAY,

--- a/src/pages/household/output/EarningsVariation/cliffs.jsx
+++ b/src/pages/household/output/EarningsVariation/cliffs.jsx
@@ -33,7 +33,7 @@ export function getCliffs(
   return cliffs.map((points, i) => {
     return {
       x: [points[0], points[0], points[1], points[1], points[0]],
-      y: [range[0], range[1], range[1], range[0], range[0]],
+      y: [0, range[1], range[1], 0, 0],
       fill: "toself",
       mode: "lines",
       fillcolor: style.colors.DARK_GRAY,


### PR DESCRIPTION
Fix #978 by passing the y-axis range to the `getCliffs` function.

Tested against [this household](https://policyengine.org/us/household?focus=householdOutput.earnings&household=38027). Now, the chart looks like this:

<img width="743" alt="Screenshot 2023-12-18 at 11 17 55 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/0c296dc1-d962-414f-8388-fc51f405fe3a">
