### PR TITLE
Reenable lint check in PR workflow and fix lint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,4 @@ deploy: build deploy-setup
 	rm main.py
 	rm requirements.txt
 format:
-	black . -l 79
-	npm run lint
+	npm run fix

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,5 @@ deploy: build deploy-setup
 	rm main.py
 	rm requirements.txt
 format:
+	black . -l 79
 	npm run fix

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "fix": "eslint --fix --ext js,jsx . && prettier -w .",
-    "lint": "eslint --ext js,jsx . && prettier . --write"
+    "lint": "eslint --ext js,jsx . && prettier -c ."
   },
   "eslintConfig": {
     "extends": [

--- a/src/PolicyEngineCountry.jsx
+++ b/src/PolicyEngineCountry.jsx
@@ -27,14 +27,14 @@ export default function LegacyPolicyEngineCountry(props) {
     countryId === "uk"
       ? 1
       : countryId === "us"
-      ? 2
-      : countryId === "ca"
-      ? 3
-      : countryId === "ng"
-      ? 4
-      : countryId === "il"
-      ? 5
-      : 1;
+        ? 2
+        : countryId === "ca"
+          ? 3
+          : countryId === "ng"
+            ? 4
+            : countryId === "il"
+              ? 5
+              : 1;
   const reformPolicyId = searchParams.get("reform") || defaultBaselinePolicy;
   const baselinePolicyId =
     searchParams.get("baseline") || defaultBaselinePolicy;

--- a/src/controls/LinkButton.jsx
+++ b/src/controls/LinkButton.jsx
@@ -49,13 +49,10 @@ export default function LinkButton(props) {
 
   if (isExternalLink) {
     return (
-      <Link
-        to={link}
-        target="_blank"
-      >
+      <Link to={link} target="_blank">
         {button}
       </Link>
-    )
+    );
   } else {
     return button;
   }

--- a/src/pages/household/output/NetIncomeBreakdown.jsx
+++ b/src/pages/household/output/NetIncomeBreakdown.jsx
@@ -215,7 +215,9 @@ function VariableArithmetic(props) {
     ));
   const childNodes = childAddNodes.concat(childSubtractNodes);
   const expandable =
-    (!hasReform || doesIncomeChange) && adds.length + subtracts.length > 0 && childNodes.length > 0;
+    (!hasReform || doesIncomeChange) &&
+    adds.length + subtracts.length > 0 &&
+    childNodes.length > 0;
 
   if (childrenOnly) {
     return (

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -74,8 +74,8 @@ function SinglePolicyChange(props) {
       ? "Enable"
       : "Disable"
     : value > oldVal
-    ? "Raise"
-    : "Lower";
+      ? "Raise"
+      : "Lower";
 
   return (
     <div

--- a/src/pages/policy/output/Analysis.jsx
+++ b/src/pages/policy/output/Analysis.jsx
@@ -168,8 +168,8 @@ export default function Analysis(props) {
             audienceValue === "ELI5"
               ? "5px 0 0 5px"
               : audienceValue === "Wonk"
-              ? "0 5px 5px 0"
-              : 0,
+                ? "0 5px 5px 0"
+                : 0,
           border: borderColor,
           borderRight: audienceValue !== "Wonk" ? "none" : borderColor,
           padding: "5px 10px",

--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -56,17 +56,17 @@ export default function AverageImpactByDecile(props) {
                           0,
                         )} per year.`
                       : change < -0.0001
-                      ? `This reform lowers the income<br>of households in the ${decile} decile<br>by an average of ${formatVariableValue(
-                          metadata.variables.household_net_income,
-                          -change,
-                          0,
-                        )} per year.`
-                      : change === 0
-                      ? `This reform has no impact on the income<br>of households in the ${decile} decile.`
-                      : (change > 0
-                          ? "This reform raises "
-                          : "This reform lowers ") +
-                        `the income<br>of households in the ${decile} decile<br>by less than 0.01%.`;
+                        ? `This reform lowers the income<br>of households in the ${decile} decile<br>by an average of ${formatVariableValue(
+                            metadata.variables.household_net_income,
+                            -change,
+                            0,
+                          )} per year.`
+                        : change === 0
+                          ? `This reform has no impact on the income<br>of households in the ${decile} decile.`
+                          : (change > 0
+                              ? "This reform raises "
+                              : "This reform lowers ") +
+                            `the income<br>of households in the ${decile} decile<br>by less than 0.01%.`;
                   }),
                   hovertemplate: `<b>Decile %{x}</b><br><br>%{customdata}<extra></extra>`,
                 }),
@@ -127,17 +127,17 @@ export default function AverageImpactByDecile(props) {
                         0,
                       )} per year.`
                     : change < -0.0001
-                    ? `This reform lowers the income of households in the ${decile} decile by an average of ${formatVariableValue(
-                        metadata.variables.household_net_income,
-                        -change,
-                        0,
-                      )} per year.`
-                    : change === 0
-                    ? `This reform has no impact on the income of households in the ${decile} decile.`
-                    : (change > 0
-                        ? "This reform raises "
-                        : "This reform lowers ") +
-                      ` the income of households in the ${decile} decile by less than 0.01%.`;
+                      ? `This reform lowers the income of households in the ${decile} decile by an average of ${formatVariableValue(
+                          metadata.variables.household_net_income,
+                          -change,
+                          0,
+                        )} per year.`
+                      : change === 0
+                        ? `This reform has no impact on the income of households in the ${decile} decile.`
+                        : (change > 0
+                            ? "This reform raises "
+                            : "This reform lowers ") +
+                          ` the income of households in the ${decile} decile by less than 0.01%.`;
                 setHoverCard({
                   title: `Decile ${data.points[0].x}`,
                   body: message,

--- a/src/pages/policy/output/AverageImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByWealthDecile.jsx
@@ -56,17 +56,17 @@ export default function AverageImpactByWealthDecile(props) {
                           0,
                         )} per year.`
                       : change < -0.0001
-                      ? `This reform lowers the income<br>of households in the ${decile} wealth decile<br>by an average of ${formatVariableValue(
-                          metadata.variables.household_net_income,
-                          -change,
-                          0,
-                        )} per year.`
-                      : change === 0
-                      ? `This reform has no impact on the income<br>of households in the ${decile} wealth decile.`
-                      : (change > 0
-                          ? "This reform raises "
-                          : "This reform lowers ") +
-                        `the income<br>of households in the ${decile} wealth decile<br>by less than 0.01%.`;
+                        ? `This reform lowers the income<br>of households in the ${decile} wealth decile<br>by an average of ${formatVariableValue(
+                            metadata.variables.household_net_income,
+                            -change,
+                            0,
+                          )} per year.`
+                        : change === 0
+                          ? `This reform has no impact on the income<br>of households in the ${decile} wealth decile.`
+                          : (change > 0
+                              ? "This reform raises "
+                              : "This reform lowers ") +
+                            `the income<br>of households in the ${decile} wealth decile<br>by less than 0.01%.`;
                   }),
                   hovertemplate: `<b>Decile %{x}</b><br><br>%{customdata}<extra></extra>`,
                 }),
@@ -127,17 +127,17 @@ export default function AverageImpactByWealthDecile(props) {
                         0,
                       )} per year.`
                     : change < -0.0001
-                    ? `This reform lowers the income of households in the ${decile} wealth decile by an average of ${formatVariableValue(
-                        metadata.variables.household_net_income,
-                        -change,
-                        0,
-                      )} per year.`
-                    : change === 0
-                    ? `This reform has no impact on the income of households in the ${decile} wealth decile.`
-                    : (change > 0
-                        ? "This reform raises "
-                        : "This reform lowers ") +
-                      ` the income of households in the ${decile} wealth decile by less than 0.01%.`;
+                      ? `This reform lowers the income of households in the ${decile} wealth decile by an average of ${formatVariableValue(
+                          metadata.variables.household_net_income,
+                          -change,
+                          0,
+                        )} per year.`
+                      : change === 0
+                        ? `This reform has no impact on the income of households in the ${decile} wealth decile.`
+                        : (change > 0
+                            ? "This reform raises "
+                            : "This reform lowers ") +
+                          ` the income of households in the ${decile} wealth decile by less than 0.01%.`;
                 setHoverCard({
                   title: `Decile ${data.points[0].x}`,
                   body: message,

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -102,13 +102,13 @@ export default function BudgetaryImpact(props) {
                       relevantFigure < 0
                         ? `This reform would increase<br>`
                         : relevantFigure > 0
-                        ? `This reform would reduce<br>`
-                        : `This reform would not impact<br>`;
+                          ? `This reform would reduce<br>`
+                          : `This reform would not impact<br>`;
                     body += label.toLowerCase().includes("tax")
                       ? label.toLowerCase()
                       : label.toLowerCase().includes("benefit")
-                      ? "benefit spending"
-                      : "the budget deficit";
+                        ? "benefit spending"
+                        : "the budget deficit";
                     if (relevantFigure === 0) {
                       body += ".";
                     } else {
@@ -175,13 +175,13 @@ export default function BudgetaryImpact(props) {
                   relevantFigure < 0
                     ? "This reform would increase "
                     : relevantFigure > 0
-                    ? "This reform would reduce "
-                    : "This reform would not impact ";
+                      ? "This reform would reduce "
+                      : "This reform would not impact ";
                 body += label.toLowerCase().includes("tax")
                   ? label.toLowerCase()
                   : label.toLowerCase().includes("benefit")
-                  ? "benefit spending"
-                  : "the budget deficit";
+                    ? "benefit spending"
+                    : "the budget deficit";
                 if (relevantFigure === 0) {
                   body += ".";
                 } else {

--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -148,10 +148,10 @@ export default function CliffImpact(props) {
                             baseline,
                           )} to ${formatter(reform)}`
                         : change < -0.0001
-                        ? `would fall ${percent(-change)}<br>from ${formatter(
-                            baseline,
-                          )} to ${formatter(reform)}`
-                        : `would remain at ${percent(baseline)}`
+                          ? `would fall ${percent(-change)}<br>from ${formatter(
+                              baseline,
+                            )} to ${formatter(reform)}`
+                          : `would remain at ${percent(baseline)}`
                     }.`;
                   }),
                   hovertemplate: `<b>%{x}</b><br><br>%{customdata}<extra></extra>`,
@@ -214,10 +214,10 @@ export default function CliffImpact(props) {
                         baseline,
                       )} to ${formatter(reform)}`
                     : change < -0.0001
-                    ? `would fall ${percent(-change)} from ${formatter(
-                        baseline,
-                      )} to ${formatter(reform)}`
-                    : `would remain at ${percent(baseline)}`
+                      ? `would fall ${percent(-change)} from ${formatter(
+                          baseline,
+                        )} to ${formatter(reform)}`
+                      : `would remain at ${percent(baseline)}`
                 }.`;
                 setHoverCard({
                   title: data.points[0].x,
@@ -245,10 +245,10 @@ export default function CliffImpact(props) {
     cliff_share_change === 0 && cliff_gap_change === 0
       ? "wouldn't affect cliffs"
       : cliff_share_change >= 0 && cliff_gap_change >= 0
-      ? "would make cliffs more prevalent"
-      : cliff_share_change <= 0 && cliff_gap_change <= 0
-      ? "would make cliffs less prevalent"
-      : "would have an ambiguous effect on cliffs"
+        ? "would make cliffs more prevalent"
+        : cliff_share_change <= 0 && cliff_gap_change <= 0
+          ? "would make cliffs less prevalent"
+          : "would have an ambiguous effect on cliffs"
   } ${label}`;
 
   const csvHeader = ["Metric", "Baseline", "Reform", "Change"];

--- a/src/pages/policy/output/DeepPovertyImpact.jsx
+++ b/src/pages/policy/output/DeepPovertyImpact.jsx
@@ -91,13 +91,13 @@ export default function DeepPovertyImpact(props) {
                             baseline,
                           )} to ${percent(reform)}.`
                         : change > 0.001
-                        ? `would rise ${percent(change)} from ${percent(
-                            baseline,
-                          )} to ${percent(reform)}.`
-                        : change === 0
-                        ? `would remain at ${percent(baseline)}.`
-                        : (change > 0 ? "would rise " : "would fall ") +
-                          `by less than 0.1%.`
+                          ? `would rise ${percent(change)} from ${percent(
+                              baseline,
+                            )} to ${percent(reform)}.`
+                          : change === 0
+                            ? `would remain at ${percent(baseline)}.`
+                            : (change > 0 ? "would rise " : "would fall ") +
+                              `by less than 0.1%.`
                     }`;
                   }),
                   hovertemplate: `<b>%{x}</b><br><br>%{customdata}<extra></extra>`,
@@ -157,13 +157,13 @@ export default function DeepPovertyImpact(props) {
                         baseline,
                       )} to ${percent(reform)}.`
                     : change > 0.001
-                    ? `would rise ${percent(change)} from ${percent(
-                        baseline,
-                      )} to ${percent(reform)}.`
-                    : change === 0
-                    ? `would remain at ${percent(baseline)}.`
-                    : (change > 0 ? "would rise " : "would fall ") +
-                      `by less than 0.1%.`
+                      ? `would rise ${percent(change)} from ${percent(
+                          baseline,
+                        )} to ${percent(reform)}.`
+                      : change === 0
+                        ? `would remain at ${percent(baseline)}.`
+                        : (change > 0 ? "would rise " : "would fall ") +
+                          `by less than 0.1%.`
                 }`;
                 setHoverCard({
                   title: group,
@@ -183,7 +183,8 @@ export default function DeepPovertyImpact(props) {
   const percentagePointChange =
     Math.round(
       Math.abs(
-        impact.poverty.deep_poverty.all.reform - impact.poverty.deep_poverty.all.baseline,
+        impact.poverty.deep_poverty.all.reform -
+          impact.poverty.deep_poverty.all.baseline,
       ) * 1000,
     ) / 10;
   const screenshotRef = useRef();
@@ -223,8 +224,8 @@ export default function DeepPovertyImpact(props) {
           {totalPovertyChange > 0
             ? `would raise the deep poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
             : totalPovertyChange < 0
-            ? `would lower the deep poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
-            : `wouldn't change the deep poverty rate ${label}`}
+              ? `would lower the deep poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
+              : `wouldn't change the deep poverty rate ${label}`}
         </h2>
         <HoverCard>
           <DeepPovertyImpactPlot />

--- a/src/pages/policy/output/DeepPovertyImpactByGender.jsx
+++ b/src/pages/policy/output/DeepPovertyImpactByGender.jsx
@@ -96,10 +96,10 @@ export default function DeepPovertyImpactByGender(props) {
                             baseline,
                           )} to ${percent(reform)}.`
                         : change > 0.001
-                        ? `would rise ${percent(change)} from ${percent(
-                            baseline,
-                          )} to ${percent(reform)}.`
-                        : `would remain at ${percent(baseline)}.`
+                          ? `would rise ${percent(change)} from ${percent(
+                              baseline,
+                            )} to ${percent(reform)}.`
+                          : `would remain at ${percent(baseline)}.`
                     }`;
                   }),
                   hovertemplate: `<b>%{x}</b><br><br>%{customdata}<extra></extra>`,
@@ -167,10 +167,10 @@ export default function DeepPovertyImpactByGender(props) {
                         baseline,
                       )} to ${percent(reform)}.`
                     : change > 0.001
-                    ? `would rise ${percent(change)} from ${percent(
-                        baseline,
-                      )} to ${percent(reform)}.`
-                    : `would remain at ${percent(baseline)}.`
+                      ? `would rise ${percent(change)} from ${percent(
+                          baseline,
+                        )} to ${percent(reform)}.`
+                      : `would remain at ${percent(baseline)}.`
                 }`;
                 setHoverCard({
                   title: group,
@@ -235,8 +235,8 @@ export default function DeepPovertyImpactByGender(props) {
           {totalPovertyChange > 0
             ? `would raise the deep poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
             : totalPovertyChange < 0
-            ? `would reduce the deep poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
-            : `wouldn't change the deep poverty rate ${label}`}
+              ? `would reduce the deep poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
+              : `wouldn't change the deep poverty rate ${label}`}
         </h2>
         <HoverCard>
           <DeepPovertyImpactByGenderPlot />

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -66,17 +66,17 @@ export default function InequalityImpact(props) {
                             )}, a change of ` +
                             `${change.toFixed(3)}.`
                         : change < -0.001
-                        ? `This reform would reduce<br>the Gini index of net income<br>from ` +
-                          `${baseline.toFixed(3)} to ${reform.toFixed(
-                            3,
-                          )}, a change of ` +
-                          `${percent(change)}.`
-                        : change === 0
-                        ? "This reform would not impact<br>the Gini index of net income."
-                        : (change > 0
-                            ? "This reform would increase "
-                            : "This reform would reduce ") +
-                          "<br>the Gini index of net income<br>by less than 0.1%.";
+                          ? `This reform would reduce<br>the Gini index of net income<br>from ` +
+                            `${baseline.toFixed(3)} to ${reform.toFixed(
+                              3,
+                            )}, a change of ` +
+                            `${percent(change)}.`
+                          : change === 0
+                            ? "This reform would not impact<br>the Gini index of net income."
+                            : (change > 0
+                                ? "This reform would increase "
+                                : "This reform would reduce ") +
+                              "<br>the Gini index of net income<br>by less than 0.1%.";
                     } else if (label === "Top 10% share") {
                       // 'This reform reduces/increases benefit spending by £X/This reform has no impact on benefit spending'
                       const baseline =
@@ -90,17 +90,17 @@ export default function InequalityImpact(props) {
                             )}, an increase of ` +
                             `${percent(change)}.`
                         : change < -0.001
-                        ? `This reform would reduce the share<br>of total net income held by people<br>in the top 10% of households<br>from ` +
-                          `${percent(baseline)} to ${percent(
-                            reform,
-                          )}, a reduction of ` +
-                          `${percent(-change)}.`
-                        : change === 0
-                        ? "This reform would not impact the share<br>of total net income held by people<br>in the top 10% of households."
-                        : (change > 0
-                            ? "This reform would increase "
-                            : "This reform would reduce ") +
-                          "the share<br>of total net income held by people<br>in the top 10% of households<br>by less than 0.1%.";
+                          ? `This reform would reduce the share<br>of total net income held by people<br>in the top 10% of households<br>from ` +
+                            `${percent(baseline)} to ${percent(
+                              reform,
+                            )}, a reduction of ` +
+                            `${percent(-change)}.`
+                          : change === 0
+                            ? "This reform would not impact the share<br>of total net income held by people<br>in the top 10% of households."
+                            : (change > 0
+                                ? "This reform would increase "
+                                : "This reform would reduce ") +
+                              "the share<br>of total net income held by people<br>in the top 10% of households<br>by less than 0.1%.";
                     } else {
                       // 'This reform reduces/increases the budget deficit by £X/This reform has no impact on the budget deficit'
                       const baseline =
@@ -114,17 +114,17 @@ export default function InequalityImpact(props) {
                             )}, an increase of ` +
                             `${percent(change)}.`
                         : change < -0.001
-                        ? `This reform would reduce the share<br>of total net income held by people<br>in the top 1% of households<br>from ` +
-                          `${percent(baseline)} to ${percent(
-                            reform,
-                          )}, a reduction of ` +
-                          `${percent(-change)}.`
-                        : change === 0
-                        ? "This reform would not impact the share<br>of total net income held by people<br>in the top 1% of households."
-                        : (change > 0
-                            ? "This reform would increase "
-                            : "This reform would reduce ") +
-                          "the share<br>of total net income held by people<br>in the top 10% of households<br>by less than 0.1%.";
+                          ? `This reform would reduce the share<br>of total net income held by people<br>in the top 1% of households<br>from ` +
+                            `${percent(baseline)} to ${percent(
+                              reform,
+                            )}, a reduction of ` +
+                            `${percent(-change)}.`
+                          : change === 0
+                            ? "This reform would not impact the share<br>of total net income held by people<br>in the top 1% of households."
+                            : (change > 0
+                                ? "This reform would increase "
+                                : "This reform would reduce ") +
+                              "the share<br>of total net income held by people<br>in the top 10% of households<br>by less than 0.1%.";
                     }
                   }),
                   hovertemplate: `<b>%{x}</b><br><br>%{customdata}<extra></extra>`,
@@ -184,15 +184,15 @@ export default function InequalityImpact(props) {
                   ${baseline.toFixed(3)} to ${reform.toFixed(3)}, a change of
                   ${change.toFixed(3)}.`
                       : change < -0.001
-                      ? `This reform would reduce the Gini index of net income from
+                        ? `This reform would reduce the Gini index of net income from
                   ${baseline.toFixed(3)} to ${reform.toFixed(3)}, a change of
                   ${percent(change)}.`
-                      : change === 0
-                      ? "This reform would not impact the Gini index of net income."
-                      : (change > 0
-                          ? "This reform would increase "
-                          : "This reform would reduce ") +
-                        "the Gini index of net income by less than 0.1%.";
+                        : change === 0
+                          ? "This reform would not impact the Gini index of net income."
+                          : (change > 0
+                              ? "This reform would increase "
+                              : "This reform would reduce ") +
+                            "the Gini index of net income by less than 0.1%.";
                 } else if (label === "Top 10% share") {
                   // 'This reform reduces/increases benefit spending by £X/This reform has no impact on benefit spending'
                   const baseline = impact.inequality.top_10_pct_share.baseline;
@@ -204,15 +204,15 @@ export default function InequalityImpact(props) {
                   ${percent(baseline)} to ${percent(reform)}, an increase of
                   ${percent(change)}.`
                       : change < -0.001
-                      ? `This reform would reduce the share of total net income held by people in the top 10% of households from
+                        ? `This reform would reduce the share of total net income held by people in the top 10% of households from
                   ${percent(baseline)} to ${percent(reform)}, a reduction of
                   ${percent(-change)}.`
-                      : change === 0
-                      ? "This reform would not impact the share of total net income held by people in the top 10% of households."
-                      : (change > 0
-                          ? "This reform would increase "
-                          : "This reform would reduce ") +
-                        "the share of total net income held by people in the top 10% of households by less than 0.1%.";
+                        : change === 0
+                          ? "This reform would not impact the share of total net income held by people in the top 10% of households."
+                          : (change > 0
+                              ? "This reform would increase "
+                              : "This reform would reduce ") +
+                            "the share of total net income held by people in the top 10% of households by less than 0.1%.";
                 } else {
                   // 'This reform reduces/increases the budget deficit by £X/This reform has no impact on the budget deficit'
                   const baseline = impact.inequality.top_1_pct_share.baseline;
@@ -224,15 +224,15 @@ export default function InequalityImpact(props) {
                   ${percent(baseline)} to ${percent(reform)}, an increase of
                   ${percent(change)}.`
                       : change < -0.001
-                      ? `This reform would reduce the share of total net income held by people in the top 1% of households from
+                        ? `This reform would reduce the share of total net income held by people in the top 1% of households from
                   ${percent(baseline)} to ${percent(reform)}, a reduction of
                   ${percent(-change)}.`
-                      : change === 0
-                      ? "This reform would not impact the share of total net income held by people in the top 1% of households."
-                      : (change > 0
-                          ? "This reform would increase "
-                          : "This reform would reduce ") +
-                        "the share of total net income held by people in the top 10% of households by less than 0.1%.";
+                        : change === 0
+                          ? "This reform would not impact the share of total net income held by people in the top 1% of households."
+                          : (change > 0
+                              ? "This reform would increase "
+                              : "This reform would reduce ") +
+                            "the share of total net income held by people in the top 10% of households by less than 0.1%.";
                 }
                 setHoverCard({
                   title: label,
@@ -254,8 +254,8 @@ export default function InequalityImpact(props) {
     metricChanges[0] > 0 && metricChanges[1] > 0 && metricChanges[2] > 0
       ? "positive"
       : metricChanges[0] < 0 && metricChanges[1] < 0 && metricChanges[2] < 0
-      ? "negative"
-      : "ambiguous";
+        ? "negative"
+        : "ambiguous";
 
   const urlParams = new URLSearchParams(window.location.search);
   const region = urlParams.get("region");
@@ -302,8 +302,8 @@ export default function InequalityImpact(props) {
           {impactLabel === "positive"
             ? ` would increase inequality ${label}`
             : impactLabel === "negative"
-            ? ` would reduce inequality ${label}`
-            : ` would have an ambiguous effect on inequality ${label}`}
+              ? ` would reduce inequality ${label}`
+              : ` would have an ambiguous effect on inequality ${label}`}
         </h2>
         <HoverCard>
           <InequalityImpactPlot />

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -128,8 +128,8 @@ export default function PolicyReproducibility(props) {
     metadata.countryId == "uk"
       ? "https://colab.research.google.com/drive/16h6v-EAYk5n4qZ4krXbmFG4_oKAaflo9#scrollTo=TBTIupkjIThF"
       : metadata.countryId == "us"
-      ? "https://colab.research.google.com/drive/1hqA9a2LrNj2leJ9YtXXC3xyaCXQ7mwUW?usp=sharing"
-      : null;
+        ? "https://colab.research.google.com/drive/1hqA9a2LrNj2leJ9YtXXC3xyaCXQ7mwUW?usp=sharing"
+        : null;
 
   const notebookLink = colabLink ? (
     <a href={colabLink} target="_blank" rel="noreferrer">

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -89,13 +89,13 @@ export default function PovertyImpact(props) {
                             baseline,
                           )} to ${percent(reform)}.`
                         : change > 0.001
-                        ? `would rise ${percent(change)} from ${percent(
-                            baseline,
-                          )} to ${percent(reform)}.`
-                        : change === 0
-                        ? `would remain at ${percent(baseline)}.`
-                        : (change > 0 ? "would rise " : "would fall ") +
-                          `by less than 0.1%.`
+                          ? `would rise ${percent(change)} from ${percent(
+                              baseline,
+                            )} to ${percent(reform)}.`
+                          : change === 0
+                            ? `would remain at ${percent(baseline)}.`
+                            : (change > 0 ? "would rise " : "would fall ") +
+                              `by less than 0.1%.`
                     }`;
                   }),
                   hovertemplate: `<b>%{x}</b><br><br>%{customdata}<extra></extra>`,
@@ -154,13 +154,13 @@ export default function PovertyImpact(props) {
                         baseline,
                       )} to ${percent(reform)}.`
                     : change > 0.001
-                    ? `would rise ${percent(change)} from ${percent(
-                        baseline,
-                      )} to ${percent(reform)}.`
-                    : change === 0
-                    ? `would remain at ${percent(baseline)}.`
-                    : (change > 0 ? "would rise " : "would fall ") +
-                      ` by less than 0.1%.`
+                      ? `would rise ${percent(change)} from ${percent(
+                          baseline,
+                        )} to ${percent(reform)}.`
+                      : change === 0
+                        ? `would remain at ${percent(baseline)}.`
+                        : (change > 0 ? "would rise " : "would fall ") +
+                          ` by less than 0.1%.`
                 }`;
                 setHoverCard({
                   title: group,
@@ -218,8 +218,8 @@ export default function PovertyImpact(props) {
           {totalPovertyChange > 0
             ? `would raise the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
             : totalPovertyChange < 0
-            ? `would reduce the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
-            : `wouldn't change the poverty rate ${label}`}
+              ? `would reduce the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
+              : `wouldn't change the poverty rate ${label}`}
         </h2>
         <HoverCard>
           <PovertyImpactPlot />

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -91,13 +91,13 @@ export default function PovertyImpactByGender(props) {
                             baseline,
                           )} to ${percent(reform)}.`
                         : change > 0.001
-                        ? `would rise ${percent(change)} from ${percent(
-                            baseline,
-                          )} to ${percent(reform)}.`
-                        : change === 0
-                        ? `would remain at ${percent(baseline)}.`
-                        : (change > 0 ? "would rise " : "would fall ") +
-                          `by less than 0.1%.`
+                          ? `would rise ${percent(change)} from ${percent(
+                              baseline,
+                            )} to ${percent(reform)}.`
+                          : change === 0
+                            ? `would remain at ${percent(baseline)}.`
+                            : (change > 0 ? "would rise " : "would fall ") +
+                              `by less than 0.1%.`
                     }`;
                   }),
                   hovertemplate: `<b>%{x}</b><br><br>%{customdata}<extra></extra>`,
@@ -165,13 +165,13 @@ export default function PovertyImpactByGender(props) {
                         baseline,
                       )} to ${percent(reform)}.`
                     : change > 0.001
-                    ? `would rise ${percent(change)} from ${percent(
-                        baseline,
-                      )} to ${percent(reform)}.`
-                    : change === 0
-                    ? `would remain at ${percent(baseline)}.`
-                    : (change > 0 ? "would rise " : "would fall ") +
-                      `by less than 0.1%.`
+                      ? `would rise ${percent(change)} from ${percent(
+                          baseline,
+                        )} to ${percent(reform)}.`
+                      : change === 0
+                        ? `would remain at ${percent(baseline)}.`
+                        : (change > 0 ? "would rise " : "would fall ") +
+                          `by less than 0.1%.`
                 }`;
                 setHoverCard({
                   title: group,
@@ -235,8 +235,8 @@ export default function PovertyImpactByGender(props) {
           {totalPovertyChange > 0
             ? `would raise the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
             : totalPovertyChange < 0
-            ? `would reduce the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
-            : `wouldn't change the poverty rate ${label}`}
+              ? `would reduce the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
+              : `wouldn't change the poverty rate ${label}`}
         </h2>
         <HoverCard>
           <PovertyImpactByGenderPlot />

--- a/src/pages/policy/output/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/PovertyImpactByRace.jsx
@@ -115,13 +115,13 @@ export default function PovertyImpactByRace(props) {
                             baseline,
                           )} to ${percent(reform)}.`
                         : change > 0.001
-                        ? `would rise ${percent(change)} from ${percent(
-                            baseline,
-                          )} to ${percent(reform)}.`
-                        : change === 0
-                        ? `would remain at ${percent(baseline)}.`
-                        : (change > 0 ? "would rise " : "would fall ") +
-                          `by less than 0.1%.`
+                          ? `would rise ${percent(change)} from ${percent(
+                              baseline,
+                            )} to ${percent(reform)}.`
+                          : change === 0
+                            ? `would remain at ${percent(baseline)}.`
+                            : (change > 0 ? "would rise " : "would fall ") +
+                              `by less than 0.1%.`
                     }`;
                   }),
                   hovertemplate: `<b>%{x}</b><br><br>%{customdata}<extra></extra>`,
