### PR TITLE
Update GCP Python runtime to Python 3.8

### DIFF
--- a/gcp/app.yaml
+++ b/gcp/app.yaml
@@ -1,4 +1,4 @@
-runtime: python37
+runtime: python38
 
 handlers:
   - url: /.*


### PR DESCRIPTION
## Description

Fixes #1201. On January 30, GCP's Python 3.7 runtime will be deprecated, preventing us from pushing any further changes to the app until we update. This code updates the GCP `app.yaml` configuration file to employ Python 3.8, preventing this issue.

## Changes

This PR only changes the `app.yaml` configuration file for the GCP deploy.

## Screenshots

N/A

## Tests

None included, as it is not possible to test the GCP deployment side of the app at the moment. That said, I did run through the Python Foundation's changelog, and no apparent changes to what we currently use in the minimal amount of Python on the web app jumped out at me.
