### PR TITLE
fix: added padding to the codeblock line numbers and the edge

### DIFF
--- a/src/layout/CodeBlock.jsx
+++ b/src/layout/CodeBlock.jsx
@@ -12,6 +12,7 @@ export default function CodeBlock({ lines, language }) {
                 style={{
                   textAlign: "right",
                   paddingRight: "1em",
+                  paddingLeft: "1.5em",
                   userSelect: "none",
                   opacity: "0.5",
                 }}


### PR DESCRIPTION

closes #1028 
## Screenshots

<img width="1710" alt="Screenshot 2023-12-30 at 4 43 46 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/46224156/3469af28-2817-4858-9014-279c7b2d6756">


## Tests

Please describe how the change has been tested.
