### PR TITLE
Add syntax highlighting to `Reproduce in Python` code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "moment": "^2.29.4",
         "openai": "^4.20.1",
         "plotly.js": "^2.27.1",
+        "prism-react-renderer": "^2.3.1",
         "react": "^18.2.0",
         "react-bootstrap": "^2.9.1",
         "react-detect-print": "^0.1.2",
@@ -4997,6 +4998,11 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
       "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA=="
     },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.3",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.3.tgz",
+      "integrity": "sha512-A0D0aTXvjlqJ5ZILMz3rNfDBOx9hHxLZYv2by47Sm/pqW35zzjusrZTryatjN/Rf8Us2gZrJD+KeHbUSTux1Cw=="
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.9",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.9.tgz",
@@ -7052,6 +7058,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -20763,6 +20777,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prism-react-renderer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.3.1.tgz",
+      "integrity": "sha512-Rdf+HzBLR7KYjzpJ1rSoxT9ioO85nZngQEoFIhL07XhtJHlCU3SOz0GJ6+qvMyQe0Se+BV3qpe6Yd/NmQF5Juw==",
+      "dependencies": {
+        "@types/prismjs": "^1.26.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
       }
     },
     "node_modules/probe-image-size": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "moment": "^2.29.4",
     "openai": "^4.20.1",
     "plotly.js": "^2.27.1",
+    "prism-react-renderer": "^2.3.1",
     "react": "^18.2.0",
     "react-bootstrap": "^2.9.1",
     "react-detect-print": "^0.1.2",

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -1,0 +1,49 @@
+export function getReformDefinitionCode(metadata, policy) {
+  let lines = [
+    "from policyengine_core.reforms import Reform",
+    "from policyengine_core.periods import instant",
+    "import pandas as pd",
+    "",
+    "",
+    "def modify_parameters(parameters):",
+  ];
+
+  if (Object.keys(policy.reform.data).length === 0) {
+    lines.pop();
+    return lines;
+  }
+
+  for (const [parameterName, parameter] of Object.entries(policy.reform.data)) {
+    for (let [instant, value] of Object.entries(parameter)) {
+      const [start, end] = instant.split(".");
+      if (value === false) {
+        value = "False";
+      } else if (value === true) {
+        value = "True";
+      }
+      lines.push(
+        "    parameters." +
+          parameterName +
+          '.update(start=instant("' +
+          start +
+          '"), stop=instant("' +
+          end +
+          '"), value=' +
+          value +
+          ")",
+      );
+    }
+  }
+  lines.push("    return parameters");
+
+  lines = lines.concat([
+    "",
+    "",
+    "class reform(Reform):",
+    "    def apply(self):",
+    "        self.modify_parameters(modify_parameters)",
+    "",
+    "",
+  ]);
+  return lines;
+}

--- a/src/layout/Code.jsx
+++ b/src/layout/Code.jsx
@@ -15,27 +15,23 @@ export function CodeBlock({ lines, language }) {
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
           <pre className={className} style={style}>
             {tokens.map((line, i) => (
-              <div
-                key={i}
-                style={{ display: "table-row" }}
-                {...getLineProps({ line })}
-              >
-                <span
+              <tr key={i} {...getLineProps({ line, key: i })}>
+                <td
                   style={{
-                    display: "table-cell",
+                    textAlign: "right",
                     paddingRight: "1em",
                     userSelect: "none",
                     opacity: "0.5",
                   }}
                 >
                   {i + 1}
-                </span>
-                <div style={{ display: "table-cell" }}>
+                </td>
+                <td>
                   {line.map((token, key) => (
                     <span key={key} {...getTokenProps({ token })} />
                   ))}
-                </div>
-              </div>
+                </td>
+              </tr>
             ))}
           </pre>
         )}

--- a/src/layout/Code.jsx
+++ b/src/layout/Code.jsx
@@ -1,6 +1,6 @@
 import { Highlight, themes } from "prism-react-renderer";
 
