### PR TITLE
Show deltas by default on Earnings Variation and Marginal Tax Rate charts when a reform is present

### DIFF
--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -72,7 +72,7 @@ export default function BaselineAndReformChart(props) {
   );
 
   function BaselineAndReformChartWithToggle() {
-    const [showDelta, setShowDelta] = useState(false);
+    const [showDelta, setShowDelta] = useState(true);
     const options = [
       {
         label: "Baseline and reform",

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -36,7 +36,7 @@ export default function MarginalTaxRates(props) {
   const [reformMtr, setReformMtr] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [showDelta, setShowDelta] = useState(false);
+  const [showDelta, setShowDelta] = useState(true);
   const mobile = useMobile();
   let title;
 


### PR DESCRIPTION
Fix #233.

Tested on a random household and policy to verify that difference is displayed by default:

<img width="777" alt="Screenshot 2023-12-18 at 2 34 12 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/ae2109a2-fa41-48ae-acef-5324346a2e5e">

<img width="777" alt="Screenshot 2023-12-18 at 2 34 43 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/25479741-2b99-4efe-bf39-45a9bed270e8">
