### PR TITLE
Change labels on labor supply chart

### DIFF
--- a/src/pages/policy/output/ImpactTypes.jsx
+++ b/src/pages/policy/output/ImpactTypes.jsx
@@ -13,12 +13,12 @@ import povertyImpactByGender from "./PovertyImpactByGender";
 import povertyImpactByRace from "./PovertyImpactByRace";
 import relativeImpactByDecile from "./RelativeImpactByDecile";
 import relativeImpactByWealthDecile from "./RelativeImpactByWealthDecile";
-import laborSupplyImpact from "./LabourSupplyResponse";
+import laborSupplyImpact from "./LaborSupplyResponse";
 
 export const impactLabels = {
   netIncome: "Budgetary impact",
   detailedBudgetaryImpact: "Budgetary impact by program",
-  laborSupplyImpact: "Labour supply impact",
+  laborSupplyImpact: "Labor supply impact",
   decileAverageImpact: "Absolute impact by income decile",
   wealthDecileAverageImpact: "Absolute impact by wealth decile",
   decileRelativeImpact: "Relative impact by income decile",

--- a/src/pages/policy/output/LaborSupplyResponse.jsx
+++ b/src/pages/policy/output/LaborSupplyResponse.jsx
@@ -45,7 +45,7 @@ function ImpactPlot(props) {
               }
             : {
                 customdata: xArray.map(() => {}),
-                hovertemplate: `<b>%{x}</b><br><br>%{customdata}<extra></extra>`,
+                hovertemplate: `<b>%{x}</b><extra></extra>`,
               }),
         },
       ]}
@@ -54,7 +54,7 @@ function ImpactPlot(props) {
           title: "",
         },
         yaxis: {
-          title: "Budgetary impact (bn)",
+          title: "Employment income (bn)",
           tickformat: "$,.1f",
         },
         ...(useHoverCard
@@ -104,9 +104,9 @@ export function title(policyLabel, lsrImpact, metadata) {
   return (
     `${policyLabel} would ` +
     (lsrImpact > 0 ? "raise " : "lower ") +
-    "labor supply by " +
+    "employment income by " +
     aggregateCurrency(lsrImpact, metadata) +
-    ` this year ${label}`
+    `bn this year ${label}`
   );
 }
 
@@ -115,7 +115,7 @@ export default function lsrImpact(props) {
   const incomeEffect = impact.labour_supply_response.income_lsr;
   const substitutionEffect = impact.labour_supply_response.substitution_lsr;
 
-  const labels = ["Income elasticity", "Substitution elasticity", "Net change"];
+  const labels = ["Income effect", "Substitution effect", "Net change"];
   const values = [
     incomeEffect / 1e9,
     substitutionEffect / 1e9,


### PR DESCRIPTION
Fixes #1046

Also removes the customdata from the LSR hovercards for now

<img width="1085" alt="image" src="https://github.com/PolicyEngine/policyengine-app/assets/6076111/7d568157-f6aa-4c23-888e-0366b6a1e1ed">
