### PR TITLE
Create page for inputting household year

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This is the official web app of the PolicyEngine project. <br/><br/>
 ![PolicyEngineWebApp](https://github.com/PolicyEngine/policyengine-app/assets/14987227/70a1a74f-4585-42ec-8642-e4f4f6c2088b)
 
-
 # Getting started
 
 ## Prerequisites

--- a/src/__tests__/CountChildren.test.js
+++ b/src/__tests__/CountChildren.test.js
@@ -5,6 +5,7 @@ import {
 } from "pages/household/input/CountChildren.jsx";
 import { removePerson } from "api/variables.js";
 import { defaultHouseholds } from "data/defaultHouseholds.js";
+import { defaultYear } from "data/constants";
 
 describe("Test refactored CountChildren getChildName function", () => {
   test("Confirm that getChildName works for UK", () => {
@@ -30,16 +31,16 @@ describe("Test refactored CountChildren getCountChildren func", () => {
 
     testHousehold.people["your first child"] = {
       age: {
-        2024: 15,
+        [defaultYear]: 15,
       },
     };
     testHousehold.people["your second child"] = {
       age: {
-        2024: 4,
+        [defaultYear]: 4,
       },
     };
 
-    expect(getCountChildren(testHousehold, "uk")).toBe(2);
+    expect(getCountChildren(testHousehold, "uk", defaultYear)).toBe(2);
   });
 
   test("Confirm that getCountChildren works for US", () => {
@@ -47,11 +48,11 @@ describe("Test refactored CountChildren getCountChildren func", () => {
 
     testHousehold.people["your first dependent"] = {
       is_tax_unit_dependent: {
-        2024: true,
+        [defaultYear]: true,
       },
     };
 
-    expect(getCountChildren(testHousehold, "us")).toBe(1);
+    expect(getCountChildren(testHousehold, "us", defaultYear)).toBe(1);
   });
 });
 
@@ -60,25 +61,27 @@ describe("Test refactored addChild function", () => {
     let testHousehold = JSON.parse(JSON.stringify(defaultHouseholds.uk));
 
     const defaultChild = {
-      age: { 2024: 10 },
+      age: { [defaultYear]: 10 },
     };
-    const childCount = getCountChildren(testHousehold, "uk");
+    const childCount = getCountChildren(testHousehold, "uk", defaultYear);
     const childName = getChildName(childCount, "uk");
 
     testHousehold.people[childName] = defaultChild;
     testHousehold.benunits["your immediate family"].members.push(childName);
     testHousehold.households["your household"].members.push(childName);
 
-    expect(addChild(defaultHouseholds.uk, "uk")).toStrictEqual(testHousehold);
+    expect(addChild(defaultHouseholds.uk, "uk", defaultYear)).toStrictEqual(
+      testHousehold,
+    );
   });
   test("Confirm that addChild works for US", () => {
     let testHousehold = JSON.parse(JSON.stringify(defaultHouseholds.us));
 
     const defaultChild = {
-      age: { 2024: 10 },
-      is_tax_unit_dependent: { 2024: true },
+      age: { [defaultYear]: 10 },
+      is_tax_unit_dependent: { [defaultYear]: true },
     };
-    const childCount = getCountChildren(testHousehold, "us");
+    const childCount = getCountChildren(testHousehold, "us", defaultYear);
     const childName = getChildName(childCount, "us");
 
     testHousehold.people[childName] = defaultChild;
@@ -88,27 +91,29 @@ describe("Test refactored addChild function", () => {
     testHousehold.households["your household"].members.push(childName);
     testHousehold.marital_units[`${childName}'s marital unit`] = {
       members: [childName],
-      marital_unit_id: { 2024: childCount + 1 },
+      marital_unit_id: { [defaultYear]: childCount + 1 },
     };
 
-    expect(addChild(defaultHouseholds.us, "us")).toStrictEqual(testHousehold);
+    expect(addChild(defaultHouseholds.us, "us", defaultYear)).toStrictEqual(
+      testHousehold,
+    );
   });
 
   test("Confirm that addChild works for Nigeria", () => {
     let testHousehold = JSON.parse(JSON.stringify(defaultHouseholds.default));
 
     const defaultChild = {
-      age: { 2024: 10 },
+      age: { [defaultYear]: 10 },
     };
-    const childCount = getCountChildren(testHousehold, "ng");
+    const childCount = getCountChildren(testHousehold, "ng", defaultYear);
     const childName = getChildName(childCount, "ng");
 
     testHousehold.people[childName] = defaultChild;
     testHousehold.households["your household"].members.push(childName);
 
-    expect(addChild(defaultHouseholds.default, "ng")).toStrictEqual(
-      testHousehold,
-    );
+    expect(
+      addChild(defaultHouseholds.default, "ng", defaultYear),
+    ).toStrictEqual(testHousehold);
   });
 });
 
@@ -119,27 +124,27 @@ describe("Test that removePerson functions correctly", () => {
         you: {},
         "your partner": {
           age: {
-            2024: 40,
+            [defaultYear]: 40,
           },
         },
         "your first child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
         "your second child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
         "your third child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
         "your fourth child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
       },
@@ -154,7 +159,7 @@ describe("Test that removePerson functions correctly", () => {
             "your fourth child",
           ],
           is_married: {
-            2024: true,
+            [defaultYear]: true,
           },
         },
       },
@@ -177,22 +182,22 @@ describe("Test that removePerson functions correctly", () => {
         you: {},
         "your partner": {
           age: {
-            2024: 40,
+            [defaultYear]: 40,
           },
         },
         "your first child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
         "your second child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
         "your third child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
       },
@@ -206,7 +211,7 @@ describe("Test that removePerson functions correctly", () => {
             "your third child",
           ],
           is_married: {
-            2024: true,
+            [defaultYear]: true,
           },
         },
       },
@@ -233,39 +238,39 @@ describe("Test that removePerson functions correctly", () => {
         you: {},
         "your partner": {
           age: {
-            2024: 40,
+            [defaultYear]: 40,
           },
         },
         "your first dependent": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
           is_tax_unit_dependent: {
-            2024: true,
+            [defaultYear]: true,
           },
         },
         "your second dependent": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
           is_tax_unit_dependent: {
-            2024: true,
+            [defaultYear]: true,
           },
         },
         "your third dependent": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
           is_tax_unit_dependent: {
-            2024: true,
+            [defaultYear]: true,
           },
         },
         "your fourth dependent": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
           is_tax_unit_dependent: {
-            2024: true,
+            [defaultYear]: true,
           },
         },
       },
@@ -288,25 +293,25 @@ describe("Test that removePerson functions correctly", () => {
         "your first dependent's marital unit": {
           members: ["your first dependent"],
           marital_unit_id: {
-            2024: 1,
+            [defaultYear]: 1,
           },
         },
         "your second dependent's marital unit": {
           members: ["your second dependent"],
           marital_unit_id: {
-            2024: 2,
+            [defaultYear]: 2,
           },
         },
         "your third dependent's marital unit": {
           members: ["your third dependent"],
           marital_unit_id: {
-            2024: 3,
+            [defaultYear]: 3,
           },
         },
         "your fourth dependent's marital unit": {
           members: ["your fourth dependent"],
           marital_unit_id: {
-            2024: 4,
+            [defaultYear]: 4,
           },
         },
       },
@@ -353,31 +358,31 @@ describe("Test that removePerson functions correctly", () => {
         you: {},
         "your partner": {
           age: {
-            2024: 40,
+            [defaultYear]: 40,
           },
         },
         "your first dependent": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
           is_tax_unit_dependent: {
-            2024: true,
+            [defaultYear]: true,
           },
         },
         "your second dependent": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
           is_tax_unit_dependent: {
-            2024: true,
+            [defaultYear]: true,
           },
         },
         "your third dependent": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
           is_tax_unit_dependent: {
-            2024: true,
+            [defaultYear]: true,
           },
         },
       },
@@ -399,19 +404,19 @@ describe("Test that removePerson functions correctly", () => {
         "your first dependent's marital unit": {
           members: ["your first dependent"],
           marital_unit_id: {
-            2024: 1,
+            [defaultYear]: 1,
           },
         },
         "your second dependent's marital unit": {
           members: ["your second dependent"],
           marital_unit_id: {
-            2024: 2,
+            [defaultYear]: 2,
           },
         },
         "your third dependent's marital unit": {
           members: ["your third dependent"],
           marital_unit_id: {
-            2024: 3,
+            [defaultYear]: 3,
           },
         },
       },
@@ -463,27 +468,27 @@ describe("Test that removePerson functions correctly", () => {
         you: {},
         "your partner": {
           age: {
-            2024: 40,
+            [defaultYear]: 40,
           },
         },
         "your first child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
         "your second child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
         "your third child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
         "your fourth child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
       },
@@ -506,22 +511,22 @@ describe("Test that removePerson functions correctly", () => {
         you: {},
         "your partner": {
           age: {
-            2024: 40,
+            [defaultYear]: 40,
           },
         },
         "your first child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
         "your second child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
         "your third child": {
           age: {
-            2024: 10,
+            [defaultYear]: 10,
           },
         },
       },

--- a/src/__tests__/MaritalStatus.test.js
+++ b/src/__tests__/MaritalStatus.test.js
@@ -4,43 +4,33 @@ import {
   setCAMaritalStatus,
 } from "pages/household/input/MaritalStatus";
 import { defaultHouseholds } from "data/defaultHouseholds";
-
-// Metadata fetching function
-async function fetchMetadata(countryId) {
-  const res = await fetch(`https://api.policyengine.org/${countryId}/metadata`);
-  const metadataRaw = await res.json();
-  const metadata = metadataRaw.result;
-  return metadata;
-}
+import { defaultYear } from "data/constants";
 
 describe("Setting UK marital status within MaritalStatus.jsx", () => {
   test("functions with empty UK dataset, without adding empty tax variables", async () => {
-    // Fetch UK metadata
-    const metadata = await fetchMetadata("uk");
-
     // Take the default UK household struct, then following code from MaritalStatus.jsx,
     // edit the struct
     let testStruct = JSON.parse(JSON.stringify(defaultHouseholds.uk));
     const newStatus = "married";
     const defaultPartner = {
       age: {
-        2024: 40,
+        [defaultYear]: 40,
       },
     };
     const partnerName = "your partner";
     testStruct.people[partnerName] = JSON.parse(JSON.stringify(defaultPartner));
     testStruct.benunits["your immediate family"].members.push(partnerName);
     testStruct.benunits["your immediate family"].is_married = {
-      2024: true,
+      [defaultYear]: true,
     };
-    testStruct.benunits["your immediate family"].is_married["2024"] = true;
+    testStruct.benunits["your immediate family"].is_married[defaultYear] = true;
     testStruct.households["your household"].members.push(partnerName);
 
     // Compare the populated default struct against invocation of setUKMaritalStatus
     const output = setUKMaritalStatus(
       defaultHouseholds.uk,
       newStatus,
-      metadata.variables,
+      defaultYear,
     );
 
     expect(output).toStrictEqual(testStruct);
@@ -49,9 +39,6 @@ describe("Setting UK marital status within MaritalStatus.jsx", () => {
 
 describe("Setting US marital status within MaritalStatus.jsx", () => {
   test("functions with empty US dataset, without adding empty tax variables", async () => {
-    // Fetch US metadata
-    const metadata = await fetchMetadata("us");
-
     // Take the default US household struct, then following code from MaritalStatus.jsx,
     // edit the struct
 
@@ -59,7 +46,7 @@ describe("Setting US marital status within MaritalStatus.jsx", () => {
     const newStatus = "married";
     const defaultPartner = {
       age: {
-        2024: 40,
+        [defaultYear]: 40,
       },
     };
     const partnerName = "your partner";
@@ -74,7 +61,7 @@ describe("Setting US marital status within MaritalStatus.jsx", () => {
     const output = setUSMaritalStatus(
       defaultHouseholds.us,
       newStatus,
-      metadata.variables,
+      defaultYear,
     );
 
     expect(output).toStrictEqual(testStruct);
@@ -83,9 +70,6 @@ describe("Setting US marital status within MaritalStatus.jsx", () => {
 
 describe("Setting Canada marital status within MaritalStatus.jsx", () => {
   test("functions with empty Canada dataset, without adding empty tax variables", async () => {
-    // Fetch Canada metadata
-    const metadata = await fetchMetadata("ca");
-
     // Take the default Canada household struct, then following code from MaritalStatus.jsx,
     // edit the struct
 
@@ -93,7 +77,7 @@ describe("Setting Canada marital status within MaritalStatus.jsx", () => {
     const newStatus = "married";
     const defaultPartner = {
       age: {
-        2024: 40,
+        [defaultYear]: 40,
       },
     };
     const partnerName = "your partner";
@@ -104,7 +88,7 @@ describe("Setting Canada marital status within MaritalStatus.jsx", () => {
     const output = setCAMaritalStatus(
       defaultHouseholds.default,
       newStatus,
-      metadata.variables,
+      defaultYear,
     );
 
     expect(output).toStrictEqual(testStruct);

--- a/src/__tests__/VariableEditor.test.js
+++ b/src/__tests__/VariableEditor.test.js
@@ -1,6 +1,7 @@
 import { addVariable } from "pages/household/input/VariableEditor.jsx";
 import { defaultHouseholds } from "data/defaultHouseholds.js";
 import { addChild } from "pages/household/input/CountChildren.jsx";
+import { defaultYear } from "data/constants";
 
 // Metadata fetching function
 async function fetchMetadata(countryId) {
@@ -19,7 +20,7 @@ describe("Test addVariable function", () => {
     testHousehold.people.you = {
       ...testHousehold.people.you,
       is_blind: {
-        2024: false,
+        [defaultYear]: false,
       },
     };
 
@@ -27,6 +28,7 @@ describe("Test addVariable function", () => {
       defaultHouseholds.uk,
       testVariable,
       "people",
+      defaultYear,
     );
 
     expect(resultHousehold).toStrictEqual(testHousehold);
@@ -38,24 +40,29 @@ describe("Test addVariable function", () => {
     const testVariable = metadataUK.variables.is_blind;
 
     // Add two children to both
-    testHousehold = addChild(testHousehold, "uk");
-    testHousehold = addChild(testHousehold, "uk");
-    setupHousehold = addChild(setupHousehold, "uk");
-    setupHousehold = addChild(setupHousehold, "uk");
+    testHousehold = addChild(testHousehold, "uk", defaultYear);
+    testHousehold = addChild(testHousehold, "uk", defaultYear);
+    setupHousehold = addChild(setupHousehold, "uk", defaultYear);
+    setupHousehold = addChild(setupHousehold, "uk", defaultYear);
 
     // Add the is_blind variable to all members
     Object.keys(testHousehold.people).forEach((person) => {
       testHousehold.people[person] = {
         ...testHousehold.people[person],
         is_blind: {
-          2024: false,
+          [defaultYear]: false,
         },
       };
     });
 
     // Create a 2-child household to use within addVariable
 
-    const resultHousehold = addVariable(setupHousehold, testVariable, "people");
+    const resultHousehold = addVariable(
+      setupHousehold,
+      testVariable,
+      "people",
+      defaultYear,
+    );
 
     expect(resultHousehold).toStrictEqual(testHousehold);
   });
@@ -67,7 +74,7 @@ describe("Test addVariable function", () => {
     testHousehold.people.you = {
       ...testHousehold.people.you,
       is_blind: {
-        2024: false,
+        [defaultYear]: false,
       },
     };
 
@@ -75,6 +82,7 @@ describe("Test addVariable function", () => {
       defaultHouseholds.us,
       testVariable,
       "people",
+      defaultYear,
     );
 
     expect(resultHousehold).toStrictEqual(testHousehold);
@@ -86,24 +94,29 @@ describe("Test addVariable function", () => {
     const testVariable = metadataUS.variables.is_blind;
 
     // Add two children to both
-    testHousehold = addChild(testHousehold, "us");
-    testHousehold = addChild(testHousehold, "us");
-    setupHousehold = addChild(setupHousehold, "us");
-    setupHousehold = addChild(setupHousehold, "us");
+    testHousehold = addChild(testHousehold, "us", defaultYear);
+    testHousehold = addChild(testHousehold, "us", defaultYear);
+    setupHousehold = addChild(setupHousehold, "us", defaultYear);
+    setupHousehold = addChild(setupHousehold, "us", defaultYear);
 
     // Add the is_blind variable to all members
     Object.keys(testHousehold.people).forEach((person) => {
       testHousehold.people[person] = {
         ...testHousehold.people[person],
         is_blind: {
-          2024: false,
+          [defaultYear]: false,
         },
       };
     });
 
     // Create a 2-child household to use within addVariable
 
-    const resultHousehold = addVariable(setupHousehold, testVariable, "people");
+    const resultHousehold = addVariable(
+      setupHousehold,
+      testVariable,
+      "people",
+      defaultYear,
+    );
 
     expect(resultHousehold).toStrictEqual(testHousehold);
   });

--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -143,7 +143,7 @@ export function buildVariableTree(variables, variableModules, basicInputs) {
           {
             name: "input.household.taxYear",
             label: "Tax year",
-            index: -3
+            index: -3,
           },
           {
             name: "input.household.maritalStatus",

--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -141,6 +141,11 @@ export function buildVariableTree(variables, variableModules, basicInputs) {
         index: -10,
         children: [
           {
+            name: "input.household.taxYear",
+            label: "Tax year",
+            index: -3
+          },
+          {
             name: "input.household.maritalStatus",
             label: "Marital status",
             index: -2,

--- a/src/data/countChildrenVars.js
+++ b/src/data/countChildrenVars.js
@@ -36,7 +36,6 @@ export function childCountFilters(countryId, year) {
     return filters[countryId];
   }
   return filters.default;
-
 }
 
 export const childAdders = {

--- a/src/data/countChildrenVars.js
+++ b/src/data/countChildrenVars.js
@@ -1,30 +1,43 @@
-import { defaultYear } from "./constants";
-
 export const childNames = {
   us: "dependent",
   default: "child",
 };
 
-export const defaultChildren = {
-  us: {
-    age: {
-      [defaultYear]: 10,
+export function defaultChildren(countryId, year) {
+  const childObjects = {
+    us: {
+      age: {
+        [year]: 10,
+      },
+      is_tax_unit_dependent: {
+        [year]: true,
+      },
     },
-    is_tax_unit_dependent: {
-      [defaultYear]: true,
+    default: {
+      age: {
+        [year]: 10,
+      },
     },
-  },
-  default: {
-    age: {
-      [defaultYear]: 10,
-    },
-  },
-};
+  };
 
-export const childCountFilters = {
-  us: (person) => person?.is_tax_unit_dependent?.[defaultYear],
-  default: (person) => person?.age?.[defaultYear] < 18,
-};
+  if (countryId in childObjects) {
+    return childObjects[countryId];
+  }
+  return childObjects.default;
+}
+
+export function childCountFilters(countryId, year) {
+  const filters = {
+    us: (person) => person?.is_tax_unit_dependent?.[year],
+    default: (person) => person?.age?.[year] < 18,
+  };
+
+  if (Object.keys(filters).includes(countryId)) {
+    return filters[countryId];
+  }
+  return filters.default;
+
+}
 
 export const childAdders = {
   // prettier-ignore
@@ -36,7 +49,7 @@ export const childAdders = {
     return newSituation;
   },
   // prettier-ignore
-  us: function(situation, defaultChild, childName, childCount) { 
+  us: function(situation, defaultChild, childName, childCount, year) { 
     const newSituation = JSON.parse(JSON.stringify(situation));
     newSituation.people[childName] = defaultChild;
     newSituation.tax_units["your tax unit"].members.push(childName);
@@ -45,7 +58,7 @@ export const childAdders = {
     newSituation.households["your household"].members.push(childName);
     newSituation.marital_units[`${childName}'s marital unit`] = {
       members: [childName],
-      marital_unit_id: { [defaultYear]: childCount + 1 },
+      marital_unit_id: { [year]: childCount + 1 },
     };
     return newSituation;
   },

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -290,6 +290,8 @@ export default function HouseholdPage(props) {
         metadata={metadata}
         year={year}
         setYear={setYear}
+        householdInput={householdInput}
+        setHouseholdInput={setHouseholdInput}
       /> 
     );
   } else if (focus && focus.startsWith("householdOutput.")) {

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -50,7 +50,7 @@ export default function HouseholdPage(props) {
 
   let middle;
   const focus = searchParams.get("focus") || "";
-  
+
   // If we've landed on the page without a focus, point at the intro page.
   useEffect(() => {
     if (focus === "") {
@@ -297,6 +297,7 @@ export default function HouseholdPage(props) {
         metadata={metadata}
         year={year}
         setYear={setYear}
+        householdId={householdId}
         householdInput={householdInput}
         setHouseholdInput={setHouseholdInput}
       /> 

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -278,7 +278,9 @@ export default function HouseholdPage(props) {
     );
   } else if (focus === "input.household.taxYear") {
     middle = (
-      <TaxYear /> 
+      <TaxYear 
+        metadata={metadata}
+      /> 
     );
   } else if (focus && focus.startsWith("householdOutput.")) {
     if (!autoCompute) {

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -25,6 +25,7 @@ import HOUSEHOLD_OUTPUT_TREE from "./household/output/tree";
 import VariableSearch from "./household/VariableSearch";
 import MobileCalculatorPage from "../layout/MobileCalculatorPage.jsx";
 import RecreateHouseholdPopup from "./household/output/RecreateHouseholdPopup.jsx";
+import HouseholdYear from "./household/input/HouseholdYear";
 
 export default function HouseholdPage(props) {
   document.title = "Household | PolicyEngine";
@@ -274,6 +275,10 @@ export default function HouseholdPage(props) {
         setHouseholdInput={setHouseholdInput}
         autoCompute={autoCompute}
       />
+    );
+  } else if (focus === "input.household.year") {
+    middle = (
+      <HouseholdYear /> 
     );
   } else if (focus && focus.startsWith("householdOutput.")) {
     if (!autoCompute) {

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -50,6 +50,10 @@ export default function HouseholdPage(props) {
 
   let middle;
   const focus = searchParams.get("focus") || "";
+  
+  useEffect(() => {
+    console.log(householdInput);
+  }, [householdInput]);
 
   // If we've landed on the page without a focus, point at the intro page.
   useEffect(() => {
@@ -239,6 +243,7 @@ export default function HouseholdPage(props) {
         setHouseholdInput={setHouseholdInput}
         nextVariable={nextVariable}
         autoCompute={autoCompute}
+        year={year}
       />
     );
   } else if (
@@ -264,6 +269,7 @@ export default function HouseholdPage(props) {
         householdInput={householdInput}
         setHouseholdInput={setHouseholdInput}
         autoCompute={autoCompute}
+        year={year}
       />
     );
   } else if (focus === "intro") {
@@ -275,6 +281,7 @@ export default function HouseholdPage(props) {
         householdInput={householdInput}
         setHouseholdInput={setHouseholdInput}
         autoCompute={autoCompute}
+        year={year}
       />
     );
   } else if (focus === "input.household.taxYear") {

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -51,10 +51,6 @@ export default function HouseholdPage(props) {
   let middle;
   const focus = searchParams.get("focus") || "";
   
-  useEffect(() => {
-    console.log(householdInput);
-  }, [householdInput]);
-
   // If we've landed on the page without a focus, point at the intro page.
   useEffect(() => {
     if (focus === "") {
@@ -218,6 +214,17 @@ export default function HouseholdPage(props) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [countryId, householdId, policy.reform, metadata]);
+
+  // If page is being accessed with a household ID, set year to be
+  // year currently present within household; only do this at first render
+  useEffect(() => {
+    if (householdId && householdInput) {
+      const householdYear = getHouseholdYear(householdInput);
+      if (householdYear) {
+        setYear(householdYear);
+      }
+    }
+  }, [householdId, householdInput]);
 
   if (!householdInput || !metadata) {
     middle = <LoadingCentered />;

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -293,14 +293,14 @@ export default function HouseholdPage(props) {
     );
   } else if (focus === "input.household.taxYear") {
     middle = (
-      <TaxYear 
+      <TaxYear
         metadata={metadata}
         year={year}
         setYear={setYear}
         householdId={householdId}
         householdInput={householdInput}
         setHouseholdInput={setHouseholdInput}
-      /> 
+      />
     );
   } else if (focus && focus.startsWith("householdOutput.")) {
     if (!autoCompute) {

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -46,6 +46,7 @@ export default function HouseholdPage(props) {
   const [error, setError] = useState(null);
   const [autoCompute, setAutoCompute] = useState(false);
   const [isRHPOpen, setIsRHPOpen] = useState(false);
+  const [year, setYear] = useState(defaultYear);
 
   let middle;
   const focus = searchParams.get("focus") || "";
@@ -280,6 +281,8 @@ export default function HouseholdPage(props) {
     middle = (
       <TaxYear 
         metadata={metadata}
+        year={year}
+        setYear={setYear}
       /> 
     );
   } else if (focus && focus.startsWith("householdOutput.")) {

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -25,7 +25,7 @@ import HOUSEHOLD_OUTPUT_TREE from "./household/output/tree";
 import VariableSearch from "./household/VariableSearch";
 import MobileCalculatorPage from "../layout/MobileCalculatorPage.jsx";
 import RecreateHouseholdPopup from "./household/output/RecreateHouseholdPopup.jsx";
-import HouseholdYear from "./household/input/HouseholdYear";
+import TaxYear from "./household/input/TaxYear";
 
 export default function HouseholdPage(props) {
   document.title = "Household | PolicyEngine";
@@ -276,9 +276,9 @@ export default function HouseholdPage(props) {
         autoCompute={autoCompute}
       />
     );
-  } else if (focus === "input.household.year") {
+  } else if (focus === "input.household.taxYear") {
     middle = (
-      <HouseholdYear /> 
+      <TaxYear /> 
     );
   } else if (focus && focus.startsWith("householdOutput.")) {
     if (!autoCompute) {

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -319,6 +319,7 @@ export default function HouseholdPage(props) {
           loading={loading}
           hasShownHouseholdPopup={hasShownHouseholdPopup}
           setHasShownHouseholdPopup={setHasShownHouseholdPopup}
+          year={year}
         />
       </>
     );
@@ -372,6 +373,7 @@ export default function HouseholdPage(props) {
             autoCompute={autoCompute}
             loading={loading}
             policy={policy}
+            year={year}
           />
         }
         noMiddleScroll={

--- a/src/pages/household/HouseholdIntro.jsx
+++ b/src/pages/household/HouseholdIntro.jsx
@@ -9,7 +9,7 @@ export default function HouseholdIntro() {
     >
       <SearchParamNavButton
         text="Enter my household"
-        focus="input.household.maritalStatus"
+        focus="input.household.taxYear"
         style={{ margin: "20px auto 10px" }}
       />
     </CenteredMiddleColumn>

--- a/src/pages/household/HouseholdRightSidebar.jsx
+++ b/src/pages/household/HouseholdRightSidebar.jsx
@@ -8,7 +8,6 @@ import SearchParamNavButton from "../../controls/SearchParamNavButton";
 import Divider from "../../layout/Divider";
 import LoadingCentered from "../../layout/LoadingCentered";
 import PolicySearch from "../policy/PolicySearch";
-import { defaultYear } from "data/constants";
 
 function Figure(props) {
   const { left, right } = props;
@@ -54,6 +53,7 @@ export default function HouseholdRightSidebar(props) {
     autoCompute,
     loading,
     policy,
+    year
   } = props;
   const [showReformSearch, setShowReformSearch] = useState(false);
   const [searchParams] = useSearchParams();
@@ -74,7 +74,7 @@ export default function HouseholdRightSidebar(props) {
   );
   const mtr = getValueFromHousehold(
     "marginal_tax_rate",
-    defaultYear,
+    year,
     "you",
     householdBaseline,
     metadata,

--- a/src/pages/household/HouseholdRightSidebar.jsx
+++ b/src/pages/household/HouseholdRightSidebar.jsx
@@ -53,7 +53,7 @@ export default function HouseholdRightSidebar(props) {
     autoCompute,
     loading,
     policy,
-    year
+    year,
   } = props;
   const [showReformSearch, setShowReformSearch] = useState(false);
   const [searchParams] = useSearchParams();

--- a/src/pages/household/input/CountChildren.jsx
+++ b/src/pages/household/input/CountChildren.jsx
@@ -56,7 +56,9 @@ export function getCountChildren(situation, countryId, year) {
 export function addChild(situation, countryId, year) {
   let newSituation = JSON.parse(JSON.stringify(situation));
 
-  const defaultChild = JSON.parse(JSON.stringify(defaultChildren(countryId, year)));
+  const defaultChild = JSON.parse(
+    JSON.stringify(defaultChildren(countryId, year)),
+  );
   const childCount = getCountChildren(situation, countryId, year);
   const childName = getChildName(childCount, countryId);
 
@@ -66,7 +68,7 @@ export function addChild(situation, countryId, year) {
       defaultChild,
       childName,
       childCount,
-      year
+      year,
     );
   } else {
     newSituation = childAdders.default(
@@ -102,7 +104,8 @@ export function updateChildCount(situation, countChildren, countryId, year) {
 }
 
 export default function CountChildren(props) {
-  const { metadata, householdInput, setHouseholdInput, autoCompute, year } = props;
+  const { metadata, householdInput, setHouseholdInput, autoCompute, year } =
+    props;
 
   const [searchParams, setSearchParams] = useSearchParams();
   const [formValue, setFormValue] = useState(null);
@@ -115,7 +118,7 @@ export default function CountChildren(props) {
       householdInput,
       numberOfChildren,
       metadata.countryId,
-      year
+      year,
     );
 
     // Update browser search params
@@ -148,7 +151,11 @@ export default function CountChildren(props) {
       <RadioButton
         keys={[0, 1, 2, 3, 4, 5]}
         labels={["None", "1", "2", "3", "4", "5"]}
-        defaultValue={getCountChildren(householdInput, metadata.countryId, year)}
+        defaultValue={getCountChildren(
+          householdInput,
+          metadata.countryId,
+          year,
+        )}
         value={formValue}
         onChange={(numberOfChildren) => {
           handleChildInputChange(numberOfChildren);

--- a/src/pages/household/input/CountChildren.jsx
+++ b/src/pages/household/input/CountChildren.jsx
@@ -12,6 +12,8 @@ import {
   childAdders,
   defaultChildren,
 } from "../../../data/countChildrenVars.js";
+import { formatVerbTime } from "lang/format";
+import { defaultYear } from "data/constants";
 
 /**
  * Returns `your ${number} child`, unless a country situation calls for a custom term
@@ -160,11 +162,18 @@ export default function CountChildren(props) {
     </>
   );
 
+  let verb = "do";
+  if (year < defaultYear) {
+    verb = "did";
+  } else if (year > defaultYear) {
+    verb = "will";
+  }
+
   return (
     <CenteredMiddleColumn
       title={`How many ${
         metadata.countryId !== "us" ? "children" : "dependents"
-      } do you have?`}
+      } ${verb} you have?`}
     >
       {radioButtonComponent}
     </CenteredMiddleColumn>

--- a/src/pages/household/input/CountChildren.jsx
+++ b/src/pages/household/input/CountChildren.jsx
@@ -40,14 +40,8 @@ export function getChildName(index, countryId) {
  * @param {String} countryId Two-letter country ID string
  * @returns {Number} Number of children currently included in situation
  */
-export function getCountChildren(situation, countryId) {
-  let filter = null;
-  if (countryId in childCountFilters) {
-    filter = childCountFilters[countryId];
-  } else {
-    filter = childCountFilters.default;
-  }
-
+export function getCountChildren(situation, countryId, year) {
+  const filter = childCountFilters(countryId, year);
   return Object.values(situation.people).filter(filter).length;
 }
 
@@ -57,17 +51,11 @@ export function getCountChildren(situation, countryId) {
  * @param {String} countryId The two-digit country ID
  * @returns {Object} The updated situation
  */
-export function addChild(situation, countryId) {
+export function addChild(situation, countryId, year) {
   let newSituation = JSON.parse(JSON.stringify(situation));
 
-  let defaultChild = null;
-  if (countryId in defaultChildren) {
-    defaultChild = JSON.parse(JSON.stringify(defaultChildren[countryId]));
-  } else {
-    defaultChild = JSON.parse(JSON.stringify(defaultChildren.default));
-  }
-
-  const childCount = getCountChildren(situation, countryId);
+  const defaultChild = JSON.parse(JSON.stringify(defaultChildren(countryId, year)));
+  const childCount = getCountChildren(situation, countryId, year);
   const childName = getChildName(childCount, countryId);
 
   if (countryId in childAdders) {
@@ -76,6 +64,7 @@ export function addChild(situation, countryId) {
       defaultChild,
       childName,
       childCount,
+      year
     );
   } else {
     newSituation = childAdders.default(
@@ -95,12 +84,12 @@ export function addChild(situation, countryId) {
  * @param {String} countryId A two-letter country ID
  * @returns {Object} The updated household input object
  */
-export function updateChildCount(situation, countChildren, countryId) {
-  while (getCountChildren(situation, countryId) < countChildren) {
-    situation = addChild(situation, countryId);
+export function updateChildCount(situation, countChildren, countryId, year) {
+  while (getCountChildren(situation, countryId, year) < countChildren) {
+    situation = addChild(situation, countryId, year);
   }
   while (getCountChildren(situation, countryId) > countChildren) {
-    const childCount = getCountChildren(situation, countryId);
+    const childCount = getCountChildren(situation, countryId, year);
 
     situation = removePerson(
       situation,
@@ -111,7 +100,7 @@ export function updateChildCount(situation, countChildren, countryId) {
 }
 
 export default function CountChildren(props) {
-  const { metadata, householdInput, setHouseholdInput, autoCompute } = props;
+  const { metadata, householdInput, setHouseholdInput, autoCompute, year } = props;
 
   const [searchParams, setSearchParams] = useSearchParams();
   const [formValue, setFormValue] = useState(null);
@@ -124,6 +113,7 @@ export default function CountChildren(props) {
       householdInput,
       numberOfChildren,
       metadata.countryId,
+      year
     );
 
     // Update browser search params

--- a/src/pages/household/input/CountChildren.jsx
+++ b/src/pages/household/input/CountChildren.jsx
@@ -12,7 +12,6 @@ import {
   childAdders,
   defaultChildren,
 } from "../../../data/countChildrenVars.js";
-import { formatVerbTime } from "lang/format";
 import { defaultYear } from "data/constants";
 
 /**

--- a/src/pages/household/input/CountChildren.jsx
+++ b/src/pages/household/input/CountChildren.jsx
@@ -88,7 +88,7 @@ export function updateChildCount(situation, countChildren, countryId, year) {
   while (getCountChildren(situation, countryId, year) < countChildren) {
     situation = addChild(situation, countryId, year);
   }
-  while (getCountChildren(situation, countryId) > countChildren) {
+  while (getCountChildren(situation, countryId, year) > countChildren) {
     const childCount = getCountChildren(situation, countryId, year);
 
     situation = removePerson(

--- a/src/pages/household/input/CountChildren.jsx
+++ b/src/pages/household/input/CountChildren.jsx
@@ -146,7 +146,7 @@ export default function CountChildren(props) {
       <RadioButton
         keys={[0, 1, 2, 3, 4, 5]}
         labels={["None", "1", "2", "3", "4", "5"]}
-        defaultValue={getCountChildren(householdInput, metadata.countryId)}
+        defaultValue={getCountChildren(householdInput, metadata.countryId, year)}
         value={formValue}
         onChange={(numberOfChildren) => {
           handleChildInputChange(numberOfChildren);

--- a/src/pages/household/input/HouseholdYear.jsx
+++ b/src/pages/household/input/HouseholdYear.jsx
@@ -1,0 +1,10 @@
+import CenteredMiddleColumn from "layout/CenteredMiddleColumn";
+
+
+export default function HouseholdYear(props) {
+  return (
+    <CenteredMiddleColumn
+      title="Which tax year would you like to calculate?"
+    />
+  );
+}

--- a/src/pages/household/input/HouseholdYear.jsx
+++ b/src/pages/household/input/HouseholdYear.jsx
@@ -4,7 +4,7 @@ import CenteredMiddleColumn from "layout/CenteredMiddleColumn";
 export default function HouseholdYear(props) {
   return (
     <CenteredMiddleColumn
-      title="Which tax year would you like to calculate?"
+      title="Which year would you like to calculate?"
     />
   );
 }

--- a/src/pages/household/input/MaritalStatus.jsx
+++ b/src/pages/household/input/MaritalStatus.jsx
@@ -91,7 +91,8 @@ export function setCAMaritalStatus(situation, status, year) {
 }
 
 export default function MaritalStatus(props) {
-  const { metadata, householdInput, setHouseholdInput, autoCompute, year } = props;
+  const { metadata, householdInput, setHouseholdInput, autoCompute, year } =
+    props;
   const [searchParams, setSearchParams] = useSearchParams();
   const getMaritalStatus = {
     uk: getUKMaritalStatus,
@@ -109,7 +110,11 @@ export default function MaritalStatus(props) {
   }[metadata.countryId];
   const [value, setValue] = useState(null);
   const setMaritalStatus = (status) => {
-    let newHousehold = setMaritalStatusInHousehold(householdInput, status, year);
+    let newHousehold = setMaritalStatusInHousehold(
+      householdInput,
+      status,
+      year,
+    );
     setHouseholdInput(newHousehold);
     let newSearch = copySearchParams(searchParams);
     newSearch.set("focus", "input.household.children");
@@ -140,12 +145,12 @@ export default function MaritalStatus(props) {
       }}
     />
   );
-  
+
   let verb = "is";
   if (year < defaultYear) {
     verb = "was";
   } else if (year > defaultYear) {
-    verb = "will be"
+    verb = "will be";
   }
 
   return (

--- a/src/pages/household/input/MaritalStatus.jsx
+++ b/src/pages/household/input/MaritalStatus.jsx
@@ -6,7 +6,6 @@ import { copySearchParams } from "../../../api/call";
 import { useState } from "react";
 import SearchParamNavButton from "../../../controls/SearchParamNavButton";
 import gtag from "../../../api/analytics";
-import { defaultYear } from "data/constants";
 
 function getUKMaritalStatus(situation) {
   const partnerName = "your partner";
@@ -17,19 +16,19 @@ function getUKMaritalStatus(situation) {
   }
 }
 
-export function setUKMaritalStatus(situation, status) {
+export function setUKMaritalStatus(situation, status, year) {
   const currentStatus = getUKMaritalStatus(situation);
   const defaultPartner = {
-    age: { [defaultYear]: 40 },
+    age: { [year]: 40 },
   };
   const partnerName = "your partner";
   if (status === "married" && currentStatus === "single") {
     situation.people[partnerName] = defaultPartner;
     situation.benunits["your immediate family"].members.push(partnerName);
     situation.benunits["your immediate family"].is_married = {
-      [defaultYear]: true,
+      [year]: true,
     };
-    situation.benunits["your immediate family"].is_married[defaultYear] = true;
+    situation.benunits["your immediate family"].is_married[year] = true;
     situation.households["your household"].members.push(partnerName);
   } else if (status === "single" && currentStatus === "married") {
     situation = removePerson(situation, partnerName);
@@ -46,10 +45,10 @@ function getUSMaritalStatus(situation) {
   }
 }
 
-export function setUSMaritalStatus(situation, status) {
+export function setUSMaritalStatus(situation, status, year) {
   const currentStatus = getUSMaritalStatus(situation);
   const defaultPartner = {
-    age: { [defaultYear]: 40 },
+    age: { [year]: 40 },
   };
   const partnerName = "your partner";
   if (status === "married" && currentStatus === "single") {
@@ -74,10 +73,10 @@ function getCAMaritalStatus(situation) {
   }
 }
 
-export function setCAMaritalStatus(situation, status) {
+export function setCAMaritalStatus(situation, status, year) {
   const currentStatus = getCAMaritalStatus(situation);
   const defaultPartner = {
-    age: { [defaultYear]: 40 },
+    age: { [year]: 40 },
   };
   const partnerName = "your partner";
   if (status === "married" && currentStatus === "single") {
@@ -90,7 +89,7 @@ export function setCAMaritalStatus(situation, status) {
 }
 
 export default function MaritalStatus(props) {
-  const { metadata, householdInput, setHouseholdInput, autoCompute } = props;
+  const { metadata, householdInput, setHouseholdInput, autoCompute, year } = props;
   const [searchParams, setSearchParams] = useSearchParams();
   const getMaritalStatus = {
     uk: getUKMaritalStatus,
@@ -108,7 +107,7 @@ export default function MaritalStatus(props) {
   }[metadata.countryId];
   const [value, setValue] = useState(null);
   const setMaritalStatus = (status) => {
-    let newHousehold = setMaritalStatusInHousehold(householdInput, status);
+    let newHousehold = setMaritalStatusInHousehold(householdInput, status, year);
     setHouseholdInput(newHousehold);
     let newSearch = copySearchParams(searchParams);
     newSearch.set("focus", "input.household.children");

--- a/src/pages/household/input/MaritalStatus.jsx
+++ b/src/pages/household/input/MaritalStatus.jsx
@@ -6,6 +6,8 @@ import { copySearchParams } from "../../../api/call";
 import { useState } from "react";
 import SearchParamNavButton from "../../../controls/SearchParamNavButton";
 import gtag from "../../../api/analytics";
+import { formatVerbTime } from "lang/format";
+import { defaultYear } from "data/constants";
 
 function getUKMaritalStatus(situation) {
   const partnerName = "your partner";
@@ -138,8 +140,16 @@ export default function MaritalStatus(props) {
       }}
     />
   );
+  
+  let verb = "is";
+  if (year < defaultYear) {
+    verb = "was";
+  } else if (year > defaultYear) {
+    verb = "will be"
+  }
+
   return (
-    <CenteredMiddleColumn title="What is your marital status?">
+    <CenteredMiddleColumn title={`What ${verb} your marital status?`}>
       <>
         {radioButtonComponent}
         <SearchParamNavButton

--- a/src/pages/household/input/MaritalStatus.jsx
+++ b/src/pages/household/input/MaritalStatus.jsx
@@ -6,7 +6,6 @@ import { copySearchParams } from "../../../api/call";
 import { useState } from "react";
 import SearchParamNavButton from "../../../controls/SearchParamNavButton";
 import gtag from "../../../api/analytics";
-import { formatVerbTime } from "lang/format";
 import { defaultYear } from "data/constants";
 
 function getUKMaritalStatus(situation) {

--- a/src/pages/household/input/TaxYear.jsx
+++ b/src/pages/household/input/TaxYear.jsx
@@ -1,20 +1,53 @@
+import { useEffect, useRef } from "react";
 import { Select } from "antd";
 import CenteredMiddleColumn from "layout/CenteredMiddleColumn";
 import SearchParamNavButton from "controls/SearchParamNavButton";
 import useDisplayCategory from "redesign/components/useDisplayCategory";
+import { updateHousehold } from "pages/HouseholdPage";
 
 export default function TaxYear(props) {
   const {
     metadata,
     year,
-    setYear
+    setYear,
+    householdInput,
+    setHouseholdInput
   } = props;
+  const prevYearRef = useRef(year);
   const displayCategory = useDisplayCategory();
+
+  // Assign the year to prevYearRef; this will persist
+  // between renders, allowing access to prev year
+  useEffect(() => {
+    prevYearRef.current = year;
+  }, [year])
 
   // Replace "name" with "value" in order to conform to antd 
   const options = metadata.economy_options.time_period.map((time_period) => {
     return { value: time_period.name.toString(), label: time_period.label };
   });
+
+  function handleSubmit(value) {
+    const newYear = value;
+    // If there is a householdInput...
+    if (householdInput) {
+      // Access the previous value of year
+      const prevYear = prevYearRef.current;
+
+      // If previous value is equal to current value, return
+      // so as to avoid needlessly updating
+      if (prevYear === newYear) {
+        return;
+      }
+
+      // Set new household input by updating year
+      setHouseholdInput(updateHouseholdYear(householdInput, prevYear, newYear));
+    }
+
+    // Set year to new year
+    setYear(newYear);
+
+  }
 
   return (
     <CenteredMiddleColumn
@@ -26,7 +59,7 @@ export default function TaxYear(props) {
         style={{ width: displayCategory === "mobile" ? 150 : 200 }}
         options={options}
         defaultValue={year}
-        onSelect={(value) => setYear(Number(value))}
+        onSelect={handleSubmit}
       />
       <SearchParamNavButton
         text="Enter"
@@ -35,4 +68,42 @@ export default function TaxYear(props) {
       />
     </CenteredMiddleColumn>
   );
+}
+
+function updateHouseholdYear(householdInput, prevYear, newYear) {
+
+  // Copy householdInput into mutable variable
+  let editedHousehold = JSON.parse(JSON.stringify(householdInput));
+
+  // Variable skip list
+  const skipList = [
+    "members"
+  ];
+
+  // Map over all plural entity terms...
+  for (const entityPlural in editedHousehold) {
+    // Then over all entities...
+    for (const entity in editedHousehold[entityPlural]) {
+      // Then over all variables within each entity...
+      for (const variable in editedHousehold[entityPlural][entity]) {
+        const currentVal =
+          editedHousehold[entityPlural][entity][variable][prevYear];
+
+        // Skip special variables that aren't object-types
+        if (skipList.includes(variable)) {
+          continue;
+        }
+
+        // Delete the value at the old year
+        delete editedHousehold[entityPlural][entity][variable][prevYear];
+
+        // Add it at the new one
+        editedHousehold[entityPlural][entity][variable][newYear] = currentVal;
+
+      }
+    }
+  }
+
+  return editedHousehold;
+
 }

--- a/src/pages/household/input/TaxYear.jsx
+++ b/src/pages/household/input/TaxYear.jsx
@@ -3,7 +3,6 @@ import { Select } from "antd";
 import CenteredMiddleColumn from "layout/CenteredMiddleColumn";
 import SearchParamNavButton from "controls/SearchParamNavButton";
 import useDisplayCategory from "redesign/components/useDisplayCategory";
-import { updateHousehold } from "pages/HouseholdPage";
 
 export default function TaxYear(props) {
   const {

--- a/src/pages/household/input/TaxYear.jsx
+++ b/src/pages/household/input/TaxYear.jsx
@@ -71,7 +71,7 @@ export default function TaxYear(props) {
   }
 
   return (
-    <CenteredMiddleColumn title="Which tax year would you like to calculate?">
+    <CenteredMiddleColumn title="Which year would you like to calculate?">
       <Select
         showSearch
         optionFilterProp="label"

--- a/src/pages/household/input/TaxYear.jsx
+++ b/src/pages/household/input/TaxYear.jsx
@@ -1,7 +1,7 @@
 import CenteredMiddleColumn from "layout/CenteredMiddleColumn";
 
 
-export default function HouseholdYear(props) {
+export default function TaxYear(props) {
   return (
     <CenteredMiddleColumn
       title="Which year would you like to calculate?"

--- a/src/pages/household/input/TaxYear.jsx
+++ b/src/pages/household/input/TaxYear.jsx
@@ -2,11 +2,12 @@ import { Select } from "antd";
 import CenteredMiddleColumn from "layout/CenteredMiddleColumn";
 import SearchParamNavButton from "controls/SearchParamNavButton";
 import useDisplayCategory from "redesign/components/useDisplayCategory";
-import { defaultYear } from "data/constants";
 
 export default function TaxYear(props) {
   const {
-    metadata
+    metadata,
+    year,
+    setYear
   } = props;
   const displayCategory = useDisplayCategory();
 
@@ -14,16 +15,6 @@ export default function TaxYear(props) {
   const options = metadata.economy_options.time_period.map((time_period) => {
     return { value: time_period.name.toString(), label: time_period.label };
   });
-
-  // Determine default year; leaving out pre-created
-  // households for time being
-  const yearArray = options.reduce((accu, periodObj) => {
-    return [...accu, Number(periodObj.value)];
-  }, []);
-
-  const defaultPeriod = yearArray.includes(defaultYear)
-    ? defaultYear
-    : options[0].value;
 
   return (
     <CenteredMiddleColumn
@@ -34,8 +25,8 @@ export default function TaxYear(props) {
         optionFilterProp="label"
         style={{ width: displayCategory === "mobile" ? 150 : 200 }}
         options={options}
-        defaultValue={defaultPeriod}
-        // onSelect={submitValue}
+        defaultValue={year}
+        onSelect={(value) => setYear(Number(value))}
       />
       <SearchParamNavButton
         text="Enter"

--- a/src/pages/household/input/TaxYear.jsx
+++ b/src/pages/household/input/TaxYear.jsx
@@ -1,10 +1,47 @@
+import { Select } from "antd";
 import CenteredMiddleColumn from "layout/CenteredMiddleColumn";
-
+import SearchParamNavButton from "controls/SearchParamNavButton";
+import useDisplayCategory from "redesign/components/useDisplayCategory";
+import { defaultYear } from "data/constants";
 
 export default function TaxYear(props) {
+  const {
+    metadata
+  } = props;
+  const displayCategory = useDisplayCategory();
+
+  // Replace "name" with "value" in order to conform to antd 
+  const options = metadata.economy_options.time_period.map((time_period) => {
+    return { value: time_period.name.toString(), label: time_period.label };
+  });
+
+  // Determine default year; leaving out pre-created
+  // households for time being
+  const yearArray = options.reduce((accu, periodObj) => {
+    return [...accu, Number(periodObj.value)];
+  }, []);
+
+  const defaultPeriod = yearArray.includes(defaultYear)
+    ? defaultYear
+    : options[0].value;
+
   return (
     <CenteredMiddleColumn
-      title="Which year would you like to calculate?"
-    />
+      title="Which tax year would you like to calculate?"
+    >
+      <Select
+        showSearch
+        optionFilterProp="label"
+        style={{ width: displayCategory === "mobile" ? 150 : 200 }}
+        options={options}
+        defaultValue={defaultPeriod}
+        // onSelect={submitValue}
+      />
+      <SearchParamNavButton
+        text="Enter"
+        focus="input.household.maritalStatus"
+        style={{ margin: "20px auto 10px" }}
+      />
+    </CenteredMiddleColumn>
   );
 }

--- a/src/pages/household/input/TaxYear.jsx
+++ b/src/pages/household/input/TaxYear.jsx
@@ -14,7 +14,7 @@ export default function TaxYear(props) {
     setYear,
     householdId,
     householdInput,
-    setHouseholdInput
+    setHouseholdInput,
   } = props;
   const prevYearRef = useRef(year);
   // eslint-disable-next-line no-unused-vars
@@ -25,9 +25,9 @@ export default function TaxYear(props) {
   // between renders, allowing access to prev year
   useEffect(() => {
     prevYearRef.current = year;
-  }, [year])
+  }, [year]);
 
-  // Replace "name" with "value" in order to conform to antd 
+  // Replace "name" with "value" in order to conform to antd
   const options = metadata.economy_options.time_period.map((time_period) => {
     return { value: time_period.name.toString(), label: time_period.label };
   });
@@ -50,10 +50,10 @@ export default function TaxYear(props) {
 
       // Update household year
       newHousehold = updateHouseholdYear(newHousehold, prevYear, newYear);
-      
+
       // Set new household input, enqueuing API call
       setHouseholdInput(newHousehold);
-      
+
       // If the household already had an ID, get a new household ID and search params
       if (householdId) {
         getNewHouseholdId(metadata.countryId, newHousehold).then(
@@ -68,13 +68,10 @@ export default function TaxYear(props) {
 
     // Set year to new year
     setYear(newYear);
-
   }
 
   return (
-    <CenteredMiddleColumn
-      title="Which tax year would you like to calculate?"
-    >
+    <CenteredMiddleColumn title="Which tax year would you like to calculate?">
       <Select
         showSearch
         optionFilterProp="label"
@@ -93,14 +90,11 @@ export default function TaxYear(props) {
 }
 
 function updateHouseholdYear(householdInput, prevYear, newYear) {
-
   // Copy householdInput into mutable variable
   let editedHousehold = JSON.parse(JSON.stringify(householdInput));
 
   // Variable skip list
-  const skipList = [
-    "members"
-  ];
+  const skipList = ["members"];
 
   // Map over all plural entity terms...
   for (const entityPlural in editedHousehold) {
@@ -121,11 +115,9 @@ function updateHouseholdYear(householdInput, prevYear, newYear) {
 
         // Add it at the new one
         editedHousehold[entityPlural][entity][variable][newYear] = currentVal;
-
       }
     }
   }
 
   return editedHousehold;
-
 }

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -13,7 +13,6 @@ import SearchParamNavButton from "../../../controls/SearchParamNavButton";
 import gtag from "../../../api/analytics";
 import { useState, useEffect } from "react";
 import StableInputNumber from "controls/StableInputNumber";
-import { defaultYear } from "data/constants";
 
 export default function VariableEditor(props) {
   const [searchParams] = useSearchParams();
@@ -26,6 +25,7 @@ export default function VariableEditor(props) {
     setHouseholdInput,
     nextVariable,
     autoCompute,
+    year
   } = props;
   const [edited, setEdited] = useState(false);
   const variableName = searchParams.get("focus").split(".").slice(-1)[0];
@@ -50,6 +50,7 @@ export default function VariableEditor(props) {
         householdInput,
         variable,
         entityPlural,
+        year
       );
       setHouseholdInput(newHouseholdInput);
     }
@@ -71,6 +72,7 @@ export default function VariableEditor(props) {
         nextVariable={nextVariable}
         autoCompute={autoCompute}
         setEdited={setEdited}
+        year={year}
       />
     );
   });
@@ -121,6 +123,7 @@ function HouseholdVariableEntity(props) {
     nextVariable,
     autoCompute,
     setEdited,
+    year
   } = props;
   const possibleTimePeriods = Object.keys(
     householdInput[entityPlural][entityName][variable.name],
@@ -144,6 +147,7 @@ function HouseholdVariableEntity(props) {
             nextVariable={nextVariable}
             autoCompute={autoCompute}
             setEdited={setEdited}
+            year={year}
           />
         );
       })}
@@ -336,7 +340,7 @@ function HouseholdVariableEntityInput(props) {
  * applies to
  * @returns {Object} A new householdInput object that contains the variable
  */
-export function addVariable(householdInput, variable, entityPlural) {
+export function addVariable(householdInput, variable, entityPlural, year) {
   let newHouseholdInput = JSON.parse(JSON.stringify(householdInput));
 
   let possibleEntities = null;
@@ -357,13 +361,13 @@ export function addVariable(householdInput, variable, entityPlural) {
             // Then add it to the relevant part of the situation, along with
             // its default value
             newHouseholdInput[entityPlural][entity][variable.name] = {
-              [defaultYear]: variable.defaultValue,
+              [year]: variable.defaultValue,
             };
           } else {
             // Otherwise, add it to the relevant part of the situation, along with
             // a null value
             newHouseholdInput[entityPlural][entity][variable.name] = {
-              [defaultYear]: null,
+              [year]: null,
             };
           }
         }

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -13,6 +13,7 @@ import SearchParamNavButton from "../../../controls/SearchParamNavButton";
 import gtag from "../../../api/analytics";
 import { useState, useEffect } from "react";
 import StableInputNumber from "controls/StableInputNumber";
+import { defaultYear } from "data/constants";
 
 export default function VariableEditor(props) {
   const [searchParams] = useSearchParams();
@@ -76,6 +77,18 @@ export default function VariableEditor(props) {
       />
     );
   });
+
+  // Format the verb used to describe the variable
+  let number = variable.label.endsWith("s") ? "plural" : "singular";
+  let verb = number === "plural" ? "are" : "is";
+  if (year > defaultYear) {
+    verb = "will be";
+  } else if (year < defaultYear && number === "plural") {
+    verb = "were";
+  } else if (year < defaultYear) {
+    verb = "was";
+  }
+
   return (
     <>
       <div
@@ -89,7 +102,7 @@ export default function VariableEditor(props) {
         }}
       >
         <h1 style={{ marginBottom: 20, textAlign: "center" }}>
-          What {variable.label.endsWith("s") ? "are" : "is"} your{" "}
+          What {verb} your{" "}
           {variable.label.toLowerCase()}?
         </h1>
         <h4 style={{ textAlign: "center", paddingBottom: 10 }}>

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -26,7 +26,7 @@ export default function VariableEditor(props) {
     setHouseholdInput,
     nextVariable,
     autoCompute,
-    year
+    year,
   } = props;
   const [edited, setEdited] = useState(false);
   const variableName = searchParams.get("focus").split(".").slice(-1)[0];
@@ -51,7 +51,7 @@ export default function VariableEditor(props) {
         householdInput,
         variable,
         entityPlural,
-        year
+        year,
       );
       setHouseholdInput(newHouseholdInput);
     }
@@ -102,8 +102,7 @@ export default function VariableEditor(props) {
         }}
       >
         <h1 style={{ marginBottom: 20, textAlign: "center" }}>
-          What {verb} your{" "}
-          {variable.label.toLowerCase()}?
+          What {verb} your {variable.label.toLowerCase()}?
         </h1>
         <h4 style={{ textAlign: "center", paddingBottom: 10 }}>
           {variable.documentation}
@@ -136,7 +135,7 @@ function HouseholdVariableEntity(props) {
     nextVariable,
     autoCompute,
     setEdited,
-    year
+    year,
   } = props;
   const possibleTimePeriods = Object.keys(
     householdInput[entityPlural][entityName][variable.name],

--- a/src/pages/household/output/EarningsVariation.jsx
+++ b/src/pages/household/output/EarningsVariation.jsx
@@ -17,7 +17,7 @@ export default function EarningsVariation(props) {
     householdReform,
     metadata,
     policy,
-    year
+    year,
   } = props;
   const [baselineNetIncome, setBaselineNetIncome] = useState(null);
   const [searchParams] = useSearchParams();

--- a/src/pages/household/output/EarningsVariation.jsx
+++ b/src/pages/household/output/EarningsVariation.jsx
@@ -9,7 +9,6 @@ import { capitalize } from "../../../lang/format";
 import BaselineOnlyChart from "./EarningsVariation/BaselineOnlyChart";
 import BaselineAndReformChart from "./EarningsVariation/BaselineAndReformChart";
 import { getValueFromHousehold } from "../../../api/variables";
-import { defaultYear } from "data/constants";
 
 export default function EarningsVariation(props) {
   const {
@@ -18,6 +17,7 @@ export default function EarningsVariation(props) {
     householdReform,
     metadata,
     policy,
+    year
   } = props;
   const [baselineNetIncome, setBaselineNetIncome] = useState(null);
   const [searchParams] = useSearchParams();
@@ -49,7 +49,7 @@ export default function EarningsVariation(props) {
         ];
       validVariables = validVariables.concat(
         Object.keys(firstEntity).filter((variable) =>
-          Array.isArray(firstEntity[variable][defaultYear]),
+          Array.isArray(firstEntity[variable][year]),
         ),
       );
     }
@@ -65,10 +65,10 @@ export default function EarningsVariation(props) {
 
   useEffect(() => {
     let householdData = JSON.parse(JSON.stringify(householdInput));
-    householdData.people.you["employment_income"] = { [defaultYear]: null };
+    householdData.people.you["employment_income"] = { [year]: null };
     const currentEarnings = getValueFromHousehold(
       "employment_income",
-      defaultYear,
+      year,
       "you",
       householdInput,
       metadata,
@@ -77,7 +77,7 @@ export default function EarningsVariation(props) {
       [
         {
           name: "employment_income",
-          period: defaultYear,
+          period: year,
           min: 0,
           max: Math.max(
             metadata.countryId === "ng" ? 1_200_000 : 200_000,
@@ -165,6 +165,7 @@ export default function EarningsVariation(props) {
         metadata={metadata}
         variable={variable}
         variableLabel={variableLabel}
+        year={year}
       />
     );
   } else if (baselineNetIncome) {
@@ -178,6 +179,7 @@ export default function EarningsVariation(props) {
         variable={variable}
         variableLabel={variableLabel}
         policy={policy}
+        year={year}
       />
     );
   }

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -26,7 +26,7 @@ export default function BaselineAndReformChart(props) {
     variable,
     variableLabel,
     policy,
-    year
+    year,
   } = props;
 
   const earningsArray = getValueFromHousehold(

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -13,7 +13,6 @@ import { getCliffs } from "./cliffs";
 import HoverCard, { HoverCardContext } from "../../../../layout/HoverCard";
 import { convertToCurrencyString } from "./convertToCurrencyString";
 import { plotLayoutFont } from "pages/policy/output/utils";
-import { defaultYear } from "data/constants";
 import useMobile from "layout/Responsive";
 import Screenshottable from "layout/Screenshottable";
 
@@ -27,46 +26,47 @@ export default function BaselineAndReformChart(props) {
     variable,
     variableLabel,
     policy,
+    year
   } = props;
 
   const earningsArray = getValueFromHousehold(
     "employment_income",
-    defaultYear,
+    year,
     "you",
     householdBaselineVariation,
     metadata,
   );
   const baselineArray = getValueFromHousehold(
     variable,
-    defaultYear,
+    year,
     null,
     householdBaselineVariation,
     metadata,
   );
   const reformArray = getValueFromHousehold(
     variable,
-    defaultYear,
+    year,
     null,
     householdReformVariation,
     metadata,
   );
   const currentEarnings = getValueFromHousehold(
     "employment_income",
-    defaultYear,
+    year,
     "you",
     householdBaseline,
     metadata,
   );
   const currentValue = getValueFromHousehold(
     variable,
-    defaultYear,
+    year,
     null,
     householdReform,
     metadata,
   );
   const baselineValue = getValueFromHousehold(
     variable,
-    defaultYear,
+    year,
     null,
     householdBaseline,
     metadata,

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -11,7 +11,6 @@ import style from "../../../../style";
 import { getCliffs } from "./cliffs";
 import HoverCard, { HoverCardContext } from "../../../../layout/HoverCard";
 import { plotLayoutFont } from "pages/policy/output/utils";
-import { defaultYear } from "data/constants";
 
 import { convertToCurrencyString } from "./convertToCurrencyString";
 import useMobile from "layout/Responsive";
@@ -24,18 +23,19 @@ export default function BaselineOnlyChart(props) {
     metadata,
     variable,
     variableLabel,
+    year
   } = props;
 
   const earningsArray = getValueFromHousehold(
     "employment_income",
-    defaultYear,
+    year,
     "you",
     householdBaselineVariation,
     metadata,
   );
   const baselineArray = getValueFromHousehold(
     variable,
-    defaultYear,
+    year,
     null,
     householdBaselineVariation,
     metadata,
@@ -43,14 +43,14 @@ export default function BaselineOnlyChart(props) {
   );
   const currentEarnings = getValueFromHousehold(
     "employment_income",
-    defaultYear,
+    year,
     "you",
     householdBaseline,
     metadata,
   );
   const currentBaseline = getValueFromHousehold(
     variable,
-    defaultYear,
+    year,
     null,
     householdBaseline,
     metadata,

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -23,7 +23,7 @@ export default function BaselineOnlyChart(props) {
     metadata,
     variable,
     variableLabel,
-    year
+    year,
   } = props;
 
   const earningsArray = getValueFromHousehold(

--- a/src/pages/household/output/HouseholdOutput.jsx
+++ b/src/pages/household/output/HouseholdOutput.jsx
@@ -27,7 +27,7 @@ export default function HouseholdOutput(props) {
     loading,
     hasShownHouseholdPopup,
     setHasShownHouseholdPopup,
-    year
+    year,
   } = props;
   const mobile = useMobile();
 

--- a/src/pages/household/output/HouseholdOutput.jsx
+++ b/src/pages/household/output/HouseholdOutput.jsx
@@ -52,6 +52,7 @@ export default function HouseholdOutput(props) {
             householdInput={householdInput}
             hasShownHouseholdPopup={hasShownHouseholdPopup}
             setHasShownHouseholdPopup={setHasShownHouseholdPopup}
+            year={year}
           />
         )}
         <LoadingCentered message="Computing your household's taxes and benefits" />

--- a/src/pages/household/output/HouseholdOutput.jsx
+++ b/src/pages/household/output/HouseholdOutput.jsx
@@ -27,6 +27,7 @@ export default function HouseholdOutput(props) {
     loading,
     hasShownHouseholdPopup,
     setHasShownHouseholdPopup,
+    year
   } = props;
   const mobile = useMobile();
 
@@ -69,6 +70,7 @@ export default function HouseholdOutput(props) {
         householdBaseline={householdBaseline}
         householdReform={householdReform}
         policyLabel={policyLabel}
+        year={year}
       />
     );
   } else if (focus === "householdOutput.earnings") {
@@ -80,6 +82,7 @@ export default function HouseholdOutput(props) {
         householdBaseline={householdBaseline}
         householdReform={householdReform}
         policy={policy}
+        year={year}
       />
     );
   } else if (focus === "householdOutput.mtr") {
@@ -92,6 +95,7 @@ export default function HouseholdOutput(props) {
         householdInput={householdInput}
         policyLabel={policyLabel}
         policy={policy}
+        year={year}
       />
     );
   } else if (focus === "householdOutput.pythonReproducibility") {
@@ -103,6 +107,7 @@ export default function HouseholdOutput(props) {
         householdBaseline={householdBaseline}
         householdReform={householdReform}
         householdInput={householdInput}
+        year={year}
       />
     );
   }

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -5,10 +5,9 @@ import Button from "../../../controls/Button";
 import { Switch } from "antd";
 import CodeBlock from "layout/CodeBlock";
 import { getReformDefinitionCode } from "data/reformDefinitionCode";
-import { defaultYear } from "data/constants";
 
 export default function HouseholdReproducibility(props) {
-  const { policy, metadata, householdInput } = props;
+  const { policy, metadata, householdInput, year } = props;
   const [earningVariation, setEarningVariation] = useState(false);
 
   let lines = ["from " + metadata.package + " import Simulation"];
@@ -28,7 +27,7 @@ export default function HouseholdReproducibility(props) {
       )) {
         if (variable !== "members") {
           if (
-            householdInputCopy[entityPlural][entity][variable][defaultYear] ===
+            householdInputCopy[entityPlural][entity][variable][year] ===
             null
           ) {
             delete householdInputCopy[entityPlural][entity][variable];
@@ -69,7 +68,7 @@ export default function HouseholdReproducibility(props) {
     ")",
     "",
     "simulation.trace = True",
-    `simulation.calculate("household_net_income", ${defaultYear})`,
+    `simulation.calculate("household_net_income", ${year})`,
     "simulation.tracer.print_computation_log()",
   ]);
 

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -27,8 +27,7 @@ export default function HouseholdReproducibility(props) {
       )) {
         if (variable !== "members") {
           if (
-            householdInputCopy[entityPlural][entity][variable][year] ===
-            null
+            householdInputCopy[entityPlural][entity][variable][year] === null
           ) {
             delete householdInputCopy[entityPlural][entity][variable];
           }

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -27,7 +27,7 @@ export default function MarginalTaxRates(props) {
     metadata,
     policyLabel,
     policy,
-    year
+    year,
   } = props;
   const [baselineMtr, setBaselineMtr] = useState(null);
   const [searchParams] = useSearchParams();

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -18,7 +18,6 @@ import { plotLayoutFont } from "pages/policy/output/utils";
 import useMobile from "layout/Responsive";
 import Screenshottable from "layout/Screenshottable";
 import { localeCode } from "lang/format";
-import { defaultYear } from "data/constants";
 
 export default function MarginalTaxRates(props) {
   const {
@@ -28,6 +27,7 @@ export default function MarginalTaxRates(props) {
     metadata,
     policyLabel,
     policy,
+    year
   } = props;
   const [baselineMtr, setBaselineMtr] = useState(null);
   const [searchParams] = useSearchParams();
@@ -45,14 +45,14 @@ export default function MarginalTaxRates(props) {
 
   const currentEarnings = getValueFromHousehold(
     "employment_income",
-    defaultYear,
+    year,
     "you",
     householdInput,
     metadata,
   );
   const currentMtr = getValueFromHousehold(
     "marginal_tax_rate",
-    defaultYear,
+    year,
     "you",
     householdBaseline,
     metadata,
@@ -60,12 +60,12 @@ export default function MarginalTaxRates(props) {
 
   useEffect(() => {
     let householdData = JSON.parse(JSON.stringify(householdInput));
-    householdData.people.you.employment_income[defaultYear] = null;
+    householdData.people.you.employment_income[year] = null;
     householdData.axes = [
       [
         {
           name: "employment_income",
-          period: defaultYear,
+          period: year,
           min: 0,
           max: Math.max(
             metadata.countryId === "ng" ? 1_200_000 : 200_000,
@@ -154,14 +154,14 @@ export default function MarginalTaxRates(props) {
   if (baselineMtr && !reformMtr) {
     const earningsArray = getValueFromHousehold(
       "employment_income",
-      defaultYear,
+      year,
       "you",
       baselineMtr,
       metadata,
     );
     const mtrArray = getValueFromHousehold(
       "marginal_tax_rate",
-      defaultYear,
+      year,
       "you",
       baselineMtr,
       metadata,
@@ -256,28 +256,28 @@ export default function MarginalTaxRates(props) {
   } else if (baselineMtr && reformMtr) {
     const earningsArray = getValueFromHousehold(
       "employment_income",
-      defaultYear,
+      year,
       "you",
       baselineMtr,
       metadata,
     );
     const baselineMtrArray = getValueFromHousehold(
       "marginal_tax_rate",
-      defaultYear,
+      year,
       "you",
       baselineMtr,
       metadata,
     );
     const reformMtrArray = getValueFromHousehold(
       "marginal_tax_rate",
-      defaultYear,
+      year,
       "you",
       reformMtr,
       metadata,
     );
     const reformMtrValue = getValueFromHousehold(
       "marginal_tax_rate",
-      defaultYear,
+      year,
       "you",
       householdReform,
       metadata,

--- a/src/pages/household/output/NetIncomeBreakdown.jsx
+++ b/src/pages/household/output/NetIncomeBreakdown.jsx
@@ -55,6 +55,7 @@ function VariableArithmetic(props) {
     defaultExpanded,
     childrenOnly,
     forceShowChildValuesIfZero,
+    year
   } = props;
   let nodeSign = isAdd;
   const value = getValueFromHousehold(
@@ -177,14 +178,16 @@ function VariableArithmetic(props) {
   if (typeof adds === "string") {
     // adds is a parameter name (e.g. income.tax.groups). Find its value
     const parameter = metadata.parameters[adds];
-    adds = getParameterAtInstant(parameter, defaultStartDate);
+    console.log(parameter);
+    adds = getParameterAtInstant(parameter, `${year}-01-01`);
   }
   let subtracts = variable.subtracts || [];
   // Check if 'subtracts' is a string
   if (typeof subtracts === "string") {
     // subtracts is a parameter name (e.g. income.tax.groups). Find its value
     const parameter = metadata.parameters[subtracts];
-    subtracts = getParameterAtInstant(parameter, defaultStartDate);
+    console.log(parameter);
+    subtracts = getParameterAtInstant(parameter, `${year}-01-01`);
   }
   const childAddNodes = adds.filter(shouldShowVariable).map((variable) => (
     <VariableArithmetic

--- a/src/pages/household/output/NetIncomeBreakdown.jsx
+++ b/src/pages/household/output/NetIncomeBreakdown.jsx
@@ -54,7 +54,7 @@ function VariableArithmetic(props) {
     defaultExpanded,
     childrenOnly,
     forceShowChildValuesIfZero,
-    year
+    year,
   } = props;
   let nodeSign = isAdd;
   const value = getValueFromHousehold(

--- a/src/pages/household/output/NetIncomeBreakdown.jsx
+++ b/src/pages/household/output/NetIncomeBreakdown.jsx
@@ -13,7 +13,6 @@ import {
 import ResultsPanel from "../../../layout/ResultsPanel";
 import style from "../../../style";
 import useDisplayCategory from "redesign/components/useDisplayCategory";
-import { defaultStartDate } from "data/constants";
 
 const UpArrow = () => (
   <CaretUpFilled
@@ -178,7 +177,6 @@ function VariableArithmetic(props) {
   if (typeof adds === "string") {
     // adds is a parameter name (e.g. income.tax.groups). Find its value
     const parameter = metadata.parameters[adds];
-    console.log(parameter);
     adds = getParameterAtInstant(parameter, `${year}-01-01`);
   }
   let subtracts = variable.subtracts || [];
@@ -186,7 +184,6 @@ function VariableArithmetic(props) {
   if (typeof subtracts === "string") {
     // subtracts is a parameter name (e.g. income.tax.groups). Find its value
     const parameter = metadata.parameters[subtracts];
-    console.log(parameter);
     subtracts = getParameterAtInstant(parameter, `${year}-01-01`);
   }
   const childAddNodes = adds.filter(shouldShowVariable).map((variable) => (

--- a/src/pages/household/output/PoliciesModelledPopup.jsx
+++ b/src/pages/household/output/PoliciesModelledPopup.jsx
@@ -3,7 +3,6 @@ import { Modal } from "antd";
 import { useEffect } from "react";
 import { useState } from "react";
 import { getValueFromHousehold } from "../../../api/variables";
-import { defaultYear } from "data/constants";
 import Button from "../../../controls/Button";
 
 function PoliciesModelledChecklist(props) {

--- a/src/pages/household/output/PoliciesModelledPopup.jsx
+++ b/src/pages/household/output/PoliciesModelledPopup.jsx
@@ -7,7 +7,7 @@ import { defaultYear } from "data/constants";
 import Button from "../../../controls/Button";
 
 function PoliciesModelledChecklist(props) {
-  const { metadata, householdInput } = props;
+  const { metadata, householdInput, year } = props;
   if (!metadata.modelled_policies || !metadata.modelled_policies.filtered) {
     return null;
   }
@@ -19,7 +19,7 @@ function PoliciesModelledChecklist(props) {
       // Check if the household input matches the filter
       const actualValue = getValueFromHousehold(
         variable,
-        defaultYear,
+        year,
         "your household",
         householdInput,
         metadata,
@@ -87,6 +87,7 @@ export default function PoliciesModelledPopup(props) {
     householdInput,
     hasShownHouseholdPopup,
     setHasShownHouseholdPopup,
+    year
   } = props;
   useEffect(() => {
     const openModal = () => {
@@ -97,6 +98,7 @@ export default function PoliciesModelledPopup(props) {
             <PoliciesModelledChecklist
               metadata={metadata}
               householdInput={householdInput}
+              year={year}
             />
           </>
         ),
@@ -128,6 +130,7 @@ export default function PoliciesModelledPopup(props) {
     householdInput,
     hasShownHouseholdPopup,
     setHasShownHouseholdPopup,
+    year
   ]);
   return null;
 }

--- a/src/pages/household/output/PoliciesModelledPopup.jsx
+++ b/src/pages/household/output/PoliciesModelledPopup.jsx
@@ -86,7 +86,7 @@ export default function PoliciesModelledPopup(props) {
     householdInput,
     hasShownHouseholdPopup,
     setHasShownHouseholdPopup,
-    year
+    year,
   } = props;
   useEffect(() => {
     const openModal = () => {
@@ -129,7 +129,7 @@ export default function PoliciesModelledPopup(props) {
     householdInput,
     hasShownHouseholdPopup,
     setHasShownHouseholdPopup,
-    year
+    year,
   ]);
   return null;
 }

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -14,6 +14,7 @@ import style from "../../style";
 import PolicySearch from "./PolicySearch";
 import { Alert, Modal } from "antd";
 import { ExclamationCircleOutlined } from "@ant-design/icons";
+import { defaultYear } from "data/constants";
 
 function RegionSelector(props) {
   const { metadata } = props;
@@ -50,9 +51,8 @@ function TimePeriodSelector(props) {
     return [...accu, Number(periodObj.value)];
   }, []);
 
-  const curYear = new Date().getFullYear();
-  const defaultPeriod = yearArray.includes(curYear)
-    ? curYear
+  const defaultPeriod = yearArray.includes(defaultYear)
+    ? defaultYear
     : options[0].value;
 
   const [value] = useState(
@@ -328,9 +328,8 @@ export default function PolicyRightSidebar(props) {
         return [...accu, Number(periodObj.name)];
       }, []);
 
-      const curYear = new Date().getFullYear();
-      const defaultTimePeriod = yearArray.includes(curYear)
-        ? curYear
+      const defaultTimePeriod = yearArray.includes(defaultYear)
+        ? defaultYear
         : timeOptions[0].name;
 
       const defaults = {

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -8,6 +8,7 @@ import {
 import { useSearchParams } from "react-router-dom";
 import { asyncApiCall, copySearchParams, apiCall } from "../../../api/call";
 import ErrorPage from "layout/Error";
+import { defaultYear } from "data/constants";
 // import LoadingCentered from "layout/LoadingCentered";
 
 /**
@@ -98,9 +99,8 @@ export function FetchAndDisplayImpact(props) {
         return [...accu, Number(periodObj.name)];
       }, []);
 
-      const curYear = new Date().getFullYear();
-      const defaultTimePeriod = yearArray.includes(curYear)
-        ? curYear
+      const defaultTimePeriod = yearArray.includes(defaultYear)
+        ? defaultYear
         : timeOptions[0].name;
 
       const defaults = {
@@ -203,9 +203,8 @@ export function FetchAndDisplayCliffImpact(props) {
         return [...accu, Number(periodObj.name)];
       }, []);
 
-      const curYear = new Date().getFullYear();
-      const defaultTimePeriod = yearArray.includes(curYear)
-        ? curYear
+      const defaultTimePeriod = yearArray.includes(defaultYear)
+        ? defaultYear
         : timeOptions[0].name;
 
       const defaults = {


### PR DESCRIPTION
## Description

Fixes #218, allowing household calculator users to select a year.

## Changes

This PR does the following:
* Declares a new stateful variable `year` within `HouseholdPage` that defaults to the current year, but whenever the app is accessed with an existing household, attempts to pull the year from the household
* Creates a component called `TaxYear` that occurs first in the user input flow and allows a user to select a tax year based on the years that are available within each country's metadata
* Creates a function that, whenever year is changed, generates a new household on the back end (if a household ID currently exists), then deletes all keys stored at the prior `year` value before repopulating them using the new input year and updating said year
* Alters the formatting of verbs within the input and output components to implement correct tense

## Screenshots

A Loom video running through the impacts on the UK site (since it has both past and future years in its country package) is available [here](https://www.loom.com/share/df6aaa2bb5c0401fb769e07fdefa72f6?sid=9362e1d1-4cd5-447e-8715-a28208722561). This video also demonstrates that households are created/edited correctly within the API.

## Tests

This component does not currently add tests, as I'm waiting on #1124 to add them. As such, I'll be opening this as a draft, and after #1124 is pushed, will add tests before making the PR active.
