### PR TITLE
Change the style of connectors in `BudgetaryImpact` chart

### DIFF
--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -83,7 +83,9 @@ export default function BudgetaryImpact(props) {
                     : style.colors.BLUE,
               },
             },
-            connector: { line: { color: style.colors.DARK_GRAY } },
+            connector: {
+              line: { color: style.colors.GRAY, width: 1, dash: "dot" },
+            },
             ...(useHoverCard
               ? {
                   hoverinfo: "none",


### PR DESCRIPTION
## Description

We fix #1005. Before this fix the connectors in `BudgetaryImpact` would meld with thin bars making it hard to tell that it was a waterfall chart. Now, we use a connector that is thinner, lighter in color, and dashed -- the dashes were added to differentiate the connectors from horizontal guides.

## Screenshots

<img width="873" alt="Screenshot 2023-12-23 at 11 22 52 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/89d6e081-fc1e-4777-a1dc-7b6633375376">

## Tests

We tested that the connectors were displayed correctly for a couple of configurations.

