### PR TITLE
Hide cliff impacts page in reform calculator flow

### DIFF
--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
-import { DisplayError, DisplayImpact, DisplayWait, LowLevelDisplay } from "./Display";
+import {
+  DisplayError,
+  DisplayImpact,
+  DisplayWait,
+  LowLevelDisplay,
+} from "./Display";
 import { useSearchParams } from "react-router-dom";
 import { asyncApiCall, copySearchParams, apiCall } from "../../../api/call";
 import ErrorPage from "layout/Error";
@@ -209,7 +214,7 @@ export function FetchAndDisplayCliffImpact(props) {
   // Remove the below block when cliff impacts are reinstated
   return (
     <LowLevelDisplay {...props}>
-      <ErrorPage message="This service is temporarily unavailable. Please try again later." />;
+      <ErrorPage message="This service is temporarily unavailable. Please try again later." />
     </LowLevelDisplay>
   );
 

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { DisplayError, DisplayImpact, DisplayWait } from "./Display";
+import { DisplayError, DisplayImpact, DisplayWait, LowLevelDisplay } from "./Display";
 import { useSearchParams } from "react-router-dom";
 import { asyncApiCall, copySearchParams, apiCall } from "../../../api/call";
 import ErrorPage from "layout/Error";
@@ -206,7 +206,11 @@ export function FetchAndDisplayCliffImpact(props) {
     return <DisplayError error={error} />;
   }
 
-  return <ErrorPage message="This service is temporarily unavailable. Please try again later." />;
+  return (
+    <LowLevelDisplay {...props}>
+      <ErrorPage message="This service is temporarily unavailable. Please try again later." />;
+    </LowLevelDisplay>
+  );
 
   /*
   if (!impact) {

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -206,6 +206,7 @@ export function FetchAndDisplayCliffImpact(props) {
     return <DisplayError error={error} />;
   }
 
+  // Remove the below block when cliff impacts are reinstated
   return (
     <LowLevelDisplay {...props}>
       <ErrorPage message="This service is temporarily unavailable. Please try again later." />;

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 import { DisplayError, DisplayImpact, DisplayWait } from "./Display";
 import { useSearchParams } from "react-router-dom";
 import { asyncApiCall, copySearchParams, apiCall } from "../../../api/call";
-import LoadingCentered from "layout/LoadingCentered";
+import ErrorPage from "layout/Error";
+// import LoadingCentered from "layout/LoadingCentered";
 
 /**
  *
@@ -152,13 +153,16 @@ export function FetchAndDisplayCliffImpact(props) {
   const timePeriod = searchParams.get("timePeriod");
   const reformPolicyId = searchParams.get("reform");
   const baselinePolicyId = searchParams.get("baseline");
+
+  // Remove the following eslint ignore when cliff impacts are restored
+  // eslint-disable-next-line no-unused-vars
   const [impact, setImpact] = useState(null);
   const [error, setError] = useState(null);
   const {
     metadata,
-    policy,
-    hasShownPopulationImpactPopup,
-    setHasShownPopulationImpactPopup,
+    // policy,
+    // hasShownPopulationImpactPopup,
+    // setHasShownPopulationImpactPopup,
   } = props;
   useEffect(() => {
     if (!!region && !!timePeriod && !!reformPolicyId && !!baselinePolicyId) {
@@ -202,6 +206,9 @@ export function FetchAndDisplayCliffImpact(props) {
     return <DisplayError error={error} />;
   }
 
+  return <ErrorPage message="This service is temporarily unavailable. Please try again later." />;
+
+  /*
   if (!impact) {
     return <LoadingCentered message="Computing the cliff impact..." />;
   }
@@ -215,4 +222,5 @@ export function FetchAndDisplayCliffImpact(props) {
       setHasShownPopulationImpactPopup={setHasShownPopulationImpactPopup}
     />
   );
+  */
 }

--- a/src/pages/policy/output/ImpactTypes.jsx
+++ b/src/pages/policy/output/ImpactTypes.jsx
@@ -1,7 +1,7 @@
 import averageImpactByDecile from "./AverageImpactByDecile";
 import averageImpactByWealthDecile from "./AverageImpactByWealthDecile";
 import budgetaryImpact from "./BudgetaryImpact";
-import cliffImpact from "./CliffImpact";
+// import cliffImpact from "./CliffImpact";
 import deepPovertyImpact from "./DeepPovertyImpact";
 import deepPovertyImpactByGender from "./DeepPovertyImpactByGender";
 import detailedBudgetaryImpact from "./DetailedBudgetaryImpact";
@@ -31,7 +31,7 @@ export const impactLabels = {
   genderDeepPovertyImpact: "Deep poverty impact by sex",
   racialPovertyImpact: "Poverty impact by race and ethnicity",
   inequalityImpact: "Income inequality impact",
-  cliffImpact: "Cliff impact",
+  // cliffImpact: "Cliff impact",
   codeReproducibility: "Reproduce in Python",
   analysis: "Analysis",
 };
@@ -52,7 +52,7 @@ const map = {
   genderDeepPovertyImpact: deepPovertyImpactByGender,
   racialPovertyImpact: povertyImpactByRace,
   inequalityImpact: inequalityImpact,
-  cliffImpact: cliffImpact,
+  // cliffImpact: cliffImpact,
 };
 
 // get representations of the impact as a chart and a csv. The returned object


### PR DESCRIPTION
## Description

Fixes #1036. This PR temporarily disables the cliff impacts page in the policy reform calculator flow.

## Changes

This PR comments out the code within the `FetchAndDisplayCliffImpacts` component, itself within the `FetchAndDisplayImpact` file. The code is replaced with the `ErrorPage` component, wrapped in `LowLevelDisplay` to allow the use of the navigation buttons embedded within `BottomCarousel`. It also includes commented instructions on what to delete when reinstating the cliff impacts page.

## Screenshots

A video of the changes in action is available [here](https://www.loom.com/share/a0f7161d31b147719c536b5677283010?sid=1300fa51-44e2-499a-8bff-fa044e4e6c68).

## Tests

No tests were included.
