### PR TITLE
Add tests for TaxYear component

### DIFF
--- a/src/__tests__/TaxYear.test.js
+++ b/src/__tests__/TaxYear.test.js
@@ -1,9 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { useSearchParams } from "react-router-dom";
 import fetch from "node-fetch";
 import TaxYear from "pages/household/input/TaxYear";
 import { defaultYear } from "data/constants";
+import { defaultHouseholds } from "data/defaultHouseholds";
 
 jest.mock("react-router-dom", () => {
   const originalModule = jest.requireActual("react-router-dom");
@@ -16,54 +17,41 @@ jest.mock("react-router-dom", () => {
 });
 
 useSearchParams.mockImplementation(() => {
-  return [
-    new URLSearchParams({}), 
-    jest.fn()
-  ];
+  return [new URLSearchParams({}), jest.fn()];
 });
 
 describe("Test TaxYear component", () => {
-
   let metadataUS = null;
 
-  beforeAll( async () => {
-    const res = await fetch(
-      "https://api.policyengine.org/us/metadata",
-    );
+  beforeAll(async () => {
+    const res = await fetch("https://api.policyengine.org/us/metadata");
     const metadataRaw = await res.json();
     metadataUS = metadataRaw.result;
-
   });
 
   test("Properly sets display years based on metadata", async () => {
-
     const setYear = jest.fn();
 
     const { getByTestId } = render(
-      <TaxYear 
-        metadata={metadataUS}
-        year={defaultYear}
-        setYear={setYear}
-      />
+      <TaxYear metadata={metadataUS} year={defaultYear} setYear={setYear} />,
     );
 
     fireEvent.mouseDown(getByTestId("taxyear_dropdown").firstElementChild);
 
     // While using document.querySelector is not best testing practice,
     // Ant Design makes it difficult to correctly test their components
-    const yearOptions = document.querySelectorAll(".ant-select-item-option-content");
-    expect(yearOptions.length).toStrictEqual(metadataUS.economy_options.time_period.length);
+    const yearOptions = document.querySelectorAll(
+      ".ant-select-item-option-content",
+    );
+    expect(yearOptions.length).toStrictEqual(
+      metadataUS.economy_options.time_period.length,
+    );
   });
   test("Properly sets state variable for year when selected", () => {
-
     const setYear = jest.fn();
 
     const { getByTitle, getByTestId } = render(
-      <TaxYear 
-        metadata={metadataUS}
-        year={defaultYear}
-        setYear={setYear}
-      />
+      <TaxYear metadata={metadataUS} year={defaultYear} setYear={setYear} />,
     );
 
     const yearOptions = metadataUS.economy_options.time_period;
@@ -72,41 +60,44 @@ describe("Test TaxYear component", () => {
     fireEvent.mouseDown(getByTestId("taxyear_dropdown").firstElementChild);
     fireEvent.click(getByTitle(testYearOption));
     expect(setYear).toHaveBeenCalledWith(testYearOption);
-
   });
   test("Properly displays year for household with set year", () => {
-
     const setYear = jest.fn();
 
     const yearOptions = metadataUS.economy_options.time_period;
     const testYearOption = yearOptions[yearOptions.length - 1].label;
 
     const { getByTestId } = render(
-      <TaxYear 
-        metadata={metadataUS}
-        year={testYearOption}
-        setYear={setYear}
-      />
+      <TaxYear metadata={metadataUS} year={testYearOption} setYear={setYear} />,
     );
 
     const el = getByTestId("taxyear_dropdown").firstElementChild;
     expect(el.textContent).toStrictEqual(testYearOption);
   });
-  /*
-  test("Properly updates a household year");
-  test("Points to the correct next page");
-  */
+  test("Properly updates via updateHouseholdYear", () => {
+    const yearOptions = metadataUS.economy_options.time_period;
+    const testYearOption = yearOptions[yearOptions.length - 1].label;
 
+    const householdUS = JSON.parse(JSON.stringify(defaultHouseholds.us));
+    const testHouseholdUS = JSON.parse(JSON.stringify(defaultHouseholds.us));
+    delete testHouseholdUS.people.you.age["2024"];
+    testHouseholdUS.people.you.age[testYearOption] = 40;
 
+    const setYearMock = jest.fn();
+    const setHouseholdInputMock = jest.fn();
+
+    const { getByTitle, getByTestId } = render(
+      <TaxYear
+        metadata={metadataUS}
+        year={defaultYear}
+        setYear={setYearMock}
+        householdInput={householdUS}
+        setHouseholdInput={setHouseholdInputMock}
+      />,
+    );
+
+    fireEvent.mouseDown(getByTestId("taxyear_dropdown").firstElementChild);
+    fireEvent.click(getByTitle(testYearOption));
+    expect(setHouseholdInputMock).toHaveBeenCalledWith(testHouseholdUS);
+  });
 });
-
-/*
-describe("Test updateHouseholdYear function", () => {
-
-  test("Can properly do nothing when same year is provided");
-  test("Can properly update for later year");
-  test("Can properly update for earlier year");
-  test("Properly seeds default year when no year is provided for test var");
-
-});
-*/

--- a/src/__tests__/TaxYear.test.js
+++ b/src/__tests__/TaxYear.test.js
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { useSearchParams } from "react-router-dom";
+import fetch from "node-fetch";
+import TaxYear from "pages/household/input/TaxYear";
+import { defaultYear } from "data/constants";
+
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useSearchParams: jest.fn(),
+    useNavigate: jest.fn(),
+  };
+});
+
+useSearchParams.mockImplementation(() => {
+  return [
+    new URLSearchParams({}), 
+    jest.fn()
+  ];
+});
+
+describe("Test TaxYear component", () => {
+
+  let metadataUS = null;
+
+  beforeAll( async () => {
+    const res = await fetch(
+      "https://api.policyengine.org/us/metadata",
+    );
+    const metadataRaw = await res.json();
+    metadataUS = metadataRaw.result;
+
+  });
+
+  test("Properly sets display years based on metadata", async () => {
+
+    const setYear = jest.fn();
+
+    const { getByTestId } = render(
+      <TaxYear 
+        metadata={metadataUS}
+        year={defaultYear}
+        setYear={setYear}
+      />
+    );
+
+    fireEvent.mouseDown(getByTestId("taxyear_dropdown").firstElementChild);
+
+    // While using document.querySelector is not best testing practice,
+    // Ant Design makes it difficult to correctly test their components
+    const yearOptions = document.querySelectorAll(".ant-select-item-option-content");
+    expect(yearOptions.length).toStrictEqual(metadataUS.economy_options.time_period.length);
+  });
+  test("Properly sets state variable for year when selected", () => {
+
+    const setYear = jest.fn();
+
+    const { getByTitle, getByTestId } = render(
+      <TaxYear 
+        metadata={metadataUS}
+        year={defaultYear}
+        setYear={setYear}
+      />
+    );
+
+    const yearOptions = metadataUS.economy_options.time_period;
+    const testYearOption = yearOptions[yearOptions.length - 1].label;
+
+    fireEvent.mouseDown(getByTestId("taxyear_dropdown").firstElementChild);
+    fireEvent.click(getByTitle(testYearOption));
+    expect(setYear).toHaveBeenCalledWith(testYearOption);
+
+  });
+  test("Properly displays year for household with set year", () => {
+
+    const setYear = jest.fn();
+
+    const yearOptions = metadataUS.economy_options.time_period;
+    const testYearOption = yearOptions[yearOptions.length - 1].label;
+
+    const { getByTestId } = render(
+      <TaxYear 
+        metadata={metadataUS}
+        year={testYearOption}
+        setYear={setYear}
+      />
+    );
+
+    const el = getByTestId("taxyear_dropdown").firstElementChild;
+    expect(el.textContent).toStrictEqual(testYearOption);
+  });
+  /*
+  test("Properly updates a household year");
+  test("Points to the correct next page");
+  */
+
+
+});
+
+/*
+describe("Test updateHouseholdYear function", () => {
+
+  test("Can properly do nothing when same year is provided");
+  test("Can properly update for later year");
+  test("Can properly update for earlier year");
+  test("Properly seeds default year when no year is provided for test var");
+
+});
+*/

--- a/src/pages/household/input/TaxYear.jsx
+++ b/src/pages/household/input/TaxYear.jsx
@@ -73,6 +73,7 @@ export default function TaxYear(props) {
   return (
     <CenteredMiddleColumn title="Which year would you like to calculate?">
       <Select
+        data-testid="taxyear_dropdown"
         showSearch
         optionFilterProp="label"
         style={{ width: displayCategory === "mobile" ? 150 : 200 }}
@@ -81,6 +82,7 @@ export default function TaxYear(props) {
         onSelect={handleSubmit}
       />
       <SearchParamNavButton
+        data-testid="taxyear_navbutton"
         text="Enter"
         focus="input.household.maritalStatus"
         style={{ margin: "20px auto 10px" }}


### PR DESCRIPTION
## Description

Fixes #1154. This adds tests to the `TaxYear` component, which was incorporated late last week.

## Changes

This creates a variety of tests to ensure that TaxYear functions correctly.

## Screenshots

N/A

## Tests

N/A
