### PR TITLE
Addendum to PR #1130

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -42,7 +42,10 @@ export default function VariableEditor(props) {
   // household. addVariable is called to ensure that the variable is added to
   // all entities.
   useEffect(() => {
-    if (possibleEntities.length !== householdInput[entityPlural].length) {
+    if (
+      possibleEntities.length !==
+      Object.keys(householdInput[entityPlural]).length
+    ) {
       const newHouseholdInput = addVariable(
         householdInput,
         variable,


### PR DESCRIPTION
Fix #1133 by fixing type error in PR #1130 (checked length of an object using `.length` instead of `Object.keys().length`).

Tested using `console.log`.