### PR TITLE
Update default time periods for policy calculator

### DIFF
--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -45,8 +45,18 @@ function TimePeriodSelector(props) {
   const options = metadata.economy_options.time_period.map((time_period) => {
     return { value: time_period.name.toString(), label: time_period.label };
   });
+
+  const yearArray = options.reduce((accu, periodObj) => {
+    return [...accu, Number(periodObj.value)];
+  }, []);
+
+  const curYear = new Date().getFullYear();
+  const defaultPeriod = yearArray.includes(curYear)
+    ? curYear
+    : options[0].value;
+
   const [value] = useState(
-    (searchParams.get("timePeriod") || "").toString() || options[0].value,
+    (searchParams.get("timePeriod") || "").toString() || defaultPeriod,
   );
 
   return (


### PR DESCRIPTION
## Description

Fixes #1084. Previously, the `TimePeriodSelector` within the `PolicyRightSidebar` defaulted to either pulling the year over which to simulate from URL params or, if that didn't exist, taking the first year from the country package metadata. This PR replaces that logic with a check to see whether the current year is within the metadata; if so, it uses that, otherwise it takes the first year as before.

## Changes

This component first creates an array of the time periods included within the metadata and converts them to `Number` types. It then checks to see if the current year exists within that array; if so, it places that as the default year if no URL param is specified, otherwise it takes the first year from the metadata, as previously.

## Screenshots

A brief Loom video is available [here](https://www.loom.com/share/a3d9dfd268024982be778b66d3abc4db?sid=c1e3428c-2dfb-4b03-a6c5-e784313a7cf6).
