### PR TITLE
Fix bug: current change in net income dot doesn't display 

### DIFF
--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -379,7 +379,7 @@ function BaselineReformDeltaPlot(props) {
   const deltaArray = reformArray.map(
     (value, index) => value - baselineArray[index],
   );
-  const currentDelta = [currentValue - baselineValue];
+  const currentDelta = currentValue - baselineValue;
   let data = [
     {
       x: earningsArray,


### PR DESCRIPTION
## Description

Fix #1014. This is a regression due to a type error in #979.

## Changes

Fixed the type error: `currentDelta` is no longer surrounded by `[]`.

## Screenshots
<img width="679" alt="Screenshot 2023-12-25 at 9 59 36 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/e6af375c-4095-4099-8369-f4fcbc2e61d2">

## Tests

Tested a few configurations and checked that similar type errors were not introduced in other household charts.
