### PR TITLE
Household questionnaire asks for head age when multiple members

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -34,12 +34,15 @@ export default function VariableEditor(props) {
   const entityPlural = metadata.entities[variable.entity].plural;
   const isSimulated = !variable.isInputVariable;
   const possibleEntities = Object.keys(householdInput[entityPlural]).filter(
-    (entity) => householdInput[entityPlural][entity][variable.name],
+    (entity) => householdInput[entityPlural][entity][variableName],
   );
 
-  // Add the variable to the relevant portions of the household input object
+  // The variable must be present in all entities. The following effect is
+  // executed whenever the variable is missing from some entities in the
+  // household. addVariable is called to ensure that the variable is added to
+  // all entities.
   useEffect(() => {
-    if (!possibleEntities.length) {
+    if (possibleEntities.length !== householdInput[entityPlural].length) {
       const newHouseholdInput = addVariable(
         householdInput,
         variable,
@@ -321,8 +324,8 @@ function HouseholdVariableEntityInput(props) {
 }
 
 /**
- * Adds the VariableEditor's focus variable to a household input object
- * and returns the resulting object
+ * Adds the VariableEditor's focus variable to entities in the household input
+ * object in which it is absent and returns the resulting object
  * @param {Object} householdInput The household input object passed as a param
  * to VariableEditor
  * @param {Object} variable The relevant variable metadata


### PR DESCRIPTION
## Description

Fixed #1129. The regression was introduced in #1081 when I tried to fix the `react-hooks/exhaustive-deps` error in the `VariableEditor` component.

Before #1081, `variable` was listed as a dependency so that the effect would execute once for every variable and the dependency list was not exhaustive. Leaving aside the `exhaustive-deps` error, the dependency was also inefficient -- passing large objects as dependencies is an anti-pattern. Using just `variable.name` is more efficient but it does not get around the `exhaustive-deps` error.

From the documentation of `addVariable` I gathered that the purpose of the effect was to add the variable to all entities. `!possibleEntities.length` is true if and only if the variable is absent in all entities. Therefore, I passed no dependency array at all and added the condition `!possibleEntities.length` to the effect in #1081.

There is a subtle error in the reasoning in the above paragraph. I did not know then that a variable (such as `age`) may be present in some entities, and `addVariable` only adds the variable to the entities where it is missing. So, the effect needs to run whenever `possibleEntities.length !== householdInput[entityPlural].length`, i.e., the variable is absent in *some* entities (not *all*, as in previous paragraph).

The application logic in the front end for households is quite complex. This complexity is reflected in `addVariable` (see nested conditions) and the use of `addVariable` in the effect. Some of the default values of age are being fetched from `variable.defaultValue` while others are simply stored as constants in the front end, e.g., in `src/data/countChildrenVars.js`. Simplification is needed here for maintenance.

## Tests

Captured some tests via [loom](https://www.loom.com/share/a2e3911607ae41338a1baa5629cb42be?sid=c00e74b4-5e49-4b3d-beae-bd166277016e).
