### PR TITLE
Add print button for policy output charts and gpt analysis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-responsive-carousel": "^3.2.23",
         "react-router-dom": "^6.21.1",
         "react-scripts": "^5.0.1",
+        "react-to-print": "^2.14.15",
         "react-twitter-embed": "^4.0.4",
         "reading-time": "^1.5.0",
         "rehype-raw": "^7.0.0",
@@ -22839,6 +22840,15 @@
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-to-print": {
+      "version": "2.14.15",
+      "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-2.14.15.tgz",
+      "integrity": "sha512-SKnwOzU2cJ8eaAkoJO7+gNhvfEDmm+Y34IdcHsjtHioUevUPhprqbVtvNJlZ2JkGJ8ExK2QNWM9pXECTDR5D8w==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-responsive-carousel": "^3.2.23",
     "react-router-dom": "^6.21.1",
     "react-scripts": "^5.0.1",
+    "react-to-print": "^2.14.15",
     "react-twitter-embed": "^4.0.4",
     "reading-time": "^1.5.0",
     "rehype-raw": "^7.0.0",

--- a/src/layout/ResultActions.jsx
+++ b/src/layout/ResultActions.jsx
@@ -18,9 +18,23 @@ import {
   LinkOutlined,
   FileImageOutlined,
   FileTextOutlined,
+  PrinterFilled,
 } from "@ant-design/icons";
 import React from "react";
 
+/**
+ *
+ * @param {object} props
+ * @param {function} props.downloadPng callback for download png button
+ * @param {function} props.downloadCsv callback for download csv button
+ * @param {function} props.copyLink callback for copy link button
+ * @param {string} props.twitterLink link for twitter button
+ * @param {string} props.facebookLink link for facebook button
+ * @param {string} props.linkedInLink link for linkedin button
+ * @param {string} props.print callback for print button
+ *
+ * @returns
+ */
 export default function ResultActions(props) {
   const {
     downloadPng,
@@ -29,6 +43,7 @@ export default function ResultActions(props) {
     twitterLink,
     facebookLink,
     linkedInLink,
+    print,
   } = props;
   const iconStyle = { fontSize: 20 };
   const btnSize = "small";
@@ -46,7 +61,7 @@ export default function ResultActions(props) {
       }}
     >
       {downloadPng && (
-        <Tooltip title="Download the chart as a png file">
+        <Tooltip title="Download the result as a png file">
           <Button
             type="text"
             size={btnSize}
@@ -97,6 +112,16 @@ export default function ResultActions(props) {
           href={linkedInLink}
         />
       </Tooltip>
+      {print && (
+        <Tooltip title="Print the result">
+          <Button
+            type="text"
+            size={btnSize}
+            icon={<PrinterFilled style={iconStyle} />}
+            onClick={print}
+          />
+        </Tooltip>
+      )}
     </div>
   );
 }

--- a/src/pages/BlogPage.jsx
+++ b/src/pages/BlogPage.jsx
@@ -41,7 +41,7 @@ function MarkdownP(props) {
 }
 
 export function BlogPostMarkdown(props) {
-  const { markdown } = props;
+  const { markdown, dict } = props;
   const mobile = useMobile();
 
   const renderers = {
@@ -202,6 +202,13 @@ export function BlogPostMarkdown(props) {
             {children}
           </th>
         ),
+        abbr: (props) => {
+          const { title } = props;
+          if (Object.keys(dict).includes(title)) {
+            return dict[title];
+          }
+          return <abbr {...props}></abbr>;
+        },
       }}
     >
       {markdown}

--- a/src/pages/policy/output/Analysis.jsx
+++ b/src/pages/policy/output/Analysis.jsx
@@ -10,8 +10,7 @@ import { asyncApiCall, countryApiCall } from "../../../api/call";
 import { getImpactReps } from "./ImpactTypes";
 
 export default function Analysis(props) {
-  const { impact, policyLabel, metadata, policy, region, timePeriod, mobile } =
-    props;
+  const { impact, policyLabel, metadata, policy, region, timePeriod } = props;
   const [searchParams] = useSearchParams();
   const selectedVersion = searchParams.get("version") || metadata.version;
   const impactLabels = [
@@ -30,7 +29,8 @@ export default function Analysis(props) {
         impact: impact,
         metadata: metadata,
         policyLabel: policyLabel,
-        mobile: mobile,
+        // mobile plots have smaller heights
+        mobile: true,
       }).chart,
     ]),
   );

--- a/src/pages/policy/output/Analysis.jsx
+++ b/src/pages/policy/output/Analysis.jsx
@@ -7,11 +7,33 @@ import colors from "../../../style/colors";
 import { getParameterAtInstant } from "../../../api/parameters";
 import { BlogPostMarkdown } from "../../BlogPage";
 import { asyncApiCall, countryApiCall } from "../../../api/call";
