### PR TITLE
Fix budgetary impact charts when there is a single bar

### DIFF
--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -42,11 +42,10 @@ function ImpactPlot(props) {
           orientation: "v",
           // 'relative' for all but the last, which is 'total'
           measure:
-            yArray.length > 0
-              ? Array(yArray.length - 1)
-                  .fill("relative")
-                  .concat(["total"])
-              : ["total"],
+            yArray.length > 1 &&
+            Array(yArray.length - 1)
+              .fill("relative")
+              .concat(["total"]),
           textposition: "inside",
           text: values.map((value) => formatCur(value * 1e9)),
           increasing: { marker: { color: style.colors.BLUE } },
@@ -61,7 +60,7 @@ function ImpactPlot(props) {
             },
           },
           connector: {
-            line: { color: style.colors.GRAY, width: 1, dash: "dot" },
+            line: { color: style.colors.GRAY, width: 2, dash: "dot" },
           },
           ...(useHoverCard
             ? {

--- a/src/pages/policy/output/DetailedBudgetaryImpact.jsx
+++ b/src/pages/policy/output/DetailedBudgetaryImpact.jsx
@@ -39,11 +39,10 @@ function ImpactPlot(props) {
           orientation: "v",
           // 'relative' for all but the last, which is 'total'
           measure:
-            yArray.length > 0
-              ? Array(yArray.length - 1)
-                  .fill("relative")
-                  .concat(["total"])
-              : ["total"],
+            yArray.length > 1 &&
+            Array(yArray.length - 1)
+              .fill("relative")
+              .concat(["total"]),
           increasing: { marker: { color: style.colors.BLUE } },
           decreasing: { marker: { color: style.colors.DARK_GRAY } },
           // Total should be dark gray if negative, dark green if positive
@@ -56,7 +55,7 @@ function ImpactPlot(props) {
             },
           },
           connector: {
-            line: { color: style.colors.GRAY, width: 1, dash: "dot" },
+            line: { color: style.colors.GRAY, width: 2, dash: "dot" },
           },
           textposition: "inside",
           text: yArray.map((y) => formatCur(y * 1e9)),


### PR DESCRIPTION
## Description

Fix #1039. When there is a single bar to be displayed, the current code passes the property `measure = ["total"]` to plotly. Since the total (of the preceding bars) is zero, we cannot see anything.

## Changes

We use the default measure `relative` when there is a single bar.

## Screenshots

The single bar case for detailed budgetary impact:

<img width="759" alt="Screenshot 2023-12-30 at 2 27 38 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/0a0e8368-6637-49f6-bcdb-b4115915c670">

The multiple bar case (to ensure I didn't break the more common scenario):

<img width="759" alt="Screenshot 2023-12-30 at 2 26 45 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/0508b3a4-e05b-45ae-8de3-23784354c182">

## Tests

We tested the changes for a couple of configurations.
