### PR TITLE
Edit: NetIncomeBreakdown.jsx

### DIFF
--- a/src/pages/household/output/NetIncomeBreakdown.jsx
+++ b/src/pages/household/output/NetIncomeBreakdown.jsx
@@ -183,8 +183,6 @@ function VariableArithmetic(props) {
     const parameter = metadata.parameters[subtracts];
     subtracts = getParameterAtInstant(parameter, "2023-01-01");
   }
-  const expandable =
-    (!hasReform || doesIncomeChange) && adds.length + subtracts.length > 0;
   const childAddNodes = adds.filter(shouldShowVariable).map((variable) => (
     <VariableArithmetic
       variableName={variable}
@@ -216,6 +214,8 @@ function VariableArithmetic(props) {
       />
     ));
   const childNodes = childAddNodes.concat(childSubtractNodes);
+  const expandable =
+    (!hasReform || doesIncomeChange) && adds.length + subtracts.length > 0 && childNodes.length > 0;
 
   if (childrenOnly) {
     return (


### PR DESCRIPTION
Fixes issue: [894](https://github.com/PolicyEngine/policyengine-app/issues/894)

## Changes:
* shift line `const expandable = (!hasReform || doesIncomeChange)`  to after LOC 216
* check for `&& childNodes.length > 0`

## Tests
No tests found related to files changed since last commit.
