### PR TITLE
Temporarily disable labor supply impacts outside US

### DIFF
--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -150,6 +150,13 @@ export function DisplayImpact(props) {
         region={region}
       />
     );
+  }
+  // Remove the below else-if block when labor supply impacts are expanded
+  // back to all countries
+  else if (metadata.countryId !== "us" && impactType === "laborSupplyImpact") {
+    pane = (
+      <ErrorPage message="This service is temporarily unavailable. Please try again later." />
+    );
   } else {
     const { chart, csv } = getImpactReps(impactType, {
       impact: impact,

--- a/src/pages/policy/output/tree.js
+++ b/src/pages/policy/output/tree.js
@@ -33,7 +33,11 @@ export function getPolicyOutputTree(countryId) {
     });
   }
   if (countryId !== "us") {
-    ["racialPovertyImpact"].forEach((key) => {
+    [
+      "racialPovertyImpact",
+      // Delete the below key when labor supply impacts are reinstated to all countries
+      "laborSupplyImpact",
+    ].forEach((key) => {
       delete map[key];
     });
   }


### PR DESCRIPTION
## Description

Fixes #1186. This PR disables the labor supply impact output of the policy reform calculator for all countries except the US. It also ensures that if the user visits the labor supply impact page from a non-permitted country (e.g., a UK user revisits a previously saved link to the page), an error page is rendered instead of breaking.

## Changes

This PR removes the `laborSupplyImpact` key from the function that generates the policy output tree, thereby removing the component from the left-hand impact bar, and also hard-codes a custom display within the `Display` JSX file's `DisplayImpact` component.

## Screenshots

A Loom video of the working component is available [here](https://www.loom.com/share/4321f3a5da204b3f8a8e7060dee62330?sid=a3149459-cd8f-4db2-8928-a5282a2e9c54).

## Tests

None have been added.