+import { getImpactReps } from "./ImpactTypes";
 
 export default function Analysis(props) {
-  const { impact, policyLabel, metadata, policy, region, timePeriod } = props;
+  const { impact, policyLabel, metadata, policy, region, timePeriod, mobile } =
+    props;
   const [searchParams] = useSearchParams();
   const selectedVersion = searchParams.get("version") || metadata.version;
+  const impactLabels = [
+    "decileRelativeImpact",
+    "povertyImpact",
+    "racialPovertyImpact",
+    "inequalityImpact",
+  ];
+  if (metadata.countryId === "uk") {
+    impactLabels.splice(2, 1);
+  }
+  const chartDict = Object.fromEntries(
+    impactLabels.map((label) => [
+      label,
+      getImpactReps(label, {
+        impact: impact,
+        metadata: metadata,
+        policyLabel: policyLabel,
+        mobile: mobile,
+      }).chart,
+    ]),
+  );
   const relevantParameters = Object.keys(policy.reform.data).map(
     (parameter) => metadata.parameters[parameter],
   );
@@ -33,9 +55,6 @@ export default function Analysis(props) {
     },
     {},
   );
-  const baseResultsUrl = `https://policyengine.org/${metadata.countryId}/policy?version=${selectedVersion}&region=${region}&timePeriod=${timePeriod}&reform=${policy.reform.id}&baseline=${policy.baseline.id}&embed=True`;
-  const buildIFrame = (chartName) =>
-    `<iframe src="${baseResultsUrl}&focus=policyOutput.${chartName}" width="800px" height="418px" style="border: none; overflow: hidden;" onload="scroll(0,0);"></iframe>`;
   const policyDetails = `I'm using PolicyEngine, a free, open source tool to compute the impact of public policy. I'm writing up an economic analysis of a hypothetical tax-benefit policy reform. Please write the analysis for me using the details below, in their order. You should:
   
   * First explain each provision of the reform, noting that it's hypothetical and won't represents policy reforms for ${timePeriod} and ${
@@ -185,8 +204,9 @@ export default function Analysis(props) {
   }
 
   const displayCharts = (markdown) =>
-    markdown.replace(/{{(.*?)}}/g, (match, chartName) =>
-      buildIFrame(chartName),
+    markdown.replace(
+      /{{(.*?)}}/g,
+      (match, impactType) => `<abbr title="${impactType}"></abbr>`,
     );
 
   const onGenerate = () => {
@@ -245,8 +265,6 @@ export default function Analysis(props) {
     </>
   ) : null;
 
-  console.log(analysis);
-
   return (
     <>
       <h2>Analysis</h2>
@@ -300,11 +318,9 @@ export default function Analysis(props) {
             style={{ maxWidth: 250, margin: "20px auto 25px" }}
           />
         )}
-        {!hasClickedGenerate ? (
-          <BlogPostMarkdown markdown={analysis} />
-        ) : analysis ? (
-          <BlogPostMarkdown markdown={analysis} />
-        ) : null}
+        {hasClickedGenerate && analysis && (
+          <BlogPostMarkdown markdown={analysis} dict={chartDict} />
+        )}
       </div>
       <div
         style={{

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -139,7 +139,6 @@ export function DisplayImpact(props) {
         region={region}
         timePeriod={timePeriod}
         policyLabel={policyLabel}
-        mobile={mobile}
       />
     );
   } else {

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -128,7 +128,7 @@ export function DisplayImpact(props) {
   const filename = impactType + `${policyLabel}`;
   useEffect(() => {
     document.title = `${policyLabel} | ${impactLabels[impactType]} | PolicyEngine`;
-  }, []);
+  });
   let pane, downloadCsvFn, downloadPngFn;
   if (impactType === "analysis") {
     pane = (

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -126,6 +126,9 @@ export function DisplayImpact(props) {
   const policyLabel = getPolicyLabel(policy);
   const mobile = useMobile();
   const filename = impactType + `${policyLabel}`;
+  useEffect(() => {
+    document.title = `${policyLabel} | ${impactLabels[impactType]} | PolicyEngine`;
+  }, []);
   let pane, downloadCsvFn, downloadPngFn;
   if (impactType === "analysis") {
     pane = (
@@ -136,6 +139,7 @@ export function DisplayImpact(props) {
         region={region}
         timePeriod={timePeriod}
         policyLabel={policyLabel}
+        mobile={mobile}
       />
     );
   } else {
@@ -153,7 +157,6 @@ export function DisplayImpact(props) {
   }
   return (
     <LowLevelDisplay
-      title={`${policyLabel} | ${impactLabels[impactType]} | PolicyEngine`}
       downloadPng={downloadPngFn}
       downloadCsv={downloadCsvFn}
       metadata={metadata}
@@ -188,7 +191,6 @@ export function DisplayImpact(props) {
 export function LowLevelDisplay(props) {
   const {
     children,
-    title,
     downloadCsv,
     downloadPng,
     metadata,
@@ -196,9 +198,6 @@ export function LowLevelDisplay(props) {
     hasShownPopulationImpactPopup,
     setHasShownPopulationImpactPopup,
   } = props;
-  useEffect(() => {
-    document.title = title;
-  }, []);
   const mobile = useMobile();
   const [preparingForScreenshot, setPreparingForScreenshot] = useState(false);
   const [, takeScreenShot] = useScreenshot();

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -13,6 +13,7 @@ import useMobile from "layout/Responsive";
 import ErrorPage from "layout/Error";
 import ResultActions from "layout/ResultActions";
 import { downloadCsv, downloadPng } from "./utils";
+import { useReactToPrint } from "react-to-print";
 
 /**
  *
@@ -124,7 +125,6 @@ export function DisplayImpact(props) {
   const impactType = /policyOutput\.(.+)/.exec(focus)[1];
   const policyLabel = getPolicyLabel(policy);
   const mobile = useMobile();
-  document.title = `${policyLabel} | ${impactLabels[impactType]} | PolicyEngine`;
   const filename = impactType + `${policyLabel}`;
   let pane, downloadCsvFn, downloadPngFn;
   if (impactType === "analysis") {
@@ -153,6 +153,7 @@ export function DisplayImpact(props) {
   }
   return (
     <LowLevelDisplay
+      title={`${policyLabel} | ${impactLabels[impactType]} | PolicyEngine`}
       downloadPng={downloadPngFn}
       downloadCsv={downloadCsvFn}
       metadata={metadata}
@@ -187,6 +188,7 @@ export function DisplayImpact(props) {
 export function LowLevelDisplay(props) {
   const {
     children,
+    title,
     downloadCsv,
     downloadPng,
     metadata,
@@ -194,14 +196,17 @@ export function LowLevelDisplay(props) {
     hasShownPopulationImpactPopup,
     setHasShownPopulationImpactPopup,
   } = props;
+  useEffect(() => {
+    document.title = title;
+  }, []);
   const mobile = useMobile();
   const [preparingForScreenshot, setPreparingForScreenshot] = useState(false);
   const [, takeScreenShot] = useScreenshot();
-  const imageRef = useRef(null);
+  const componentRef = useRef(null);
   useEffect(() => {
     if (preparingForScreenshot) {
       setTimeout(() => {
-        takeScreenShot(imageRef.current).then((img) => {
+        takeScreenShot(componentRef.current).then((img) => {
           setPreparingForScreenshot(false);
           // send a request to /image with the image
           // The filename should be the current path (including query strings), but with /, &, ? etc. replaced with _
@@ -243,10 +248,14 @@ export function LowLevelDisplay(props) {
   const facebookLink = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
   const linkedInLink = `https://www.linkedin.com/sharing/share-offsite/?url=${url}`;
 
