### PR TITLE
Move negatives before currency on household y axis tick labels

### DIFF
--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -250,8 +250,11 @@ export function getPlotlyAxisFormat(unit, values, precisionOverride) {
   // TODO: unhandled units: list, variable, program
   if (isNumber) {
     return {
-      tickformat: isPercent ? `,.${precision()}%` : `,.${precision()}f`,
-      ...(isCurrency && { tickprefix: currencyMap[unit] }),
+      tickformat: isCurrency
+        ? `$,.${precision()}f`
+        : isPercent
+          ? `,.${precision()}%`
+          : `,.${precision()}f`,
       ...(isYears && { ticksuffix: "&nbsp;yrs" }),
       ...(isKwh && { ticksuffix: "&nbsp;kWh" }),
       ...(values && {

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -2,7 +2,7 @@ import { useContext, useState } from "react";
 import { Radio } from "antd";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../../api/charts";
-import { capitalize } from "../../../../api/language";
+import { capitalize, localeCode } from "../../../../api/language";
 import {
   getPlotlyAxisFormat,
   getValueFromHousehold,
@@ -312,6 +312,7 @@ function BaselineAndReformTogetherPlot(props) {
         config={{
           displayModeBar: false,
           responsive: true,
+          locale: localeCode(metadata.countryId),
         }}
         style={{
           width: "100%",
@@ -507,6 +508,7 @@ function BaselineReformDeltaPlot(props) {
         config={{
           displayModeBar: false,
           responsive: true,
+          locale: localeCode(metadata.countryId),
         }}
         style={{
           width: "100%",

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../../api/charts";
-import { capitalize } from "../../../../api/language";
+import { capitalize, localeCode } from "../../../../api/language";
 import {
   getPlotlyAxisFormat,
   getValueFromHousehold,
@@ -165,6 +165,7 @@ export default function BaselineOnlyChart(props) {
             config={{
               displayModeBar: false,
               responsive: true,
+              locale: localeCode(metadata.countryId),
             }}
             style={{
               width: "100%",

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -17,6 +17,7 @@ import { ChartLogo } from "../../../api/charts";
 import { plotLayoutFont } from "pages/policy/output/utils";
 import useMobile from "layout/Responsive";
 import Screenshottable from "layout/Screenshottable";
+import { localeCode } from "api/language";
 
 export default function MarginalTaxRates(props) {
   const {
@@ -242,6 +243,7 @@ export default function MarginalTaxRates(props) {
             config={{
               displayModeBar: false,
               responsive: true,
+              locale: localeCode(metadata.countryId),
             }}
             style={{
               width: "100%",
@@ -474,6 +476,7 @@ export default function MarginalTaxRates(props) {
             config={{
               displayModeBar: false,
               responsive: true,
+              locale: localeCode(metadata.countryId),
             }}
             style={{
               width: "100%",

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -138,7 +138,11 @@ export default function ParameterEditor(props) {
           type="warning"
         />
       )}
-      <ParameterOverTime parameter={parameter} policy={policy} />
+      <ParameterOverTime
+        parameter={parameter}
+        policy={policy}
+        metadata={metadata}
+      />
     </CenteredMiddleColumn>
   );
 }

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -6,9 +6,10 @@ import useMobile from "../../../layout/Responsive";
 import useWindowHeight from "layout/WindowHeight";
 import style from "../../../style";
 import { plotLayoutFont } from "pages/policy/output/utils";
+import { localeCode } from "api/language";
 
 export default function ParameterOverTime(props) {
-  const { parameter, policy } = props;
+  const { parameter, policy, metadata } = props;
   const mobile = useMobile();
   const windowHeight = useWindowHeight();
   let values = parameter.values;
@@ -113,6 +114,7 @@ export default function ParameterOverTime(props) {
         config={{
           displayModeBar: false,
           responsive: true,
+          locale: localeCode(metadata.countryId),
         }}
       />
     </>


### PR DESCRIPTION
## Description

Fix #1068 by adding the current locale to household charts and changing the tickformat for currencies in `getPlotlyAxisFormat`. Since `getPlotlyAxisFormat` is also used by `ParameterOverTime` we also add the current locale to it.

Thus, negative currencies should be displayed properly for household charts and the parameter editor.

## Screenshots

<img width="817" alt="Screenshot 2023-12-30 at 11 33 07 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/8a877443-2dce-4a16-a264-0f86513a0f9d">

<img width="817" alt="Screenshot 2023-12-30 at 11 44 02 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/11707d84-2df1-4fa3-b759-5edb020c2bc5">

