### PR TITLE
Fix policy calculator side of app failing on Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "remark-gfm": "^3.0.0 < 4.0.0",
         "styled-components": "^6.1.1",
         "use-react-screenshot": "^3.0.0",
+        "wordwrapjs": "^5.1.0",
         "workbox-background-sync": "^7.0.0",
         "workbox-broadcast-update": "^7.0.0",
         "workbox-cacheable-response": "^7.0.0",
@@ -26920,6 +26921,14 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
+      "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/workbox-background-sync": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "remark-gfm": "^3.0.0 < 4.0.0",
     "styled-components": "^6.1.1",
     "use-react-screenshot": "^3.0.0",
+    "wordwrapjs": "^5.1.0",
     "workbox-background-sync": "^7.0.0",
     "workbox-broadcast-update": "^7.0.0",
     "workbox-cacheable-response": "^7.0.0",

--- a/src/pages/policy/output/ImpactChart.jsx
+++ b/src/pages/policy/output/ImpactChart.jsx
@@ -62,7 +62,7 @@ export function relativeChangeMessage(
             ? `decrease ${objectTerm} by less than ${formatter(tolerance)}`
             : `have no effect on ${objectTerm}`;
   const msg = `${subjectTerm} would ${signTerm}`;
-  return wordwrap.wrap(msg, {width: 50}).replaceAll("\n", "<br>");
+  return wordwrap.wrap(msg, { width: 50 }).replaceAll("\n", "<br>");
 }
 
 /**
@@ -94,7 +94,7 @@ export function absoluteChangeMessage(
             ? `decrease ${objectTerm} by less than ${formatter(tolerance)}`
             : `have no effect on ${objectTerm}`;
   const msg = `${subjectTerm} would ${signTerm}`;
-  return wordwrap.wrap(msg, {width: 50}).replaceAll("\n", "<br>");
+  return wordwrap.wrap(msg, { width: 50 }).replaceAll("\n", "<br>");
 }
 
 /**

--- a/src/pages/policy/output/ImpactChart.jsx
+++ b/src/pages/policy/output/ImpactChart.jsx
@@ -1,7 +1,6 @@
 import HoverCard from "layout/HoverCard";
 import DownloadableScreenshottable from "./DownloadableScreenshottable";
 import { useRef } from "react";
-//import wrapAnsi from "wrap-ansi";
 import wordwrap from "wordwrapjs";
 import { formatPercent } from "api/language";
 
@@ -63,7 +62,6 @@ export function relativeChangeMessage(
             ? `decrease ${objectTerm} by less than ${formatter(tolerance)}`
             : `have no effect on ${objectTerm}`;
   const msg = `${subjectTerm} would ${signTerm}`;
-  // return wrapAnsi(msg, 50).replaceAll("\n", "<br>");
   return wordwrap.wrap(msg, {width: 50}).replaceAll("\n", "<br>");
 }
 
@@ -96,7 +94,6 @@ export function absoluteChangeMessage(
             ? `decrease ${objectTerm} by less than ${formatter(tolerance)}`
             : `have no effect on ${objectTerm}`;
   const msg = `${subjectTerm} would ${signTerm}`;
-  // return wrapAnsi(msg, 50).replaceAll("\n", "<br>");
   return wordwrap.wrap(msg, {width: 50}).replaceAll("\n", "<br>");
 }
 

--- a/src/pages/policy/output/ImpactChart.jsx
+++ b/src/pages/policy/output/ImpactChart.jsx
@@ -1,7 +1,8 @@
 import HoverCard from "layout/HoverCard";
 import DownloadableScreenshottable from "./DownloadableScreenshottable";
 import { useRef } from "react";
-import wrapAnsi from "wrap-ansi";
+//import wrapAnsi from "wrap-ansi";
+import wordwrap from "wordwrapjs";
 import { formatPercent } from "api/language";
 
 export default function ImpactChart(props) {
@@ -62,7 +63,8 @@ export function relativeChangeMessage(
             ? `decrease ${objectTerm} by less than ${formatter(tolerance)}`
             : `have no effect on ${objectTerm}`;
   const msg = `${subjectTerm} would ${signTerm}`;
-  return wrapAnsi(msg, 50).replaceAll("\n", "<br>");
+  // return wrapAnsi(msg, 50).replaceAll("\n", "<br>");
+  return wordwrap.wrap(msg, {width: 50}).replaceAll("\n", "<br>");
 }
 
 /**
@@ -94,7 +96,8 @@ export function absoluteChangeMessage(
             ? `decrease ${objectTerm} by less than ${formatter(tolerance)}`
             : `have no effect on ${objectTerm}`;
   const msg = `${subjectTerm} would ${signTerm}`;
-  return wrapAnsi(msg, 50).replaceAll("\n", "<br>");
+  // return wrapAnsi(msg, 50).replaceAll("\n", "<br>");
+  return wordwrap.wrap(msg, {width: 50}).replaceAll("\n", "<br>");
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #1087.

## Changes

#1087 occurred because `wrap-ansi` utilizes the built-in object method `Intl.Segmenter()`, which is not yet supported on Firefox, but appears to be on Safari and Chrome. This commit replaces `wrap-ansi` with the similar package `wordwrapjs`, which is used for the same purpose: wrapping words to a particular size within the `ImpactChart` component.

## Screenshots

A clip of the changes functioning with the same data used to produce the bug in #1087 is available [here](https://www.loom.com/share/ec5020411fde4c40ab9e865a1b4f1a75?sid=fdcba006-d57f-4d70-94b6-d68a1748113e).

## Tests

None have been included
