### PR TITLE
Remove hardcoding of year

### DIFF
--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -1,6 +1,7 @@
 import { countryApiCall } from "./call";
 import { capitalize } from "./language";
 import { defaultHouseholds } from "../data/defaultHouseholds";
+import { defaultYear } from "data/constants";
 
 export function removePerson(situation, name) {
   // Remove a person from the situation
@@ -273,9 +274,8 @@ export function getPlotlyAxisFormat(unit, values, precisionOverride) {
       minYear = Number(minYear.match(/\d+/)[0]);
       maxYear = Number(maxYear.match(/\d+/)[0]);
     } else {
-      const currentYear = new Date().getFullYear();
-      minYear = currentYear;
-      maxYear = currentYear;
+      minYear = defaultYear;
+      maxYear = defaultYear;
     }
     return {
       range: [minYear - 5 + "-01-01", maxYear + 5 + "-12-31"],

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,3 +1,3 @@
 export const defaultYear = new Date().getFullYear();
-export const defaultStartDate = defaultYear.concat("-01-01");
-export const defaultEndDate = (defaultYear + 5).concat("-12-31");
+export const defaultStartDate = defaultYear.toString().concat("-01-01");
+export const defaultEndDate = (defaultYear + 5).toString().concat("-12-31");

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,0 +1,3 @@
+export const defaultYear = new Date().getFullYear();
+export const defaultStartDate = defaultYear.concat("-01-01");
+export const defaultEndDate = (defaultYear + 5).concat("-12-31");

--- a/src/data/countChildrenVars.js
+++ b/src/data/countChildrenVars.js
@@ -1,3 +1,5 @@
+import { defaultYear } from "./constants";
+
 export const childNames = {
   us: "dependent",
   default: "child",
@@ -6,22 +8,22 @@ export const childNames = {
 export const defaultChildren = {
   us: {
     age: {
-      2024: 10,
+      [defaultYear]: 10,
     },
     is_tax_unit_dependent: {
-      2024: true,
+      [defaultYear]: true,
     },
   },
   default: {
     age: {
-      2024: 10,
+      [defaultYear]: 10,
     },
   },
 };
 
 export const childCountFilters = {
-  us: (person) => person?.is_tax_unit_dependent?.["2024"],
-  default: (person) => person?.age?.[2024] < 18,
+  us: (person) => person?.is_tax_unit_dependent?.[defaultYear],
+  default: (person) => person?.age?.[defaultYear] < 18,
 };
 
 export const childAdders = {
@@ -43,7 +45,7 @@ export const childAdders = {
     newSituation.households["your household"].members.push(childName);
     newSituation.marital_units[`${childName}'s marital unit`] = {
       members: [childName],
-      marital_unit_id: { 2024: childCount + 1 },
+      marital_unit_id: { [defaultYear]: childCount + 1 },
     };
     return newSituation;
   },

--- a/src/layout/Footer.jsx
+++ b/src/layout/Footer.jsx
@@ -1,4 +1,5 @@
 import useMobile from "./Responsive";
+import { defaultYear } from "data/constants";
 
 export default function Footer(props) {
   const { countryId } = props;
@@ -13,7 +14,7 @@ export default function Footer(props) {
     `/${countryId}/privacy`,
   ];
   const labels = [
-    "PolicyEngine © 2023",
+    `PolicyEngine © ${defaultYear}`,
     "About",
     "Contact",
     "Donate",

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -7,6 +7,7 @@ import {
   getNewHouseholdId,
 } from "../api/variables";
 import { copySearchParams, countryApiCall } from "../api/call";
+import { defaultYear } from "data/constants";
 import { useEffect, useState } from "react";
 import { Result } from "antd";
 
@@ -462,7 +463,12 @@ export function updateHousehold(householdInput, metadata) {
  * @returns {Number} The household's default year
  */
 export function getHouseholdYear(householdInput) {
-  // Determine current year present in household
-  const householdYear = Object.keys(householdInput["people"]["you"]["age"])[0];
-  return householdYear;
+  // Determine if [people][you][age][year] is present in household;
+  // if so, return this; if not, return the current year
+
+  const householdYear = Object.keys(householdInput?.["people"]?.["you"]?.["age"])[0];
+  if (householdYear) {
+    return householdYear;
+  }
+  return defaultYear;
 }

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -418,7 +418,8 @@ export function updateHousehold(householdInput, metadata) {
     for (const entity in householdInput[entityPlural]) {
       // Then over all variables within each entity...
       for (const variable in householdInput[entityPlural][entity]) {
-        const currentVal = householdInput[entityPlural][entity][variable][householdYear];
+        const currentVal =
+          householdInput[entityPlural][entity][variable][householdYear];
 
         // If the variable is a reserved one, do nothing and continue
         if (reservedInputs.includes(variable)) {

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -466,7 +466,9 @@ export function getHouseholdYear(householdInput) {
   // Determine if [people][you][age][year] is present in household;
   // if so, return this; if not, return the current year
 
-  const householdYear = Object.keys(householdInput?.["people"]?.["you"]?.["age"])[0];
+  const householdYear = Object.keys(
+    householdInput?.["people"]?.["you"]?.["age"],
+  )[0];
   if (householdYear) {
     return householdYear;
   }

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -409,13 +409,16 @@ export function updateHousehold(householdInput, metadata) {
   // Copy householdInput into mutable variable
   let editedHousehold = JSON.parse(JSON.stringify(householdInput));
 
+  // Determine current year present in household
+  let householdYear = Object.keys(householdInput["people"]["you"]["age"])[0];
+
   // Map over all plural entity terms...
   for (const entityPlural in householdInput) {
     // Then over all entities...
     for (const entity in householdInput[entityPlural]) {
       // Then over all variables within each entity...
       for (const variable in householdInput[entityPlural][entity]) {
-        const currentVal = householdInput[entityPlural][entity][variable][2024];
+        const currentVal = householdInput[entityPlural][entity][variable][householdYear];
 
         // If the variable is a reserved one, do nothing and continue
         if (reservedInputs.includes(variable)) {

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -386,6 +386,7 @@ function HouseholdLeftSidebar(props) {
     </div>
   );
 }
+
 /**
  * Updates households to remove yearly variables and bring them in line with
  * newest API version
@@ -410,7 +411,7 @@ export function updateHousehold(householdInput, metadata) {
   let editedHousehold = JSON.parse(JSON.stringify(householdInput));
 
   // Determine current year present in household
-  let householdYear = Object.keys(householdInput["people"]["you"]["age"])[0];
+  const householdYear = getHouseholdYear(householdInput);
 
   // Map over all plural entity terms...
   for (const entityPlural in householdInput) {
@@ -453,4 +454,15 @@ export function updateHousehold(householdInput, metadata) {
   }
 
   return editedHousehold;
+}
+
+/**
+ * Determine a household object's current year
+ * @param {Object} householdInput An existing household input object
+ * @returns {Number} The household's default year
+ */
+export function getHouseholdYear(householdInput) {
+  // Determine current year present in household
+  const householdYear = Object.keys(householdInput["people"]["you"]["age"])[0];
+  return householdYear;
 }

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -8,6 +8,8 @@ import {
 } from "../api/variables";
 import { copySearchParams, countryApiCall } from "../api/call";
 import { useEffect, useState } from "react";
+import { Result } from "antd";
+
 import VariableEditor from "./household/input/VariableEditor";
 import LoadingCentered from "../layout/LoadingCentered";
 import MaritalStatus from "./household/input/MaritalStatus";
@@ -22,7 +24,6 @@ import HOUSEHOLD_OUTPUT_TREE from "./household/output/tree";
 import VariableSearch from "./household/VariableSearch";
 import MobileCalculatorPage from "../layout/MobileCalculatorPage.jsx";
 import RecreateHouseholdPopup from "./household/output/RecreateHouseholdPopup.jsx";
-import { Result } from "antd";
 
 export default function HouseholdPage(props) {
   document.title = "Household | PolicyEngine";

--- a/src/pages/household/HouseholdRightSidebar.jsx
+++ b/src/pages/household/HouseholdRightSidebar.jsx
@@ -8,6 +8,7 @@ import SearchParamNavButton from "../../controls/SearchParamNavButton";
 import Divider from "../../layout/Divider";
 import LoadingCentered from "../../layout/LoadingCentered";
 import PolicySearch from "../policy/PolicySearch";
+import { defaultYear } from "data/constants";
 
 function Figure(props) {
   const { left, right } = props;
@@ -73,7 +74,7 @@ export default function HouseholdRightSidebar(props) {
   );
   const mtr = getValueFromHousehold(
     "marginal_tax_rate",
-    "2024",
+    defaultYear,
     "you",
     householdBaseline,
     metadata,

--- a/src/pages/household/input/MaritalStatus.jsx
+++ b/src/pages/household/input/MaritalStatus.jsx
@@ -6,6 +6,7 @@ import { copySearchParams } from "../../../api/call";
 import { useState } from "react";
 import SearchParamNavButton from "../../../controls/SearchParamNavButton";
 import gtag from "../../../api/analytics";
+import { defaultYear } from "data/constants";
 
 function getUKMaritalStatus(situation) {
   const partnerName = "your partner";
@@ -19,16 +20,16 @@ function getUKMaritalStatus(situation) {
 export function setUKMaritalStatus(situation, status) {
   const currentStatus = getUKMaritalStatus(situation);
   const defaultPartner = {
-    age: { 2024: 40 },
+    age: { [defaultYear]: 40 },
   };
   const partnerName = "your partner";
   if (status === "married" && currentStatus === "single") {
     situation.people[partnerName] = defaultPartner;
     situation.benunits["your immediate family"].members.push(partnerName);
     situation.benunits["your immediate family"].is_married = {
-      2024: true,
+      [defaultYear]: true,
     };
-    situation.benunits["your immediate family"].is_married["2024"] = true;
+    situation.benunits["your immediate family"].is_married[defaultYear] = true;
     situation.households["your household"].members.push(partnerName);
   } else if (status === "single" && currentStatus === "married") {
     situation = removePerson(situation, partnerName);
@@ -48,7 +49,7 @@ function getUSMaritalStatus(situation) {
 export function setUSMaritalStatus(situation, status) {
   const currentStatus = getUSMaritalStatus(situation);
   const defaultPartner = {
-    age: { 2024: 40 },
+    age: { [defaultYear]: 40 },
   };
   const partnerName = "your partner";
   if (status === "married" && currentStatus === "single") {
@@ -76,7 +77,7 @@ function getCAMaritalStatus(situation) {
 export function setCAMaritalStatus(situation, status) {
   const currentStatus = getCAMaritalStatus(situation);
   const defaultPartner = {
-    age: { 2024: 40 },
+    age: { [defaultYear]: 40 },
   };
   const partnerName = "your partner";
   if (status === "married" && currentStatus === "single") {

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -13,6 +13,7 @@ import SearchParamNavButton from "../../../controls/SearchParamNavButton";
 import gtag from "../../../api/analytics";
 import { useState, useEffect } from "react";
 import StableInputNumber from "controls/StableInputNumber";
+import { defaultYear } from "data/constants";
 
 export default function VariableEditor(props) {
   const [searchParams] = useSearchParams();
@@ -350,13 +351,13 @@ export function addVariable(householdInput, variable, entityPlural) {
             // Then add it to the relevant part of the situation, along with
             // its default value
             newHouseholdInput[entityPlural][entity][variable.name] = {
-              2024: variable.defaultValue,
+              [defaultYear]: variable.defaultValue,
             };
           } else {
             // Otherwise, add it to the relevant part of the situation, along with
             // a null value
             newHouseholdInput[entityPlural][entity][variable.name] = {
-              2024: null,
+              [defaultYear]: null,
             };
           }
         }

--- a/src/pages/household/output/EarningsVariation.jsx
+++ b/src/pages/household/output/EarningsVariation.jsx
@@ -9,6 +9,7 @@ import { capitalize } from "../../../api/language";
 import BaselineOnlyChart from "./EarningsVariation/BaselineOnlyChart";
 import BaselineAndReformChart from "./EarningsVariation/BaselineAndReformChart";
 import { getValueFromHousehold } from "../../../api/variables";
+import { defaultYear } from "data/constants";
 
 export default function EarningsVariation(props) {
   const {
@@ -48,7 +49,7 @@ export default function EarningsVariation(props) {
         ];
       validVariables = validVariables.concat(
         Object.keys(firstEntity).filter((variable) =>
-          Array.isArray(firstEntity[variable][2024]),
+          Array.isArray(firstEntity[variable][defaultYear]),
         ),
       );
     }
@@ -64,10 +65,10 @@ export default function EarningsVariation(props) {
 
   useEffect(() => {
     let householdData = JSON.parse(JSON.stringify(householdInput));
-    householdData.people.you["employment_income"] = { 2024: null };
+    householdData.people.you["employment_income"] = { [defaultYear]: null };
     const currentEarnings = getValueFromHousehold(
       "employment_income",
-      "2024",
+      defaultYear,
       "you",
       householdInput,
       metadata,
@@ -76,7 +77,7 @@ export default function EarningsVariation(props) {
       [
         {
           name: "employment_income",
-          period: "2024",
+          period: defaultYear,
           min: 0,
           max: Math.max(
             metadata.countryId === "ng" ? 1_200_000 : 200_000,

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -13,6 +13,7 @@ import { getCliffs } from "./cliffs";
 import HoverCard, { HoverCardContext } from "../../../../layout/HoverCard";
 import { convertToCurrencyString } from "./convertToCurrencyString";
 import { plotLayoutFont } from "pages/policy/output/utils";
+import { defaultYear } from "data/constants";
 import useMobile from "layout/Responsive";
 import Screenshottable from "layout/Screenshottable";
 
@@ -30,42 +31,42 @@ export default function BaselineAndReformChart(props) {
 
   const earningsArray = getValueFromHousehold(
     "employment_income",
-    "2024",
+    defaultYear,
     "you",
     householdBaselineVariation,
     metadata,
   );
   const baselineArray = getValueFromHousehold(
     variable,
-    "2024",
+    defaultYear,
     null,
     householdBaselineVariation,
     metadata,
   );
   const reformArray = getValueFromHousehold(
     variable,
-    "2024",
+    defaultYear,
     null,
     householdReformVariation,
     metadata,
   );
   const currentEarnings = getValueFromHousehold(
     "employment_income",
-    "2024",
+    defaultYear,
     "you",
     householdBaseline,
     metadata,
   );
   const currentValue = getValueFromHousehold(
     variable,
-    "2024",
+    defaultYear,
     null,
     householdReform,
     metadata,
   );
   const baselineValue = getValueFromHousehold(
     variable,
-    "2024",
+    defaultYear,
     null,
     householdBaseline,
     metadata,

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -11,6 +11,7 @@ import style from "../../../../style";
 import { getCliffs } from "./cliffs";
 import HoverCard, { HoverCardContext } from "../../../../layout/HoverCard";
 import { plotLayoutFont } from "pages/policy/output/utils";
+import { defaultYear } from "data/constants";
 
 import { convertToCurrencyString } from "./convertToCurrencyString";
 import useMobile from "layout/Responsive";
@@ -27,14 +28,14 @@ export default function BaselineOnlyChart(props) {
 
   const earningsArray = getValueFromHousehold(
     "employment_income",
-    "2024",
+    defaultYear,
     "you",
     householdBaselineVariation,
     metadata,
   );
   const baselineArray = getValueFromHousehold(
     variable,
-    "2024",
+    defaultYear,
     null,
     householdBaselineVariation,
     metadata,
@@ -42,14 +43,14 @@ export default function BaselineOnlyChart(props) {
   );
   const currentEarnings = getValueFromHousehold(
     "employment_income",
-    "2024",
+    defaultYear,
     "you",
     householdBaseline,
     metadata,
   );
   const currentBaseline = getValueFromHousehold(
     variable,
-    "2024",
+    defaultYear,
     null,
     householdBaseline,
     metadata,

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -5,6 +5,7 @@ import Button from "../../../controls/Button";
 import { Switch } from "antd";
 import CodeBlock from "layout/CodeBlock";
 import { getReformDefinitionCode } from "data/reformDefinitionCode";
+import { defaultYear } from "data/constants";
 
 export default function HouseholdReproducibility(props) {
   const { policy, metadata, householdInput } = props;
@@ -27,7 +28,7 @@ export default function HouseholdReproducibility(props) {
       )) {
         if (variable !== "members") {
           if (
-            householdInputCopy[entityPlural][entity][variable][2024] === null
+            householdInputCopy[entityPlural][entity][variable][defaultYear] === null
           ) {
             delete householdInputCopy[entityPlural][entity][variable];
           }
@@ -67,7 +68,7 @@ export default function HouseholdReproducibility(props) {
     ")",
     "",
     "simulation.trace = True",
-    'simulation.calculate("household_net_income", 2024)',
+    `simulation.calculate("household_net_income", ${defaultYear})`,
     "simulation.tracer.print_computation_log()",
   ]);
 

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -28,7 +28,8 @@ export default function HouseholdReproducibility(props) {
       )) {
         if (variable !== "members") {
           if (
-            householdInputCopy[entityPlural][entity][variable][defaultYear] === null
+            householdInputCopy[entityPlural][entity][variable][defaultYear] ===
+            null
           ) {
             delete householdInputCopy[entityPlural][entity][variable];
           }

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -18,6 +18,7 @@ import { plotLayoutFont } from "pages/policy/output/utils";
 import useMobile from "layout/Responsive";
 import Screenshottable from "layout/Screenshottable";
 import { localeCode } from "api/language";
+import { defaultYear } from "data/constants";
 
 export default function MarginalTaxRates(props) {
   const {
@@ -44,14 +45,14 @@ export default function MarginalTaxRates(props) {
 
   const currentEarnings = getValueFromHousehold(
     "employment_income",
-    "2024",
+    defaultYear,
     "you",
     householdInput,
     metadata,
   );
   const currentMtr = getValueFromHousehold(
     "marginal_tax_rate",
-    "2024",
+    defaultYear,
     "you",
     householdBaseline,
     metadata,
@@ -59,12 +60,12 @@ export default function MarginalTaxRates(props) {
 
   useEffect(() => {
     let householdData = JSON.parse(JSON.stringify(householdInput));
-    householdData.people.you.employment_income["2024"] = null;
+    householdData.people.you.employment_income[defaultYear] = null;
     householdData.axes = [
       [
         {
           name: "employment_income",
-          period: "2024",
+          period: defaultYear,
           min: 0,
           max: Math.max(
             metadata.countryId === "ng" ? 1_200_000 : 200_000,
@@ -153,14 +154,14 @@ export default function MarginalTaxRates(props) {
   if (baselineMtr && !reformMtr) {
     const earningsArray = getValueFromHousehold(
       "employment_income",
-      "2024",
+      defaultYear,
       "you",
       baselineMtr,
       metadata,
     );
     const mtrArray = getValueFromHousehold(
       "marginal_tax_rate",
-      "2024",
+      defaultYear,
       "you",
       baselineMtr,
       metadata,
@@ -255,28 +256,28 @@ export default function MarginalTaxRates(props) {
   } else if (baselineMtr && reformMtr) {
     const earningsArray = getValueFromHousehold(
       "employment_income",
-      "2024",
+      defaultYear,
       "you",
       baselineMtr,
       metadata,
     );
     const baselineMtrArray = getValueFromHousehold(
       "marginal_tax_rate",
-      "2024",
+      defaultYear,
       "you",
       baselineMtr,
       metadata,
     );
     const reformMtrArray = getValueFromHousehold(
       "marginal_tax_rate",
-      "2024",
+      defaultYear,
       "you",
       reformMtr,
       metadata,
     );
     const reformMtrValue = getValueFromHousehold(
       "marginal_tax_rate",
-      "2024",
+      defaultYear,
       "you",
       householdReform,
       metadata,

--- a/src/pages/household/output/NetIncomeBreakdown.jsx
+++ b/src/pages/household/output/NetIncomeBreakdown.jsx
@@ -13,6 +13,7 @@ import {
 import ResultsPanel from "../../../layout/ResultsPanel";
 import style from "../../../style";
 import useDisplayCategory from "redesign/components/useDisplayCategory";
+import { defaultStartDate } from "data/constants";
 
 const UpArrow = () => (
   <CaretUpFilled
@@ -176,14 +177,14 @@ function VariableArithmetic(props) {
   if (typeof adds === "string") {
     // adds is a parameter name (e.g. income.tax.groups). Find its value
     const parameter = metadata.parameters[adds];
-    adds = getParameterAtInstant(parameter, "2024-01-01");
+    adds = getParameterAtInstant(parameter, defaultStartDate);
   }
   let subtracts = variable.subtracts || [];
   // Check if 'subtracts' is a string
   if (typeof subtracts === "string") {
     // subtracts is a parameter name (e.g. income.tax.groups). Find its value
     const parameter = metadata.parameters[subtracts];
-    subtracts = getParameterAtInstant(parameter, "2024-01-01");
+    subtracts = getParameterAtInstant(parameter, defaultStartDate);
   }
   const childAddNodes = adds.filter(shouldShowVariable).map((variable) => (
     <VariableArithmetic

--- a/src/pages/household/output/PoliciesModelledPopup.jsx
+++ b/src/pages/household/output/PoliciesModelledPopup.jsx
@@ -3,6 +3,7 @@ import { Modal } from "antd";
 import { useEffect } from "react";
 import { useState } from "react";
 import { getValueFromHousehold } from "../../../api/variables";
+import { defaultYear } from "data/constants";
 import Button from "../../../controls/Button";
 
 function PoliciesModelledChecklist(props) {
@@ -18,7 +19,7 @@ function PoliciesModelledChecklist(props) {
       // Check if the household input matches the filter
       const actualValue = getValueFromHousehold(
         variable,
-        2024,
+        defaultYear,
         "your household",
         householdInput,
         metadata,

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -14,6 +14,7 @@ import { copySearchParams } from "../../../api/call";
 import useMobile from "../../../layout/Responsive";
 import { capitalize } from "../../../api/language";
 import { formatVariableValue } from "../../../api/variables";
+import { defaultStartDate, defaultEndDate } from "data/constants";
 
 const { RangePicker } = DatePicker;
 
@@ -22,9 +23,8 @@ export default function ParameterEditor(props) {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const parameter = metadata.parameters[parameterName];
-  const currentYear = new Date().getFullYear();
-  const [startDate, setStartDate] = useState(currentYear + "-01-01");
-  const [endDate, setEndDate] = useState(currentYear + 5 + "-12-31");
+  const [startDate, setStartDate] = useState(defaultStartDate);
+  const [endDate, setEndDate] = useState(defaultEndDate);
   const startValue = getParameterAtInstant(
     getReformedParameter(parameter, policy.reform.data),
     startDate,

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -1,6 +1,7 @@
 import CodeBlock from "layout/CodeBlock";
 import { getReformDefinitionCode } from "data/reformDefinitionCode";
 import Button from "../../../controls/Button";
+import { defaultYear } from "data/constants";
 
 export default function PolicyReproducibility(props) {
   const { policy, metadata } = props;
@@ -13,8 +14,8 @@ export default function PolicyReproducibility(props) {
     "baseline = Microsimulation()",
     "reformed = Microsimulation(reform=reform)",
     'HOUSEHOLD_VARIABLES = ["person_id", "household_id", "age", "household_net_income", "household_income_decile", "in_poverty", "household_tax", "household_benefits"]',
-    "baseline_person_df = baseline.calculate_dataframe(HOUSEHOLD_VARIABLES, 2024)",
-    "reformed_person_df = reformed.calculate_dataframe(HOUSEHOLD_VARIABLES, 2024)",
+    `baseline_person_df = baseline.calculate_dataframe(HOUSEHOLD_VARIABLES, ${defaultYear})`,
+    `reformed_person_df = reformed.calculate_dataframe(HOUSEHOLD_VARIABLES, ${defaultYear})`,
     "difference_person_df = reformed_person_df - baseline_person_df",
   ]);
 


### PR DESCRIPTION
## Description

Fixes #1017. This removes the hardcoding of the year that we currently maintain in the application, especially in the household input. It does not allow for selection of the year, which will come via a different PR and may change some of this code. This is necessary before beginning work on #218.

## Changes

These commits create a new `constants.js` file that defines three things: a `defaultYear` (fetched via `new Date().getFullYear()`), a `defaultStartDate` (a string that appends `-01-01` to the year) and a `defaultEndDate` (the same, but with `-12-31`). This component is then utilized in place of all relevant references to 2023 except the `updateHousehold` function within `HouseholdPage.jsx`.

`updateHousehold`, meanwhile, removes unnecessary data from back-end households created before September 2023. Because the household may not use 2023 as its year, to avoid runtime issues, the component first checks what year the household contains, then uses that value to remove unnecessary values.

## Screenshots

Loom video available [here](https://www.loom.com/share/fcfc76f5b9aa46adac2a6226e5d69271?sid=19732957-4948-4ee3-8cbf-117fb70ce758). Note that nothing has changed visually.
