### PR TITLE
Fix error encountered in deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "fix": "eslint --fix --ext js,jsx . && prettier -w .",
-    "lint": "eslint --ext js,jsx . && prettier -c ."
+    "lint": "eslint --ext js,jsx --max-warnings 0 . && prettier -c ."
   },
   "browserslist": {
     "production": [

--- a/src/pages/policy/output/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/BudgetaryImpact.jsx
@@ -161,7 +161,7 @@ export default function budgetaryImpact(props) {
     "Benefits",
     "Net",
   ];
-  if (metadata.countryId != "us") {
+  if (metadata.countryId !== "us") {
     desktopLabels[0] = "Tax revenues";
     mobileLabels[0] = "Taxes";
   }


### PR DESCRIPTION
Fix lint error that prevented [deployment](https://github.com/PolicyEngine/policyengine-app/actions/runs/7413645656/job/20173038901).

The lint error was created in the master branch after PR #1080 was created -- therefore, it was not caught. We should not see these errors during deployment after merging new PRs.