### PR TITLE
fix: improved us institute logos for readability

### DIFF
--- a/src/redesign/components/HomeUsedBy.jsx
+++ b/src/redesign/components/HomeUsedBy.jsx
@@ -43,7 +43,7 @@ export default function HomeUsedBy() {
             justifyContent: {
               mobile: "center",
               tablet: "center",
-              desktop: "center",
+              desktop: "space-around",
             }[displayCategory],
             marginBottom: 30,
             marginTop: 20,
@@ -61,15 +61,15 @@ export default function HomeUsedBy() {
 function IndividualOrg({ name, logo, link }) {
   const displayCategory = useDisplayCategory();
   const size = {
-    mobile: 80,
+    mobile: 85,
     tablet: 100,
-    desktop: 60,
+    desktop: 100,
   }[displayCategory];
   return (
     <a href={link}>
       <div
         style={{
-          width: size,
+          maxwidth: size,
           display: "flex",
           flexDirection: {
             mobile: "row",
@@ -80,6 +80,7 @@ function IndividualOrg({ name, logo, link }) {
           marginLeft: 20,
           alignItems: "center",
           justifyContent: "center",
+          backgroundColor: "white",
         }}
       >
         <img
@@ -89,7 +90,7 @@ function IndividualOrg({ name, logo, link }) {
           height={size}
           style={{
             objectFit: "contain",
-            marginRight: displayCategory === "mobile" ? 30 : 0,
+            marginRight: displayCategory === "mobile" ? 20 : 0,
             marginBottom: displayCategory !== "mobile" ? 20 : 0,
           }}
         />


### PR DESCRIPTION
## Description
closes #760  

## Changes
- Modified the size of images, so that in every type of screens i.e. desktop, tablet and mobile, the size remains approximately same
- Modified margins for the mobile view so that there's won't be any horizontal scroll

Please describe the changes in detail.

## Screenshots

### Before
<img width="1710" alt="Screenshot 2023-12-30 at 9 41 18 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/46224156/db5cc89c-fe56-4540-abd1-7e08247003ce">



### After
<img width="1710" alt="Screenshot 2023-12-30 at 9 41 53 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/46224156/ddfe47ba-e4cd-4025-9abf-dd2bdc31c8e2">


Please include screenshots, gifs, etc.