-export function PythonCodeBlock({ lines }) {
+export function CodeBlock({ lines, language }) {
   const code = lines.join("\r\n");
   return (
     <div
@@ -11,7 +11,7 @@ export function PythonCodeBlock({ lines }) {
         overflowY: "scroll",
       }}
     >
-      <Highlight theme={themes.vsDark} code={code} language="python">
+      <Highlight theme={themes.vsDark} code={code} language={language}>
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
           <pre className={className} style={style}>
             {tokens.map((line, i) => (

--- a/src/layout/Code.jsx
+++ b/src/layout/Code.jsx
@@ -1,25 +1,7 @@
-import style from "redesign/style";
+import { Highlight, themes } from "prism-react-renderer";
 
 export function PythonCodeBlock({ lines }) {
-  // Turn 4-space indents into padding-left
-  const lineIndents = lines.map((line) => {
-    let numIndents = 0;
-    if (!line) {
-      return 0;
-    }
-    let lineCopy = line.toString();
-    while (
-      Array.from(lineCopy.slice(0, 4)).filter((char) => char === " ").length ===
-      4
-    ) {
-      lineCopy = lineCopy.slice(4);
-      if (lineCopy.length < 4) {
-        break;
-      }
-      numIndents++;
-    }
-    return numIndents;
-  });
+  const code = lines.join("\r\n");
   return (
     <div
       style={{
@@ -29,51 +11,35 @@ export function PythonCodeBlock({ lines }) {
         overflowY: "scroll",
       }}
     >
-      <div
-        style={{
-          backgroundColor: style.colors.DARK_GRAY,
-          borderRadius: 20,
-          padding: 20,
-          width: 600,
-          overflowX: "scroll",
-        }}
-      >
-        {lines.map((line, i) => {
-          if (line === "") {
-            return <div key={i} style={{ paddingTop: 15 }} />;
-          } else if (line.includes("situation = {")) {
-            return (
-              <pre
+      <Highlight theme={themes.vsDark} code={code} language="python">
+        {({ className, style, tokens, getLineProps, getTokenProps }) => (
+          <pre className={className} style={style}>
+            {tokens.map((line, i) => (
+              <div
                 key={i}
-                style={{
-                  color: style.colors.WHITE,
-                  fontFamily: "monospace",
-                  margin: 0,
-                  paddingTop: 5,
-                }}
+                style={{ display: "table-row" }}
+                {...getLineProps({ line })}
               >
-                {line}
-              </pre>
-            );
-          } else {
-            return (
-              <p
-                key={i}
-                style={{
-                  color: style.colors.WHITE,
-                  fontFamily: "monospace",
-                  paddingLeft: lineIndents[i] * 30,
-                  margin: 0,
-                  whiteSpace: "nowrap",
-                  paddingTop: 5,
-                }}
-              >
-                {line}
-              </p>
-            );
-          }
-        })}
-      </div>
+                <span
+                  style={{
+                    display: "table-cell",
+                    paddingRight: "1em",
+                    userSelect: "none",
+                    opacity: "0.5",
+                  }}
+                >
+                  {i + 1}
+                </span>
+                <div style={{ display: "table-cell" }}>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({ token })} />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </pre>
+        )}
+      </Highlight>
     </div>
   );
 }

--- a/src/layout/Code.jsx
+++ b/src/layout/Code.jsx
@@ -1,0 +1,79 @@
+import style from "redesign/style";
+
+export function PythonCodeBlock({ lines }) {
+  // Turn 4-space indents into padding-left
+  const lineIndents = lines.map((line) => {
+    let numIndents = 0;
+    if (!line) {
+      return 0;
+    }
+    let lineCopy = line.toString();
+    while (
+      Array.from(lineCopy.slice(0, 4)).filter((char) => char === " ").length ===
+      4
+    ) {
+      lineCopy = lineCopy.slice(4);
+      if (lineCopy.length < 4) {
+        break;
+      }
+      numIndents++;
+    }
+    return numIndents;
+  });
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "center",
+        maxHeight: "50vh",
+        overflowY: "scroll",
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: style.colors.DARK_GRAY,
+          borderRadius: 20,
+          padding: 20,
+          width: 600,
+          overflowX: "scroll",
+        }}
+      >
+        {lines.map((line, i) => {
+          if (line === "") {
+            return <div key={i} style={{ paddingTop: 15 }} />;
+          } else if (line.includes("situation = {")) {
+            return (
+              <pre
+                key={i}
+                style={{
+                  color: style.colors.WHITE,
+                  fontFamily: "monospace",
+                  margin: 0,
+                  paddingTop: 5,
+                }}
+              >
+                {line}
+              </pre>
+            );
+          } else {
+            return (
+              <p
+                key={i}
+                style={{
+                  color: style.colors.WHITE,
+                  fontFamily: "monospace",
+                  paddingLeft: lineIndents[i] * 30,
+                  margin: 0,
+                  whiteSpace: "nowrap",
+                  paddingTop: 5,
+                }}
+              >
+                {line}
+              </p>
+            );
+          }
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/layout/CodeBlock.jsx
+++ b/src/layout/CodeBlock.jsx
@@ -1,6 +1,6 @@
 import { Highlight, themes } from "prism-react-renderer";
 
-export function CodeBlock({ lines, language }) {
+export default function CodeBlock({ lines, language }) {
   const code = lines.join("\r\n");
   return (
     <div

--- a/src/layout/CodeBlock.jsx
+++ b/src/layout/CodeBlock.jsx
@@ -3,39 +3,30 @@ import { Highlight, themes } from "prism-react-renderer";
 export default function CodeBlock({ lines, language }) {
   const code = lines.join("\r\n");
   return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "center",
-        maxHeight: "50vh",
-        overflowY: "scroll",
-      }}
-    >
-      <Highlight theme={themes.vsDark} code={code} language={language}>
-        {({ className, style, tokens, getLineProps, getTokenProps }) => (
-          <pre className={className} style={style}>
-            {tokens.map((line, i) => (
-              <tr key={i} {...getLineProps({ line, key: i })}>
-                <td
-                  style={{
-                    textAlign: "right",
-                    paddingRight: "1em",
-                    userSelect: "none",
-                    opacity: "0.5",
-                  }}
-                >
-                  {i + 1}
-                </td>
-                <td>
-                  {line.map((token, key) => (
-                    <span key={key} {...getTokenProps({ token })} />
-                  ))}
-                </td>
-              </tr>
-            ))}
-          </pre>
-        )}
-      </Highlight>
-    </div>
+    <Highlight theme={themes.vsDark} code={code} language={language}>
+      {({ className, style, tokens, getLineProps, getTokenProps }) => (
+        <pre className={className} style={style}>
+          {tokens.map((line, i) => (
+            <tr key={i} {...getLineProps({ line, key: i })}>
+              <td
+                style={{
+                  textAlign: "right",
+                  paddingRight: "1em",
+                  userSelect: "none",
+                  opacity: "0.5",
+                }}
+              >
+                {i + 1}
+              </td>
+              <td>
+                {line.map((token, key) => (
+                  <span key={key} {...getTokenProps({ token })} />
+                ))}
+              </td>
+            </tr>
+          ))}
+        </pre>
+      )}
+    </Highlight>
   );
 }

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -3,7 +3,7 @@ import { optimiseHousehold } from "../../../api/variables";
 import ResultsPanel from "../../../layout/ResultsPanel";
 import Button from "../../../controls/Button";
 import { Switch } from "antd";
-import { CodeBlock } from "layout/Code";
+import CodeBlock from "layout/CodeBlock";
 import { getReformDefinitionCode } from "data/reformDefinitionCode";
 
 export default function HouseholdReproducibility(props) {

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -3,86 +3,8 @@ import { optimiseHousehold } from "../../../api/variables";
 import ResultsPanel from "../../../layout/ResultsPanel";
 import Button from "../../../controls/Button";
 import { Switch } from "antd";
-import style from "../../../style";
-import { getReformDefinitionCode } from "../../policy/output/PolicyReproducibility";
-
-function PythonCodeBlock({ lines }) {
-  // Turn 4-space indents into padding-left
-  const lineIndents = lines.map((line) => {
-    let numIndents = 0;
-    if (!line) {
-      return 0;
-    }
-    let lineCopy = line.toString();
-    while (
-      Array.from(lineCopy.slice(0, 4)).filter((char) => char === " ").length ===
-      4
-    ) {
-      lineCopy = lineCopy.slice(4);
-      if (lineCopy.length < 4) {
-        break;
-      }
-      numIndents++;
-    }
-    return numIndents;
-  });
-  return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "center",
-        maxHeight: "50vh",
-        overflowY: "scroll",
-      }}
-    >
-      <div
-        style={{
-          backgroundColor: style.colors.DARK_GRAY,
-          borderRadius: 20,
-          padding: 20,
-          width: 600,
-          overflowX: "scroll",
-        }}
-      >
-        {lines.map((line, i) => {
-          if (line === "") {
-            return <div key={i} style={{ paddingTop: 15 }} />;
-          } else if (line.includes("situation = {")) {
-            return (
-              <pre
-                key={i}
-                style={{
-                  color: style.colors.WHITE,
-                  fontFamily: "monospace",
-                  margin: 0,
-                  paddingTop: 5,
-                }}
-              >
-                {line}
-              </pre>
-            );
-          } else {
-            return (
-              <p
-                key={i}
-                style={{
-                  color: style.colors.WHITE,
-                  fontFamily: "monospace",
-                  paddingLeft: lineIndents[i] * 30,
-                  margin: 0,
-                  whiteSpace: "nowrap",
-                  paddingTop: 5,
-                }}
-              >
-                {line}
-              </p>
-            );
-          }
-        })}
-      </div>
-    </div>
-  );
-}
+import { PythonCodeBlock } from "layout/Code";
+import { getReformDefinitionCode } from "data/reformDefinitionCode";
 
 export default function HouseholdReproducibility(props) {
   const { policy, metadata, householdInput } = props;

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -3,7 +3,7 @@ import { optimiseHousehold } from "../../../api/variables";
 import ResultsPanel from "../../../layout/ResultsPanel";
 import Button from "../../../controls/Button";
 import { Switch } from "antd";
-import { PythonCodeBlock } from "layout/Code";
+import { CodeBlock } from "layout/Code";
 import { getReformDefinitionCode } from "data/reformDefinitionCode";
 
 export default function HouseholdReproducibility(props) {
@@ -93,7 +93,7 @@ export default function HouseholdReproducibility(props) {
           onChange={() => setEarningVariation(!earningVariation)}
         />
       </div>
-      <PythonCodeBlock lines={lines} />
+      <CodeBlock lines={lines} language={"python"} />
       <div
         style={{
           display: "flex",

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -10,12 +10,10 @@ export default function HouseholdReproducibility(props) {
   const { policy, metadata, householdInput } = props;
   const [earningVariation, setEarningVariation] = useState(false);
 
-  let initialLines = ["from " + metadata.package + " import Simulation"];
+  let lines = ["from " + metadata.package + " import Simulation"];
 
   if (policy.reform.data) {
-    initialLines = initialLines.concat(
-      getReformDefinitionCode(metadata, policy),
-    );
+    lines = lines.concat(getReformDefinitionCode(metadata, policy));
   }
 
   let householdInputCopy = JSON.parse(
@@ -54,11 +52,17 @@ export default function HouseholdReproducibility(props) {
     .replace(/false/g, "False")
     .replace(/null/g, "None");
 
-  initialLines = initialLines.concat([
+  lines = lines.concat([
     "situation = " + householdJson,
     "",
     "simulation = Simulation(",
-    Object.keys(policy.reform.data).length ? "    reform=reform," : "",
+  ]);
+
+  if (Object.keys(policy.reform.data).length) {
+    lines.push("    reform=reform,");
+  }
+
+  lines = lines.concat([
     "    situation=situation,",
     ")",
     "",
@@ -89,7 +93,7 @@ export default function HouseholdReproducibility(props) {
           onChange={() => setEarningVariation(!earningVariation)}
         />
       </div>
-      <PythonCodeBlock lines={initialLines} />
+      <PythonCodeBlock lines={lines} />
       <div
         style={{
           display: "flex",
@@ -101,7 +105,7 @@ export default function HouseholdReproducibility(props) {
           text="Copy"
           style={{ width: 100, margin: "20px auto 10px" }}
           onClick={() => {
-            navigator.clipboard.writeText(initialLines.join("\n"));
+            navigator.clipboard.writeText(lines.join("\n"));
           }}
         />
       </div>

--- a/src/pages/policy/output/Analysis.jsx
+++ b/src/pages/policy/output/Analysis.jsx
@@ -2,7 +2,7 @@ import { useSearchParams } from "react-router-dom";
 import { useState } from "react";
 import Spinner from "../../../layout/Spinner";
 import Button from "../../../controls/Button";
-import { PythonCodeBlock } from "layout/Code";
+import { CodeBlock } from "layout/Code";
 import colors from "../../../style/colors";
 import { getParameterAtInstant } from "../../../api/parameters";
 import { BlogPostMarkdown } from "../../BlogPage";
@@ -168,8 +168,8 @@ export default function Analysis(props) {
             audienceValue === "ELI5"
               ? "5px 0 0 5px"
               : audienceValue === "Wonk"
-              ? "0 5px 5px 0"
-              : 0,
+                ? "0 5px 5px 0"
+                : 0,
           border: borderColor,
           borderRight: audienceValue !== "Wonk" ? "none" : borderColor,
           padding: "5px 10px",
@@ -340,7 +340,7 @@ export default function Analysis(props) {
             />
           </div>
           <p>
-            <PythonCodeBlock lines={lines} />
+            <CodeBlock lines={lines} language={"markdown"} />
           </p>
         </>
       ) : null}

--- a/src/pages/policy/output/Analysis.jsx
+++ b/src/pages/policy/output/Analysis.jsx
@@ -2,7 +2,7 @@ import { useSearchParams } from "react-router-dom";
 import { useState } from "react";
 import Spinner from "../../../layout/Spinner";
 import Button from "../../../controls/Button";
-import { CodeBlock } from "layout/Code";
+import CodeBlock from "layout/CodeBlock";
 import colors from "../../../style/colors";
 import { getParameterAtInstant } from "../../../api/parameters";
 import { BlogPostMarkdown } from "../../BlogPage";

--- a/src/pages/policy/output/Analysis.jsx
+++ b/src/pages/policy/output/Analysis.jsx
@@ -2,7 +2,7 @@ import { useSearchParams } from "react-router-dom";
 import { useState } from "react";
 import Spinner from "../../../layout/Spinner";
 import Button from "../../../controls/Button";
-import { PythonCodeBlock } from "./PolicyReproducibility";
+import { PythonCodeBlock } from "layout/Code";
 import colors from "../../../style/colors";
 import { getParameterAtInstant } from "../../../api/parameters";
 import { BlogPostMarkdown } from "../../BlogPage";

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -1,4 +1,4 @@
-import { PythonCodeBlock } from "layout/Code";
+import { CodeBlock } from "layout/Code";
 import { getReformDefinitionCode } from "data/reformDefinitionCode";
 import Button from "../../../controls/Button";
 
@@ -42,7 +42,7 @@ export default function PolicyReproducibility(props) {
         Run the code below into a {notebookLink} to reproduce the
         microsimulation results.
       </p>
-      <PythonCodeBlock lines={initialLines} />
+      <CodeBlock lines={initialLines} language={"python"} />
       <div
         style={{
           display: "flex",

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -1,112 +1,6 @@
+import { PythonCodeBlock } from "layout/Code";
+import { getReformDefinitionCode } from "data/reformDefinitionCode";
 import Button from "../../../controls/Button";
-import style from "../../../style";
-
-export function PythonCodeBlock({ lines }) {
-  // Turn 4-space indents into padding-left
-  const lineIndents = lines.map((line) => {
-    let numIndents = 0;
-    if (!line) {
-      return 0;
-    }
-    let lineCopy = line.toString();
-    while (
-      Array.from(lineCopy.slice(0, 4)).filter((char) => char === " ").length ===
-      4
-    ) {
-      lineCopy = lineCopy.slice(4);
-      if (lineCopy.length < 4) {
-        break;
-      }
-      numIndents++;
-    }
-    return numIndents;
-  });
-  return (
-    <div style={{ display: "flex", justifyContent: "center" }}>
-      <div
-        style={{
-          backgroundColor: style.colors.DARK_GRAY,
-          borderRadius: 20,
-          padding: 20,
-          width: 600,
-          overflowX: "scroll",
-        }}
-      >
-        {lines.map((line, i) => {
-          if (line === "") {
-            return <div key={i} style={{ paddingTop: 15 }} />;
-          } else {
-            return (
-              <p
-                key={i}
-                style={{
-                  color: style.colors.WHITE,
-                  fontFamily: "monospace",
-                  paddingLeft: lineIndents[i] * 30,
-                  margin: 0,
-                  whiteSpace: "nowrap",
-                  paddingTop: 5,
-                }}
-              >
-                {line}
-              </p>
-            );
-          }
-        })}
-      </div>
-    </div>
-  );
-}
-
-export function getReformDefinitionCode(metadata, policy) {
-  let lines = [
-    "from policyengine_core.reforms import Reform",
-    "from policyengine_core.periods import instant",
-    "import pandas as pd",
-    "",
-    "",
-    "def modify_parameters(parameters):",
-  ];
-
-  if (Object.keys(policy.reform.data).length === 0) {
-    lines.pop();
-    return lines;
-  }
-
-  for (const [parameterName, parameter] of Object.entries(policy.reform.data)) {
-    for (let [instant, value] of Object.entries(parameter)) {
-      const [start, end] = instant.split(".");
-      if (value === false) {
-        value = "False";
-      } else if (value === true) {
-        value = "True";
-      }
-      lines.push(
-        "    parameters." +
-          parameterName +
-          '.update(start=instant("' +
-          start +
-          '"), stop=instant("' +
-          end +
-          '"), value=' +
-          value +
-          ")",
-      );
-    }
-  }
-  lines.push("    return parameters");
-
-  lines = lines.concat([
-    "",
-    "",
-    "class reform(Reform):",
-    "    def apply(self):",
-    "        self.modify_parameters(modify_parameters)",
-    "",
-    "",
-  ]);
-  return lines;
-}
 
 export default function PolicyReproducibility(props) {
   const { policy, metadata } = props;
@@ -128,8 +22,8 @@ export default function PolicyReproducibility(props) {
     metadata.countryId == "uk"
       ? "https://colab.research.google.com/drive/16h6v-EAYk5n4qZ4krXbmFG4_oKAaflo9#scrollTo=TBTIupkjIThF"
       : metadata.countryId == "us"
-      ? "https://colab.research.google.com/drive/1hqA9a2LrNj2leJ9YtXXC3xyaCXQ7mwUW?usp=sharing"
-      : null;
+        ? "https://colab.research.google.com/drive/1hqA9a2LrNj2leJ9YtXXC3xyaCXQ7mwUW?usp=sharing"
+        : null;
 
   const notebookLink = colabLink ? (
     <a href={colabLink} target="_blank" rel="noreferrer">

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -1,4 +1,4 @@
-import { CodeBlock } from "layout/Code";
+import CodeBlock from "layout/CodeBlock";
 import { getReformDefinitionCode } from "data/reformDefinitionCode";
 import Button from "../../../controls/Button";
 


### PR DESCRIPTION
## Description

We fix #168, i.e., we add syntax highlighting to the `Reproduce in Python` in the household and policy calculators. Since the GPT prompt in `Analysis` also used the same component, it is displayed closer to the theme in our new component but without syntax highlighting because prompts are just natural language.

## Changes

- Refactor the Python code generation and display logic into separate files. The new display component is called `CodeBlock`.
- We use [prism-react-renderer](https://github.com/FormidableLabs/prism-react-renderer) in `CodeBlock`.
  - We used some code from [this official sandbox](https://codesandbox.io/p/sandbox/prism-react-renderer-example-u6vhk?file=%2Fsrc%2Fstyles.js).
- The policy and household calculators use `CodeBlock` with language `"python"`. The `Analysis` component uses `CodeBlock` with language `"markdown"` (this is the most natural language supported by `prism` fit for GPT prompt but we are not ruling out better [options](https://github.com/FormidableLabs/prism-react-renderer#language)). 

## Screenshots

Policy:
<img width="795" alt="Screenshot 2023-12-20 at 12 38 51 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/8358aa52-e1d0-4aa7-a58f-05f893985629">

Household:
<img width="482" alt="Screenshot 2023-12-20 at 12 37 07 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/7be09d72-47b7-4f4c-afe5-7e0ec4e9c865">

Analysis:
<img width="795" alt="Screenshot 2023-12-20 at 12 38 31 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/1ccdc2e9-e9bf-4f4e-bf5a-90d87efb421c">


## Tests

We checked that the code was displayed properly for a couple of policy and household configurations.
