### PR TITLE
Repair getHouseholdYear

### DIFF
--- a/src/data/defaultHouseholds.js
+++ b/src/data/defaultHouseholds.js
@@ -1,7 +1,15 @@
+import { defaultYear } from "./constants";
+
+const DEFAULT_AGE = 40;
+
 export const defaultHouseholds = {
   uk: {
     people: {
-      you: {},
+      you: {
+        age: {
+          [defaultYear]: DEFAULT_AGE
+        }
+      },
     },
     benunits: {
       "your immediate family": {
@@ -16,7 +24,11 @@ export const defaultHouseholds = {
   },
   us: {
     people: {
-      you: {},
+      you: {
+        age: {
+          [defaultYear]: DEFAULT_AGE
+        }
+      },
     },
     families: {
       "your family": {
@@ -46,7 +58,11 @@ export const defaultHouseholds = {
   },
   default: {
     people: {
-      you: {},
+      you: {
+        age: {
+          [defaultYear]: DEFAULT_AGE
+        }
+      },
     },
     households: {
       "your household": {

--- a/src/data/defaultHouseholds.js
+++ b/src/data/defaultHouseholds.js
@@ -7,8 +7,8 @@ export const defaultHouseholds = {
     people: {
       you: {
         age: {
-          [defaultYear]: DEFAULT_AGE
-        }
+          [defaultYear]: DEFAULT_AGE,
+        },
       },
     },
     benunits: {
@@ -26,8 +26,8 @@ export const defaultHouseholds = {
     people: {
       you: {
         age: {
-          [defaultYear]: DEFAULT_AGE
-        }
+          [defaultYear]: DEFAULT_AGE,
+        },
       },
     },
     families: {
@@ -60,8 +60,8 @@ export const defaultHouseholds = {
     people: {
       you: {
         age: {
-          [defaultYear]: DEFAULT_AGE
-        }
+          [defaultYear]: DEFAULT_AGE,
+        },
       },
     },
     households: {

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -466,11 +466,11 @@ export function getHouseholdYear(householdInput) {
   // Determine if [people][you][age][year] is present in household;
   // if so, return this; if not, return the current year
 
-  const householdYear = Object.keys(
+  const householdYearArr = Object.keys(
     householdInput?.["people"]?.["you"]?.["age"],
-  )[0];
-  if (householdYear) {
-    return householdYear;
+  );
+  if (householdYearArr && householdYearArr.length > 0) {
+    return householdYearArr[0];
   }
   return defaultYear;
 }


### PR DESCRIPTION
## Description

Fixes #1134. 

## Changes

This PR does two things:
* Adds `age` by default to the head of household, preventing breakage of `getHouseholdYear` when assessing age and according with all other household members' default structures, which include age
* Ensures that `getHouseholdYear` not only determines if `age` is within the head of household's data object, but that it also includes 1 or more years, before attempting to determine those years; previously, the function did not assume the potential breakage of functions defining age

## Screenshots

N/A

## Tests

N/A
