### PR TITLE
Create Twitter feed with Athabasca Dev component

### DIFF
--- a/src/redesign/components/Footer.jsx
+++ b/src/redesign/components/Footer.jsx
@@ -48,7 +48,8 @@ function ContactUs() {
 
 function TwitterEmbed() {
   const displayCategory = useDisplayCategory();
-  const athabascaTwitterLink = "https://www.athabasca.dev/hydra/content/twitteriframes/QOJXetYBdppnFEcjtYUDRuWJmXAMPotTWDeqkkbMQeCkJKwB.html?v=AtCahfJd";
+  const athabascaTwitterLink =
+    "https://www.athabasca.dev/hydra/content/twitteriframes/QOJXetYBdppnFEcjtYUDRuWJmXAMPotTWDeqkkbMQeCkJKwB.html?v=AtCahfJd";
 
   return (
     <div
@@ -57,15 +58,15 @@ function TwitterEmbed() {
         marginRight: 20,
       }}
     >
-      <iframe 
+      <iframe
         scrolling="no" // This is deprecated, but essential to function correctly
         height="100%"
         style={{
           width: "100%",
           height: displayCategory === "mobile" ? "500px" : "100%",
           border: "none",
-          borderRadius: "12px"
-         }}
+          borderRadius: "12px",
+        }}
         src={athabascaTwitterLink}
       />
     </div>

--- a/src/redesign/components/Footer.jsx
+++ b/src/redesign/components/Footer.jsx
@@ -47,20 +47,27 @@ function ContactUs() {
 }
 
 function TwitterEmbed() {
+  const displayCategory = useDisplayCategory();
+  const athabascaTwitterLink = "https://www.athabasca.dev/hydra/content/twitteriframes/QOJXetYBdppnFEcjtYUDRuWJmXAMPotTWDeqkkbMQeCkJKwB.html?v=AtCahfJd";
+
   return (
     <div
       style={{
-        marginLeft: 40,
-        marginRight: 40,
+        marginLeft: 20,
+        marginRight: 20,
       }}
     >
-      <a
-        className="twitter-timeline"
-        href="https://twitter.com/ThePolicyEngine?ref_src=twsrc%5Etfw"
-        {...{
-          "data-height": "300",
-        }}
-      ></a>
+      <iframe 
+        scrolling="no" // This is deprecated, but essential to function correctly
+        height="100%"
+        style={{
+          width: "100%",
+          height: displayCategory === "mobile" ? "500px" : "100%",
+          border: "none",
+          borderRadius: "12px"
+         }}
+        src={athabascaTwitterLink}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Description
Creates a new Twitter feed using an iframe from Athabasca Dev so as to allow users without Twitter accounts or who aren't logged in to see PolicyEngine's feed. Fixes #925. Linking @orestisathanasopoulos for visibility.

## Screenshots
Loom video available at https://www.loom.com/share/23393aea7ac342748d91ca711ec2a9fb?sid=b84d90b1-5086-4c22-b221-0f6e8e24d371.

Note that I am unsure as to the permanence of the iframe link embedded in this component. Athabasca Dev's team assured me that the hashes are permanent, but I'm making this a draft so as to allow us to check back a few days from now to make sure the link persists.