### PR TITLE
Change streamlit url to fix display

### DIFF
--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -364,9 +364,7 @@ export default function APIDocumentationPage({ metadata }) {
       <Section title="API playground">
         <p>Try out the API in this interactive demo.</p>
         <iframe
-          src={
-            "https://policyengine-policyengine-api-demo-app-xy5rgn.streamlit.app/?embed=true&embed_options=light_theme"
-          }
+          src={`https://policyengine-policyengine-api-demo-app-xy5rgn.streamlit.app/?embed=true&embed_options=light_theme&?mode=${countryId}`}
           // the demo is in the policyengine-api-demo repository in PolicyEngine
           title="PolicyEngine API demo"
           height="500px"

--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -364,7 +364,9 @@ export default function APIDocumentationPage({ metadata }) {
       <Section title="API playground">
         <p>Try out the API in this interactive demo.</p>
         <iframe
-          src={`https://policyengine-policyengine-api-demo-app-xy5rgn.streamlit.app/~/+/?mode=${countryId}`}
+          src={
+            "https://policyengine-policyengine-api-demo-app-xy5rgn.streamlit.app/?embed=true&embed_options=light_theme"
+          }
           // the demo is in the policyengine-api-demo repository in PolicyEngine
           title="PolicyEngine API demo"
           height="500px"


### PR DESCRIPTION
## Description

Fix #215. Streamlit was not reading the updated api-demo repository. Followed the instructions [here](https://docs.streamlit.io/streamlit-community-cloud/share-your-app/embed-your-app) to modify the url.

## Screenshots

<img width="1308" alt="Screenshot 2023-12-27 at 8 13 29 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/e8c5110d-768b-43e6-8f83-0e88b8c3f141">
