### PR TITLE
Add .0 to percentages when rounding to one decimal place in policy output charts

### DIFF
--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -9,8 +9,7 @@ import {
 import { HoverCardContext } from "../../../layout/HoverCard";
 import style from "../../../style";
 import { plotLayoutFont } from "pages/policy/output/utils";
-import ImpactChart, { regionName } from "./ImpactChart";
-import wrapAnsi from "wrap-ansi";
+import ImpactChart, { regionName, wordWrap } from "./ImpactChart";
 
 function ImpactPlot(props) {
   const {
@@ -25,7 +24,10 @@ function ImpactPlot(props) {
   const xArray = ["Cliff rate", "Cliff gap"];
   const yArray = [cliffShareChange, cliffGapChange];
   const formatPer = (x) =>
-    formatPercent(x, metadata, { maximumFractionDigits: 1 });
+    formatPercent(x, metadata, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    });
   const formatCur = (x) =>
     formatCurrencyAbbr(x, metadata, {
       maximumFractionDigits: 1,
@@ -48,16 +50,16 @@ function ImpactPlot(props) {
       change > tolerance
         ? `increase ${objectTerm} by ${formatPer(change) + baselineReformTerm}`
         : change > 0
-          ? `increase ${objectTerm} by ${formatPer(tolerance)}`
+          ? `increase ${objectTerm} by less than ${formatPer(tolerance)}`
           : change < -tolerance
             ? `decrease ${objectTerm} by ${
                 formatPer(-change) + baselineReformTerm
               }`
             : change < 0
-              ? `decrease ${objectTerm} by ${formatPer(tolerance)}`
+              ? `decrease ${objectTerm} by less than ${formatPer(tolerance)}`
               : `have no effect on ${objectTerm}`;
     const msg = `This reform would ${signTerm}`;
-    return wrapAnsi(msg, 50).replaceAll("\n", "<br>");
+    return wordWrap(msg, 50).replaceAll("\n", "<br>");
   };
   return (
     <Plot

--- a/src/pages/policy/output/ImpactChart.jsx
+++ b/src/pages/policy/output/ImpactChart.jsx
@@ -19,6 +19,16 @@ export default function ImpactChart(props) {
 }
 
 /**
+ * 
+ * @param {string} text the text to wrap
+ * @param {number} width the width of the column
+ * @returns 
+ */
+export function wordWrap(text, width = 50) {
+  return wordwrap.wrap(text, { width: width });
+}
+
+/**
  *
  * @param {string} subjectTerm the subject of the sentence
  * @param {string} objectTerm the object of the sentence
@@ -43,7 +53,10 @@ export function relativeChangeMessage(
   options,
 ) {
   const formatter = (x) =>
-    formatPercent(x, metadata, { maximumFractionDigits: 1 });
+    formatPercent(x, metadata, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    });
   const baselineReformTerm = options
     ? ` from ${options.formatter(options.baseline)} to ${options.formatter(
         options.reform,
@@ -62,7 +75,7 @@ export function relativeChangeMessage(
             ? `decrease ${objectTerm} by less than ${formatter(tolerance)}`
             : `have no effect on ${objectTerm}`;
   const msg = `${subjectTerm} would ${signTerm}`;
-  return wordwrap.wrap(msg, { width: 50 }).replaceAll("\n", "<br>");
+  return wordWrap(msg, 50).replaceAll("\n", "<br>");
 }
 
 /**
@@ -94,7 +107,7 @@ export function absoluteChangeMessage(
             ? `decrease ${objectTerm} by less than ${formatter(tolerance)}`
             : `have no effect on ${objectTerm}`;
   const msg = `${subjectTerm} would ${signTerm}`;
-  return wordwrap.wrap(msg, { width: 50 }).replaceAll("\n", "<br>");
+  return wordWrap(msg, 50).replaceAll("\n", "<br>");
 }
 
 /**

--- a/src/pages/policy/output/ImpactChart.jsx
+++ b/src/pages/policy/output/ImpactChart.jsx
@@ -19,10 +19,10 @@ export default function ImpactChart(props) {
 }
 
 /**
- * 
+ *
  * @param {string} text the text to wrap
  * @param {number} width the width of the column
- * @returns 
+ * @returns the wrapped text with the eol character \n inserted for breaks
  */
 export function wordWrap(text, width = 50) {
   return wordwrap.wrap(text, { width: width });

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -20,7 +20,10 @@ function ImpactPlot(props) {
     useHoverCard,
   } = props;
   const formatPer = (x) =>
-    formatPercent(x, metadata, { maximumFractionDigits: 1 });
+    formatPercent(x, metadata, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    });
   const hoverMessage = (x) => {
     let obj, baseline, reform, formatter;
     if (x === "Gini index") {

--- a/src/pages/policy/output/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/IntraDecileImpact.jsx
@@ -4,8 +4,7 @@ import { ChartLogo } from "../../../api/charts";
 import style from "../../../style";
 import { cardinal, formatPercent, localeCode } from "../../../api/language";
 import { plotLayoutFont } from "pages/policy/output/utils";
-import ImpactChart, { regionName } from "./ImpactChart";
-import wrapAnsi from "wrap-ansi";
+import ImpactChart, { regionName, wordWrap } from "./ImpactChart";
 
 // this function is called in this file with yaxistitle="Income decile" from
 // IntraWealthDecileImpact with yaxistitle="Wealth decile"
@@ -52,9 +51,12 @@ export function ImpactPlot(props) {
         type1 === "all"
           ? "Of all households,"
           : `Of households in the ${cardinal(y)} decile,`;
-      const term2 = formatPercent(x, metadata, { maximumFractionDigits: 1 });
+      const term2 = formatPercent(x, metadata, {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      });
       const msg = `${term1} ${policyLabel} would cause ${term2} of people to ${hoverTextMap[type2]} their net income.`;
-      return wrapAnsi(msg, 50).replaceAll("\n", "<br>");
+      return wordWrap(msg, 50).replaceAll("\n", "<br>");
     }
     const xArray = type1 === "all" ? [all[type2]] : deciles[type2];
     const yArray = type1 === "all" ? ["All"] : decileNumbers;

--- a/src/pages/policy/output/PovertyImpact.jsx
+++ b/src/pages/policy/output/PovertyImpact.jsx
@@ -24,7 +24,10 @@ export function ImpactPlot(props) {
   } = props;
   const setHoverCard = useContext(HoverCardContext);
   const formatPer = (n) =>
-    formatPercent(n, metadata, { maximumFractionDigits: 1 });
+    formatPercent(n, metadata, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    });
   const hoverMessage = (x) => {
     const obj = `the percentage of ${
       x === "All" ? "people" : x.toLowerCase()

--- a/src/pages/policy/output/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/PovertyImpactByGender.jsx
@@ -29,7 +29,10 @@ export function ImpactPlot(props) {
   const setHoverCard = useContext(HoverCardContext);
 
   const formatPer = (n) =>
-    formatPercent(n, metadata, { maximumFractionDigits: 1 });
+    formatPercent(n, metadata, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    });
   const hoverMessage = (x) => {
     const baseline =
       x === "All"

--- a/src/pages/policy/output/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/PovertyImpactByRace.jsx
@@ -25,7 +25,10 @@ function ImpactPlot(props) {
   } = props;
   const setHoverCard = useContext(HoverCardContext);
   const formatPer = (n) =>
-    formatPercent(n, metadata, { maximumFractionDigits: 1 });
+    formatPercent(n, metadata, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    });
   const hoverMessage = (x) => {
     const baseline =
       x === "All"

--- a/src/pages/policy/output/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/RelativeImpactByDecile.jsx
@@ -19,7 +19,10 @@ export function ImpactPlot(props) {
   } = props;
   const setHoverCard = useContext(HoverCardContext);
   const formatPer = (n) =>
-    formatPercent(n, metadata, { maximumFractionDigits: 1 });
+    formatPercent(n, metadata, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    });
   const hoverMessage = (x, y) => {
     const obj = `the income of households in the ${cardinal(x)} ${decileType}`;
     return relativeChangeMessage("This reform", obj, y, 0.001, metadata);


### PR DESCRIPTION
## Description

- We fix #1093 by specifying the minimum number of fraction digits in hover messages for all %-numbers in policy output charts
- We fix the hover message for cliff charts when the change is less than the specified tolerance -- the text `less than` was missing after changes in #1069.
- We fix #1087 by replacing `wrap-ansi` with the `wordwrapjs` in the charts missed in the fix #1094.

## Screenshots

For decimal places:

<img width="784" alt="Screenshot 2024-01-02 at 10 04 28 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/836f554f-02d8-46be-89d4-cec659f50885">

For word wrap (the chart is displayed now):
<img width="784" alt="Screenshot 2024-01-02 at 9 49 50 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/e60916d1-dada-4076-8fde-a093abb375cb">

## Tests

The charts were tested for a few configurations on Safari and Firefox.