@@ -193,13 +193,13 @@ export default function PovertyImpactByRace(props) {
                         baseline,
                       )} to ${percent(reform)}.`
                     : change > 0.001
-                    ? `would rise ${percent(change)} from ${percent(
-                        baseline,
-                      )} to ${percent(reform)}.`
-                    : change === 0
-                    ? `would remain at ${percent(baseline)}.`
-                    : (change > 0 ? "would rise " : "would fall ") +
-                      `by less than 0.1%.`
+                      ? `would rise ${percent(change)} from ${percent(
+                          baseline,
+                        )} to ${percent(reform)}.`
+                      : change === 0
+                        ? `would remain at ${percent(baseline)}.`
+                        : (change > 0 ? "would rise " : "would fall ") +
+                          `by less than 0.1%.`
                 }`;
                 setHoverCard({
                   title: group,
@@ -263,8 +263,8 @@ export default function PovertyImpactByRace(props) {
           {totalPovertyChange > 0
             ? `would raise the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
             : totalPovertyChange < 0
-            ? `would reduce the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
-            : `wouldn't change the poverty rate ${label}`}
+              ? `would reduce the poverty rate ${label} by ${povertyRateChange} (${percentagePointChange}pp)`
+              : `wouldn't change the poverty rate ${label}`}
         </h2>
         <HoverCard>
           <PovertyImpactByRacePlot />

--- a/src/pages/policy/output/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByDecile.jsx
@@ -53,15 +53,15 @@ export default function RelativeImpactByDecile(props) {
                           relativeChange,
                         )}.`
                       : relativeChange < -0.001
-                      ? `This reform would lower the income<br>of households in the ${decile} decile<br>by an average of ${percent(
-                          -relativeChange,
-                        )}.`
-                      : relativeChange === 0
-                      ? `This reform would not impact the income<br>of households in the ${decile} decile.`
-                      : (relativeChange > 0
-                          ? "This reform would raise "
-                          : "This reform would lower ") +
-                        `the income<br>of households in the ${decile} decile<br>by less than 0.1%.`;
+                        ? `This reform would lower the income<br>of households in the ${decile} decile<br>by an average of ${percent(
+                            -relativeChange,
+                          )}.`
+                        : relativeChange === 0
+                          ? `This reform would not impact the income<br>of households in the ${decile} decile.`
+                          : (relativeChange > 0
+                              ? "This reform would raise "
+                              : "This reform would lower ") +
+                            `the income<br>of households in the ${decile} decile<br>by less than 0.1%.`;
                   }),
                   hovertemplate: `<b>Decile %{x}</b><br><br>%{customdata}<extra></extra>`,
                 }),
@@ -119,15 +119,15 @@ export default function RelativeImpactByDecile(props) {
                         relativeChange,
                       )}.`
                     : relativeChange < -0.001
-                    ? `This reform would lower the income of households in the ${decile} decile by an average of ${percent(
-                        -relativeChange,
-                      )}.`
-                    : relativeChange === 0
-                    ? `This reform would not impact the income of households in the ${decile} decile.`
-                    : (relativeChange > 0
-                        ? "This reform would raise "
-                        : "This reform would lower ") +
-                      ` the income of households in the ${decile} decile by less than 0.1%.`;
+                      ? `This reform would lower the income of households in the ${decile} decile by an average of ${percent(
+                          -relativeChange,
+                        )}.`
+                      : relativeChange === 0
+                        ? `This reform would not impact the income of households in the ${decile} decile.`
+                        : (relativeChange > 0
+                            ? "This reform would raise "
+                            : "This reform would lower ") +
+                          ` the income of households in the ${decile} decile by less than 0.1%.`;
                 setHoverCard({
                   title: `Decile ${data.points[0].x}`,
                   body: message,

--- a/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByWealthDecile.jsx
@@ -53,15 +53,15 @@ export default function RelativeImpactByWealthDecile(props) {
                           relativeChange,
                         )}.`
                       : relativeChange < -0.001
-                      ? `This reform would lower the income<br>of households in the ${decile} decile<br>by an average of ${percent(
-                          -relativeChange,
-                        )}.`
-                      : relativeChange === 0
-                      ? `This reform would ot impact the income<br>of households in the ${decile} decile.`
-                      : (relativeChange > 0
-                          ? "This reform would raise "
-                          : "This reform would lower ") +
-                        `the income<br>of households in the ${decile} decile<br>by less than 0.1%.`;
+                        ? `This reform would lower the income<br>of households in the ${decile} decile<br>by an average of ${percent(
+                            -relativeChange,
+                          )}.`
+                        : relativeChange === 0
+                          ? `This reform would ot impact the income<br>of households in the ${decile} decile.`
+                          : (relativeChange > 0
+                              ? "This reform would raise "
+                              : "This reform would lower ") +
+                            `the income<br>of households in the ${decile} decile<br>by less than 0.1%.`;
                   }),
                   hovertemplate: `<b>Decile %{x}</b><br><br>%{customdata}<extra></extra>`,
                 }),
@@ -119,15 +119,15 @@ export default function RelativeImpactByWealthDecile(props) {
                         relativeChange,
                       )}.`
                     : relativeChange < -0.001
-                    ? `This reform would lower the income of households in the ${decile} decile by an average of ${percent(
-                        -relativeChange,
-                      )}.`
-                    : relativeChange === 0
-                    ? `This reform would ot impact the income of households in the ${decile} decile.`
-                    : (relativeChange > 0
-                        ? "This reform would raise "
-                        : "This reform would lower ") +
-                      ` the income of households in the ${decile} decile by less than 0.1%.`;
+                      ? `This reform would lower the income of households in the ${decile} decile by an average of ${percent(
+                          -relativeChange,
+                        )}.`
+                      : relativeChange === 0
+                        ? `This reform would ot impact the income of households in the ${decile} decile.`
+                        : (relativeChange > 0
+                            ? "This reform would raise "
+                            : "This reform would lower ") +
+                          ` the income of households in the ${decile} decile by less than 0.1%.`;
                 setHoverCard({
                   title: `Decile ${data.points[0].x}`,
                   body: message,

--- a/src/redesign/components/PolicyEngine.jsx
+++ b/src/redesign/components/PolicyEngine.jsx
@@ -67,14 +67,14 @@ export default function PolicyEngine({ pathname }) {
     countryId === "uk"
       ? 1
       : countryId === "us"
-      ? 2
-      : countryId === "ca"
-      ? 3
-      : countryId === "ng"
-      ? 4
-      : countryId === "il"
-      ? 5
-      : 1;
+        ? 2
+        : countryId === "ca"
+          ? 3
+          : countryId === "ng"
+            ? 4
+            : countryId === "il"
+              ? 5
+              : 1;
   const reformPolicyId = searchParams.get("reform") || defaultBaselinePolicy;
   const baselinePolicyId =
     searchParams.get("baseline") || defaultBaselinePolicy;

--- a/src/redesign/data/Posts.jsx
+++ b/src/redesign/data/Posts.jsx
@@ -717,13 +717,14 @@ let posts = [
   },
   {
     title: "Autumn 2023 model calibration update",
-    description: "Evaluating PolicyEngine's model performance with the latest official statistics.",
+    description:
+      "Evaluating PolicyEngine's model performance with the latest official statistics.",
     date: "2023-12-04 09:00:00",
     filename: "uk-calibration-2023-q4.ipynb",
     tags: ["uk", "technical"],
     image: "uk-calibration-dec-2023-update.png",
     authors: ["nikhil-woodruff"],
-  }
+  },
 ].sort((a, b) => (a.date < b.date ? 1 : -1));
 
 for (let post of posts) {


### PR DESCRIPTION
## Description

Fix #1006 by using the right flags for lint. The lint action `prettier -c` was used to check for errors but in #902 was changed to `prettier -w` which does not do anything in the context of the PR workflow. We switch back to using `-c` again, and use `fix` instead of `lint` in the Makefile.