### PR TITLE
Remove erroneous character from chart description

### DIFF
--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -266,7 +266,7 @@ function title(metricChanges, policyLabel, metadata) {
 
 const description = (
   <p>
-    The chart above shows how this policy reform affects \ different measures of
+    The chart above shows how this policy reform affects different measures of
     income inequality.
   </p>
 );


### PR DESCRIPTION
## Description

Issue 1050 identified an erroneous '\' character in a chart description. The backslash was not part of a code description, but instead appears to be just a typo.

## Changes

- Removed erroneous backslash from chart description on `InequalityImpact.jsx`