-  function copyLink() {
+  const copyLink = () => {
     navigator.clipboard.writeText(window.location.href);
     message.info("Link copied to clipboard");
-  }
+  };
+
+  const print = useReactToPrint({
+    content: () => componentRef.current,
+  });
 
   const embed = new URLSearchParams(window.location.search).get("embed");
   const bottomElements =
@@ -277,7 +286,7 @@ export function LowLevelDisplay(props) {
     return (
       <>
         <div
-          ref={imageRef}
+          ref={componentRef}
           style={{
             position: "absolute",
             top: 0,
@@ -307,10 +316,11 @@ export function LowLevelDisplay(props) {
   }
 
   return (
-    <ResultsPanel ref={imageRef}>
+    <ResultsPanel>
       {!preparingForScreenshot && (
         <ResultActions
           downloadPng={downloadPng}
+          print={print}
           downloadCsv={downloadCsv}
           copyLink={copyLink}
           twitterLink={twitterLink}
@@ -323,7 +333,7 @@ export function LowLevelDisplay(props) {
         hasShownPopulationImpactPopup={hasShownPopulationImpactPopup}
         setHasShownPopulationImpactPopup={setHasShownPopulationImpactPopup}
       />
-      {children}
+      <div ref={componentRef}>{children}</div>
       {!mobile && !preparingForScreenshot && (
         <BottomCarousel
           selected={focus}


### PR DESCRIPTION
## Description

We fix #475 by adding a print button for policy output charts and gpt analysis.

## Changes

- We added a print action to the `ResultActions` component.
- We use `react-to-print` to print the contents of the main component, i.e., the chart or the analysis.
- Since `Analysis` uses iframes to display charts, it is a little inefficient and hard to print using `react-to-print`. We stop using iframes in `Analysis`. 
  - To stop using iframes we needed a different method to pass the chart to `BlogPostMarkdown`. We use the `abbr` tag for this purpose.

## Screenshots

See the printer icon on the far right:
<img width="784" alt="Screenshot 2024-01-03 at 9 18 06 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/a5974858-c2a9-4171-98e2-02ee2a1cf7bc">

------

A pdf generated by clicking on print icon for a gpt analysis:
[Policy #42716 | Analysis | PolicyEngine.pdf](https://github.com/PolicyEngine/policyengine-app/files/13825328/Policy.42716.Analysis.PolicyEngine.pdf)

------

A pdf generated by clicking on print icon for a chart:
[Policy #40085 | Outcomes by income decile | PolicyEngine.pdf](https://github.com/PolicyEngine/policyengine-app/files/13825342/Policy.40085.Outcomes.by.income.decile.PolicyEngine.pdf)

------

## Tests

We tested the print button for about a dozen configurations.
