### PR TITLE
Link cliffs explainer from cliffs chart

### DIFF
--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -298,7 +298,11 @@ export default function CliffImpact(props) {
         The cliff rate is the share of households whose net income falls if each
         adult earned an additional {metadata.currency}2,000. The cliff gap is
         the sum of the losses incurred by all households on a cliff if their
-        income rose in this way.
+        income rose in this way.{" "}
+        <a href="https://policyengine.org/us/research/how-would-reforms-affect-cliffs">
+          Read more about how PolicyEngine models the effect of reforms on
+          cliffs.
+        </a>
       </p>
     </ResultsPanel>
   );


### PR DESCRIPTION
Fix #279. Now, the description looks like:

<img width="743" alt="Screenshot 2023-12-18 at 11 52 40 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/16a1128d-b6ab-41ec-8f5b-f1a7e0bdc02e">

The last sentence links to https://policyengine.org/us/research/how-would-reforms-affect-cliffs.