### PR TITLE
Change default timePeriod search param values to current year, if present in metadata

### DIFF
--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -313,7 +313,6 @@ export default function PolicyRightSidebar(props) {
 
   useEffect(() => {
     if (!region || !timePeriod || !reformPolicyId || !baselinePolicyId) {
-      
       const timeOptions = metadata.economy_options.time_period;
 
       const yearArray = timeOptions.reduce((accu, periodObj) => {

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -313,9 +313,21 @@ export default function PolicyRightSidebar(props) {
 
   useEffect(() => {
     if (!region || !timePeriod || !reformPolicyId || !baselinePolicyId) {
+      
+      const timeOptions = metadata.economy_options.time_period;
+
+      const yearArray = timeOptions.reduce((accu, periodObj) => {
+        return [...accu, Number(periodObj.name)];
+      }, []);
+
+      const curYear = new Date().getFullYear();
+      const defaultTimePeriod = yearArray.includes(curYear)
+        ? curYear
+        : timeOptions[0].name;
+
       const defaults = {
         region: metadata.economy_options.region[0].name,
-        timePeriod: metadata.economy_options.time_period[0].name,
+        timePeriod: defaultTimePeriod,
         baseline: metadata.current_law_id,
       };
       let newSearch = copySearchParams(searchParams);

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -92,9 +92,21 @@ export function FetchAndDisplayImpact(props) {
           clearInterval(interval);
         });
     } else {
+      
+      const timeOptions = metadata.economy_options.time_period;
+
+      const yearArray = timeOptions.reduce((accu, periodObj) => {
+        return [...accu, Number(periodObj.name)];
+      }, []);
+
+      const curYear = new Date().getFullYear();
+      const defaultTimePeriod = yearArray.includes(curYear)
+        ? curYear
+        : timeOptions[0].name;
+
       const defaults = {
         region: metadata.economy_options.region[0].name,
-        timePeriod: metadata.economy_options.time_period[0].name,
+        timePeriod: defaultTimePeriod,
         baseline: metadata.current_law_id,
       };
       let newSearch = copySearchParams(searchParams);
@@ -186,9 +198,21 @@ export function FetchAndDisplayCliffImpact(props) {
           setError(err);
         });
     } else {
+      
+      const timeOptions = metadata.economy_options.time_period;
+
+      const yearArray = timeOptions.reduce((accu, periodObj) => {
+        return [...accu, Number(periodObj.name)];
+      }, []);
+
+      const curYear = new Date().getFullYear();
+      const defaultTimePeriod = yearArray.includes(curYear)
+        ? curYear
+        : timeOptions[0].name;
+
       const defaults = {
         region: metadata.economy_options.region[0].name,
-        timePeriod: metadata.economy_options.time_period[0].name,
+        timePeriod: defaultTimePeriod,
         baseline: metadata.current_law_id,
       };
       let newSearch = copySearchParams(searchParams);

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -92,7 +92,6 @@ export function FetchAndDisplayImpact(props) {
           clearInterval(interval);
         });
     } else {
-      
       const timeOptions = metadata.economy_options.time_period;
 
       const yearArray = timeOptions.reduce((accu, periodObj) => {
@@ -198,7 +197,6 @@ export function FetchAndDisplayCliffImpact(props) {
           setError(err);
         });
     } else {
-      
       const timeOptions = metadata.economy_options.time_period;
 
       const yearArray = timeOptions.reduce((accu, periodObj) => {


### PR DESCRIPTION
## Description

Fixes #1107 and fixes #1106. This fixes a regression from #1105 whereby URLs without defined `timePeriod` params were automatically given the first item from the country metadata's `time_periods` list, meaning that the UK would default to 2023. 

## Changes

There are three places where the app determines whether or not a `timePeriod` URL param exists, then provides a default if not. In all three of these places, this PR replaces the previous behavior (pulling from the top of `time_periods`) with new behavior that obtains the current year, checks if this is present in `time_periods`, and if it is, supplies it, but if not, supplies the first item in `time_periods`. This check is done to prevent a case where PolicyEngine has yet to create a dataset for the current year.

## Screenshots

Loom video available [here](https://www.loom.com/share/f71a4bb27e204e879c66980994f9217b?sid=ea33bcd4-2848-4553-98ad-7d6f0d235c08).

## Tests

None supplied.
