### PR TITLE
Describe state income taxes as state and local income taxes for budgetary impact chart

### DIFF
--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -157,12 +157,17 @@ export default function budgetaryImpact(props) {
   const taxImpact = impact.budget.tax_revenue_impact - stateTaxImpact;
   const desktopLabels = [
     "Federal tax revenues",
-    "State tax revenues",
+    "State and local income tax revenues",
     "Benefit spending",
     "Net impact",
   ];
-  const mobileLabels = ["Federal taxes", "State taxes", "Benefits", "Net"];
-  if (!window.location.pathname.includes("/us/")) {
+  const mobileLabels = [
+    "Federal taxes",
+    "State and local income taxes",
+    "Benefits",
+    "Net",
+  ];
+  if (metadata.countryId != "us") {
     desktopLabels[0] = "Tax revenues";
     mobileLabels[0] = "Taxes";
   }


### PR DESCRIPTION
## Description

We fix #1053 by changing the mobile label from "State taxes" to "State and local income taxes" and changing the desktop label from "State tax revenues" to "State and local income tax revenues".

## Screenshots

<img width="759" alt="Screenshot 2023-12-30 at 2 49 20 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/b75dd21f-274f-4b16-9a5e-5206fd95b383">
