### PR TITLE
Change poverty rate calculation to percent change

### DIFF
--- a/src/pages/policy/output/PolicyBreakdown.jsx
+++ b/src/pages/policy/output/PolicyBreakdown.jsx
@@ -17,7 +17,17 @@ export default function PolicyBreakdown(props) {
   const budgetaryImpact = impact.budget.budgetary_impact;
   const povertyOverview = impact.poverty.poverty.all;
   const decileOverview = impact.intra_decile.all;
-  const povertyRateChange = povertyOverview.reform - povertyOverview.baseline;
+  let povertyRateChange = null;
+  if (povertyOverview.baseline === 0) {
+    console.error(
+      "PolicyBreakdown: baseline poverty rate reported as 0; API error likely",
+    );
+    povertyRateChange = Infinity;
+  } else {
+    povertyRateChange =
+      (povertyOverview.reform - povertyOverview.baseline) /
+      povertyOverview.baseline;
+  }
 
   const listItems = [
     {


### PR DESCRIPTION
## Description

Fixes #1137.

## Changes

This changes the calculation of the poverty rate change within the `PolicyBreakdown` component from percentage point difference to percent change. Because this formula includes division, in the extremely rare case that baseline poverty rate is for some reason returned as 0 from the back end, it also includes a provision that evaluates the baseline rate, then `console.error`s and sets the poverty rate increase to `Infinity`, as opposed to runtime erroring.

## Screenshots

A Loom video of the component in action is available [here](https://www.loom.com/share/b59d279eea244c8e94ea2a5ae4a5110a?sid=e3e5a937-6566-480a-8881-395c07e03b05).

## Tests

N/A
