### PR TITLE
Update header height constant

### DIFF
--- a/src/layout/ThreeColumnPage.jsx
+++ b/src/layout/ThreeColumnPage.jsx
@@ -1,4 +1,4 @@
-import { HEADER_HEIGHT } from "../layout/Header";
+import { HEADER_HEIGHT } from "../redesign/style/spacing";
 import style from "../style";
 
 export default function ThreeColumnPage(props) {


### PR DESCRIPTION
## Description

Fixes #885. This commit updates the `ThreeColumnPage` component's imported `HEADER_HEIGHT` constant to reflect updates during the autumn front-end redesign.

## Changes

- Update the `HEADER_HEIGHT` import from the old styles file to the updated one created post-redesign.

## Screenshots

The Loom video [here](https://www.loom.com/share/89de5db11ff142e686b5213db0bf4815?sid=b2610c64-daac-487f-9130-c02f62c9ab93) shows me attempting to scroll vertically at various points where the current application would do so.

## Tests

None have been added.
