### PR TITLE
fix: capitalise 'API' title on documentation page #1042

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.4.3",
         "lint-staged": "^15.2.0",
-        "prettier": "^3.1.0"
+        "prettier": "^3.1.1"
       },
       "engines": {
         "node": ">=19.0.0"

--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -10,7 +10,7 @@ import { Input, Card, Divider, Tag, Drawer } from "antd";
 function APIResultCard(props) {
   const { metadata, type, setSelectedCard } = props;
   useEffect(() => {
-    document.title = 'API Documentation'
+    document.title = "API Documentation";
   }, []);
 
   // type can be: parameter, variable

--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -3,12 +3,16 @@ import Footer from "./Footer";
 import Header from "./Header";
 import Section from "./Section";
 import useCountryId from "./useCountryId";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Container } from "react-bootstrap";
 import { Input, Card, Divider, Tag, Drawer } from "antd";
 
 function APIResultCard(props) {
   const { metadata, type, setSelectedCard } = props;
+  useEffect(() => {
+    document.title = 'Api Documentation'
+  }, []);
+
   // type can be: parameter, variable
   // parameters look like this: "gov.dcms.bbc.tv_licence.discount.aged.discount":{"description":"Percentage discount for qualifying aged households.","economy":true,"household":true,"label":"Aged TV Licence discount","parameter":"gov.dcms.bbc.tv_licence.discount.aged.discount","period":null,"type":"parameter","unit":"/1","values":{"2003-01-01":1}}
   // variables look like this: "income_tax":{"adds":["earned_income_tax","savings_income_tax","dividend_income_tax","CB_HITC"],"category":"tax","defaultValue":0,"definitionPeriod":"year","documentation":"Total Income Tax liability","entity":"person","hidden_input":false,"indexInModule":22,"isInputVariable":false,"label":"Income Tax","moduleName":"gov.hmrc.income_tax.liability","name":"income_tax","subtracts":["capped_mcad"],"unit":"currency-GBP","valueType":"float"}

--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -10,7 +10,7 @@ import { Input, Card, Divider, Tag, Drawer } from "antd";
 function APIResultCard(props) {
   const { metadata, type, setSelectedCard } = props;
   useEffect(() => {
-    document.title = 'Api Documentation'
+    document.title = 'API Documentation'
   }, []);
 
   // type can be: parameter, variable


### PR DESCRIPTION
## Description

Please provide a summary of the changes and which issue is fixed. Please include relevant motivation and context.
Capitalized 'api' on documentation page as it was more befitting. 
## Changes

Please describe the changes in detail.
Added a useEffect hook onto APIDocumentationPage.jsx in order to update title of page. 
## Screenshots

Please include screenshots, gifs, etc.
![image](https://github.com/PolicyEngine/policyengine-app/assets/124013342/117d6f83-fbc5-4525-955d-b8c4a46b23d5)

## Tests

Please describe how the change has been tested.
Change was tested locally.
