### PR TITLE
Fix display for parameter over time chart for units such as years, kWh, etc.

### DIFF
--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -242,17 +242,18 @@ export function getPlotlyAxisFormat(unit, values, precisionOverride) {
     return d > 10 ? 0 : d === 0 ? 1 : 1 - Math.round(Math.log10(d));
   };
 
-  if (Object.keys(currencyMap).includes(unit)) {
+  const isCurrency = Object.keys(currencyMap).includes(unit);
+  const isPercent = unit === "/1";
+  const isYears = unit === "years";
+  const isKwh = unit === "kilowatt-hour";
+  const isNumber = isCurrency || isPercent || isYears || isKwh;
+  // TODO: unhandled units: list, variable, program
+  if (isNumber) {
     return {
-      tickformat: `,.${precision()}f`,
-      tickprefix: currencyMap[unit],
-      ...(values && {
-        range: paddedRange(),
-      }),
-    };
-  } else if (unit === "/1") {
-    return {
-      tickformat: `,.${precision()}%`,
+      tickformat: isPercent ? `,.${precision()}%` : `,.${precision()}f`,
+      ...(isCurrency && { tickprefix: currencyMap[unit] }),
+      ...(isYears && { ticksuffix: "yrs" }),
+      ...(isKwh && { ticksuffix: "kWh" }),
       ...(values && {
         range: paddedRange(),
       }),

--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -252,8 +252,8 @@ export function getPlotlyAxisFormat(unit, values, precisionOverride) {
     return {
       tickformat: isPercent ? `,.${precision()}%` : `,.${precision()}f`,
       ...(isCurrency && { tickprefix: currencyMap[unit] }),
-      ...(isYears && { ticksuffix: "yrs" }),
-      ...(isKwh && { ticksuffix: "kWh" }),
+      ...(isYears && { ticksuffix: "&nbsp;yrs" }),
+      ...(isKwh && { ticksuffix: "&nbsp;kWh" }),
       ...(values && {
         range: paddedRange(),
       }),

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -51,6 +51,8 @@ export default function ParameterOverTime(props) {
     (e) => e !== "0000-01-01" && e !== "2099-12-31",
   );
   const yaxisValues = reformedY ? y.concat(reformedY) : y;
+  const xaxisFormat = getPlotlyAxisFormat("date", xaxisValues);
+  const yaxisFormat = getPlotlyAxisFormat(parameter.unit, yaxisValues);
 
   return (
     <>
@@ -85,8 +87,8 @@ export default function ParameterOverTime(props) {
           .reverse()
           .filter((x) => x)}
         layout={{
-          xaxis: getPlotlyAxisFormat("date", xaxisValues),
-          yaxis: getPlotlyAxisFormat(parameter.unit, yaxisValues),
+          xaxis: { ...xaxisFormat },
+          yaxis: { ...yaxisFormat },
           legend: {
             // Position above the plot
             y: 1.1,


### PR DESCRIPTION
## Description

- We fix #987.
- We display units `yrs` and `kWh` on the y-axis.

## Changes

- This regression described in #987 was introduced in #939 which used a direct call to `getPlotlyAxisFormat` instead of wrapping it in the spread operator. Before #939, the `yaxis` property was set to equal `{...getPlotlyAxisFormat(...)}` but in #939 this was changed to `getPlotlyAxisFormat(...)`, i.e., the spread operator was removed. However, `getPlotlyAxisFormat` returns `undefined` in many cases. Using the spread operator results in `yaxis = {...undefined} = {}`, and not using the spread operator results in `yaxis = undefined`. In the latter case, plotly does not display the chart. Therefore, we use the spread operator in this PR.
- We improve the `getPlotlyAxisFormat` function so that it handles the units `years` and `kilowatt-hour`. Thus, it returns `undefined` in fewer cases. There are still some unhandled units such as `list`, `variable`, and `program`.

## Screenshots

<img width="777" alt="Screenshot 2023-12-19 at 11 03 19 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/24f18b3a-b05d-433e-8060-f0b004559830">
<img width="777" alt="Screenshot 2023-12-19 at 11 03 43 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/c9cef703-6332-4db5-830e-19c878fcdd87">
<img width="798" alt="Screenshot 2023-12-19 at 11 04 15 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/15df0aef-3b9b-47d1-88ed-c4081d99ef39">
<img width="798" alt="Screenshot 2023-12-19 at 11 05 09 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/85d1cd8e-e6ba-4da3-9fd7-ac31b145aa6a">


## Tests

We checked that the parameter over time chart was displayed with the correct y-axis for currencies, percentages, speeds, and ages, as shown in the above screenshots.

## Suggestions

- It would help if the parameters also contained a data type property, e.g., `int`, `float`, etc.
