### PR TITLE
Show states in titles

### DIFF
--- a/src/pages/policy/output/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/AverageImpactByDecile.jsx
@@ -6,8 +6,7 @@ import { HoverCardContext } from "../../../layout/HoverCard";
 import style from "../../../style";
 import { plotLayoutFont } from "./utils";
 import React from "react";
-import ImpactChart, { absoluteChangeMessage } from "./ImpactChart";
-import { COUNTRY_NAMES } from "pages/statusPageDefaults";
+import ImpactChart, { absoluteChangeMessage, regionName } from "./ImpactChart";
 
 export function ImpactPlot(props) {
   const {
@@ -116,20 +115,17 @@ export function ImpactPlot(props) {
 }
 
 export function title(policyLabel, relativeChange, metadata) {
-  const term1 = "the net income of households";
+  const region = regionName(metadata);
+  const regionPhrase = region ? ` in ${region}` : "";
+  const term1 = `the net income of households${regionPhrase}`;
   const term2 = formatCurrency(Math.abs(relativeChange), metadata, {
     maximumFractionDigits: 0,
   });
   const signTerm = relativeChange > 0 ? "increase" : "decrease";
-  const countryId = metadata.countryId;
-  const countryPhrase =
-    countryId === "us" || countryId === "uk"
-      ? ""
-      : `in ${COUNTRY_NAMES(countryId)}`;
   const msg =
     relativeChange === 0
-      ? `${policyLabel} would have no effect on ${term1} on average ${countryPhrase}`
-      : `${policyLabel} would ${signTerm} ${term1} by ${term2} on average ${countryPhrase}`;
+      ? `${policyLabel} would have no effect on ${term1} on average`
+      : `${policyLabel} would ${signTerm} ${term1} by ${term2} on average`;
   return msg;
 }
 

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -5,8 +5,7 @@ import { formatCurrencyAbbr, localeCode } from "../../../api/language";
 import { HoverCardContext } from "../../../layout/HoverCard";
 import style from "../../../style";
 import { plotLayoutFont } from "pages/policy/output/utils";
-import ImpactChart, { absoluteChangeMessage } from "./ImpactChart";
-import { COUNTRY_NAMES } from "pages/statusPageDefaults";
+import ImpactChart, { absoluteChangeMessage, regionName } from "./ImpactChart";
 
 function ImpactPlot(props) {
   const { budgetaryImpact, values, labels, metadata, mobile, useHoverCard } =
@@ -136,16 +135,12 @@ export function title(policyLabel, change, metadata) {
     maximumFractionDigits: 1,
   });
   const signTerm = change > 0 ? "raise" : "cost";
-  const countryId = metadata.countryId;
-  const countryPhrase =
-    countryId === "us" || countryId === "uk"
-      ? ""
-      : `in ${COUNTRY_NAMES(countryId)}`;
-  // TODO: a tolerance should be used to decide the sign.
+  const region = regionName(metadata);
+  const regionPhrase = region ? ` in ${region}` : "";
   const msg =
     change === 0
-      ? `${policyLabel} would have no effect on ${term1} this year ${countryPhrase}`
-      : `${policyLabel} would ${signTerm} ${term2} this year ${countryPhrase}`;
+      ? `${policyLabel} would have no effect on ${term1}${regionPhrase} this year`
+      : `${policyLabel} would ${signTerm} ${term2}${regionPhrase} this year`;
   return msg;
 }
 

--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -9,9 +9,8 @@ import {
 import { HoverCardContext } from "../../../layout/HoverCard";
 import style from "../../../style";
 import { plotLayoutFont } from "pages/policy/output/utils";
-import ImpactChart from "./ImpactChart";
+import ImpactChart, { regionName } from "./ImpactChart";
 import wrapAnsi from "wrap-ansi";
-import { COUNTRY_NAMES } from "pages/statusPageDefaults";
 
 function ImpactPlot(props) {
   const {
@@ -151,12 +150,9 @@ function title(cliffShareChange, cliffGapChange, metadata, policyLabel) {
         : cliffShareChange <= 0 && cliffGapChange <= 0
           ? "would make cliffs less prevalent"
           : "would have an ambiguous effect on cliffs";
-  const countryId = metadata.countryId;
-  const countryPhrase =
-    countryId === "us" || countryId === "uk"
-      ? ""
-      : `in ${COUNTRY_NAMES(countryId)}`;
-  const msg = `${policyLabel} ${signTerm} ${countryPhrase}`;
+  const region = regionName(metadata);
+  const regionPhrase = region ? ` in ${region}` : "";
+  const msg = `${policyLabel} ${signTerm}${regionPhrase}`;
   return msg;
 }
 

--- a/src/pages/policy/output/ImpactChart.jsx
+++ b/src/pages/policy/output/ImpactChart.jsx
@@ -96,3 +96,22 @@ export function absoluteChangeMessage(
   const msg = `${subjectTerm} would ${signTerm}`;
   return wrapAnsi(msg, 50).replaceAll("\n", "<br>");
 }
+
+/**
+ *
+ * Note this is not a general-purpose function -- it is meant to be used to
+ * create titles in impact charts.
+ *
+ * @param {object} metadata the metadata object
+ * @returns name of the region if it is found in metadata.economy_options.region
+ * and it is not us or uk
+ */
+export function regionName(metadata) {
+  const urlParams = new URLSearchParams(window.location.search);
+  const region = urlParams.get("region");
+  if (region === "us" || region === "uk") return;
+  const options = metadata.economy_options.region.map((region) => {
+    return { value: region.name, label: region.label };
+  });
+  return options.find((option) => option.value === region)?.label;
+}

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -4,8 +4,7 @@ import { ChartLogo } from "../../../api/charts";
 import { HoverCardContext } from "../../../layout/HoverCard";
 import style from "../../../style";
 import { plotLayoutFont } from "pages/policy/output/utils";
-import ImpactChart, { relativeChangeMessage } from "./ImpactChart";
-import { COUNTRY_NAMES } from "pages/statusPageDefaults";
+import ImpactChart, { regionName, relativeChangeMessage } from "./ImpactChart";
 import { formatPercent, localeCode } from "api/language";
 
 function ImpactPlot(props) {
@@ -144,12 +143,9 @@ function title(metricChanges, policyLabel, metadata) {
       : metricChanges[0] < 0 && metricChanges[1] < 0 && metricChanges[2] < 0
         ? "decrease"
         : "have an ambiguous effect on";
-  const countryId = metadata.countryId;
-  const countryPhrase =
-    countryId === "us" || countryId === "uk"
-      ? ""
-      : `in ${COUNTRY_NAMES(countryId)}`;
-  const msg = `${policyLabel} would ${signTerm} inequality ${countryPhrase}`;
+  const region = regionName(metadata);
+  const regionPhrase = region ? ` in ${region}` : "";
+  const msg = `${policyLabel} would ${signTerm} inequality${regionPhrase}`;
   return msg;
 }
 

--- a/src/pages/policy/output/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/IntraDecileImpact.jsx
@@ -4,9 +4,8 @@ import { ChartLogo } from "../../../api/charts";
 import style from "../../../style";
 import { cardinal, formatPercent, localeCode } from "../../../api/language";
 import { plotLayoutFont } from "pages/policy/output/utils";
-import ImpactChart from "./ImpactChart";
+import ImpactChart, { regionName } from "./ImpactChart";
 import wrapAnsi from "wrap-ansi";
-import { COUNTRY_NAMES } from "pages/statusPageDefaults";
 
 // this function is called in this file with yaxistitle="Income decile" from
 // IntraWealthDecileImpact with yaxistitle="Wealth decile"
@@ -218,22 +217,19 @@ export function title(policyLabel, all, metadata) {
   const totalAheadTerm = percent(totalAhead);
   const totalBehindTerm = percent(totalBehind);
   const objectTerm = "the net income";
-  const countryId = metadata.countryId;
-  const countryPhrase =
-    countryId === "us" || countryId === "uk"
-      ? ""
-      : ` in ${COUNTRY_NAMES(countryId)}`;
+  const region = regionName(metadata);
+  const regionPhrase = region ? ` in ${region}` : "";
   let msg;
   if (totalAhead > 0 && totalBehind > 0) {
-    msg = `${policyLabel} would increase ${objectTerm} for ${totalAheadTerm} of the population and decrease it for ${totalBehindTerm}`;
+    msg = `${policyLabel} would increase ${objectTerm} for ${totalAheadTerm} of the population${regionPhrase} and decrease it for ${totalBehindTerm}`;
   } else if (totalAhead > 0) {
-    msg = `${policyLabel} would increase ${objectTerm} for ${totalAheadTerm} of the population`;
+    msg = `${policyLabel} would increase ${objectTerm} for ${totalAheadTerm} of the population${regionPhrase}`;
   } else if (totalBehind > 0) {
-    msg = `${policyLabel} would decrease ${objectTerm} for ${totalBehindTerm} of the population`;
+    msg = `${policyLabel} would decrease ${objectTerm} for ${totalBehindTerm} of the population${regionPhrase}`;
   } else {
-    msg = `${policyLabel} would have no effect on ${objectTerm} for the population`;
+    msg = `${policyLabel} would have no effect on ${objectTerm} for the population${regionPhrase}`;
   }
-  return msg + countryPhrase;
+  return msg;
 }
 
 const description = (

--- a/src/pages/policy/output/LaborSupplyResponse.jsx
+++ b/src/pages/policy/output/LaborSupplyResponse.jsx
@@ -4,8 +4,7 @@ import { ChartLogo } from "../../../api/charts";
 import { formatCurrencyAbbr, localeCode } from "../../../api/language";
 import style from "../../../style";
 import { plotLayoutFont } from "pages/policy/output/utils";
-import ImpactChart from "./ImpactChart";
-import { COUNTRY_NAMES } from "pages/statusPageDefaults";
+import ImpactChart, { regionName } from "./ImpactChart";
 
 function ImpactPlot(props) {
   const { values, labels, metadata, mobile, useHoverCard } = props;
@@ -97,21 +96,17 @@ function ImpactPlot(props) {
 }
 
 export function title(policyLabel, change, metadata) {
-  const term1 = "employment income";
+  const region = regionName(metadata);
+  const regionPhrase = region ? ` in ${region}` : "";
+  const term1 = `employment income${regionPhrase}`;
   const term2 = formatCurrencyAbbr(Math.abs(change * 1e9), metadata, {
     maximumFractionDigits: 1,
   });
   const signTerm = change > 0 ? "increase" : "decrease";
-  const countryId = metadata.countryId;
-  const countryPhrase =
-    countryId === "us" || countryId === "uk"
-      ? ""
-      : `in ${COUNTRY_NAMES(countryId)}`;
-  // TODO: a tolerance should be used to decide the sign.
   const msg =
     change === 0
-      ? `${policyLabel} would have no effect on ${term1} this year ${countryPhrase}`
-      : `${policyLabel} would ${signTerm} ${term1} by ${term2} this year ${countryPhrase}`;
+      ? `${policyLabel} would have no effect on ${term1} this year`
+      : `${policyLabel} would ${signTerm} ${term1} by ${term2} this year`;
   return msg;
 }
 

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -9,8 +9,7 @@ import {
   PovertyChangeContext,
   PovertyChangeProvider,
 } from "./PovertyChangeContext";
-import ImpactChart, { relativeChangeMessage } from "./ImpactChart";
-import { COUNTRY_NAMES } from "pages/statusPageDefaults";
+import ImpactChart, { regionName, relativeChangeMessage } from "./ImpactChart";
 
 export function ImpactPlot(props) {
   const {
@@ -137,16 +136,12 @@ export function title(policyLabel, objectTerm, baseline, reform, metadata) {
   });
   const term2 = `${relTerm} (${absTerm}pp)`;
   const signTerm = relativeChange > 0 ? "increase" : "decrease";
-  const countryId = metadata.countryId;
-  const countryPhrase =
-    countryId === "us" || countryId === "uk"
-      ? ""
-      : `in ${COUNTRY_NAMES(countryId)}`;
-  // TODO: a tolerance should be used to decide the sign.
+  const region = regionName(metadata);
+  const regionPhrase = region ? ` in ${region}` : "";
   const msg =
     absTerm === 0
-      ? `${policyLabel} would have no effect on ${objectTerm} ${countryPhrase}`
-      : `${policyLabel} would ${signTerm} ${objectTerm} by ${term2} ${countryPhrase}`;
+      ? `${policyLabel} would have no effect on ${objectTerm}${regionPhrase}`
+      : `${policyLabel} would ${signTerm} ${objectTerm}${regionPhrase} by ${term2}`;
   return msg;
 }
 

--- a/src/pages/policy/output/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByDecile.jsx
@@ -6,8 +6,7 @@ import { HoverCardContext } from "../../../layout/HoverCard";
 import { cardinal, formatPercent } from "../../../api/language";
 import { plotLayoutFont } from "./utils";
 import React from "react";
-import ImpactChart, { relativeChangeMessage } from "./ImpactChart";
-import { COUNTRY_NAMES } from "pages/statusPageDefaults";
+import ImpactChart, { regionName, relativeChangeMessage } from "./ImpactChart";
 
 export function ImpactPlot(props) {
   const {
@@ -124,21 +123,17 @@ const description = (
 );
 
 export function title(policyLabel, change, metadata) {
-  const term1 = "the net income of households";
+  const region = regionName(metadata);
+  const regionPhrase = region ? ` in ${region}` : "";
+  const term1 = `the net income of households${regionPhrase}`;
   const term2 = formatPercent(Math.abs(change), metadata, {
     maximumFractionDigits: 1,
   });
   const signTerm = change > 0 ? "increase" : "decrease";
-  const countryId = metadata.countryId;
-  const countryPhrase =
-    countryId === "us" || countryId === "uk"
-      ? ""
-      : `in ${COUNTRY_NAMES(countryId)}`;
-  // TODO: a tolerance should be used to decide the sign.
   const msg =
     change === 0
-      ? `${policyLabel} would have no effect on ${term1} on average ${countryPhrase}`
-      : `${policyLabel} would ${signTerm} ${term1} by ${term2} on average ${countryPhrase}`;
+      ? `${policyLabel} would have no effect on ${term1} on average`
+      : `${policyLabel} would ${signTerm} ${term1} by ${term2} on average`;
   return msg;
 }
 


### PR DESCRIPTION
## Description

During refactoring in #1069, I tried to simplify the logic for generating the region phrase in title sentences by just using the country ID but I overlooked the fact that regions could be states. I fix #1077 in this PR by reverting to the previous method for finding the region phrase, i.e., extracting the name of the region from the URL and `metadata.economy_options.region`.

## Screenshots

<img width="764" alt="Screenshot 2023-12-30 at 8 04 56 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/10b4f0f9-1728-456d-988b-24f314b86c12">
<img width="764" alt="Screenshot 2023-12-30 at 8 05 17 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/36f87ff4-4e94-4ac1-b333-4fa3ce7d786d">
<img width="764" alt="Screenshot 2023-12-30 at 8 05 31 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/b3df3830-de19-4c2b-a9ce-e1bfdae9e215">
<img width="764" alt="Screenshot 2023-12-30 at 8 05 46 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/804ba9c5-3d2f-4365-b3d1-2e49db8b7e44">
