### PR TITLE
Change BottomCarousel height to remove unnecessary scroll

### DIFF
--- a/src/layout/BottomCarousel.jsx
+++ b/src/layout/BottomCarousel.jsx
@@ -17,7 +17,7 @@ export default function BottomCarousel(props) {
         position: "absolute",
         bottom: mobile ? "25vh" : 0,
         display: "flex",
-        height: 80,
+        height: 81,
         left: mobile ? 0 : "25%",
         width: mobile ? "100%" : "50%",
         alignItems: "center",


### PR DESCRIPTION
## Description

Fixes #1111. This PR corrects `BottomCarousel`'s height to remove unnecessary vertical scroll.

## Changes

`BottomCarousel`'s height has been updated from 80 to 81 to include the border

## Screenshots

N/A

## Tests

None
