### PR TITLE
Add effect hook to determine if placeholder changes in InputField

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -27,3 +27,4 @@ yarn-error.log*
 /main.py
 /requirements.txt
 **/__pycache__
+.mypy_cache

--- a/src/controls/InputField.jsx
+++ b/src/controls/InputField.jsx
@@ -1,7 +1,7 @@
 import { motion } from "framer-motion";
 import useMobile from "../layout/Responsive";
 import style from "../style";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export default function InputField(props) {
   const {
@@ -17,6 +17,11 @@ export default function InputField(props) {
   const [inputValue, setInputValue] = useState(value ? value : "");
   const mobile = useMobile();
   const re = /^[0-9\b]*[.]?[0-9\b]*?$/;
+
+  useEffect(() => {
+    setInputValue("");
+  }, [placeholder]);
+
   const onInput = (e) => {
     let value = e.target.value === "" ? placeholder : e.target.value;
     onChange(value);


### PR DESCRIPTION
## Description

Fixes #1212. Previously, the `InputField` component displayed stale values input by the user when switching to a new policy parameter. This is because the input value of the component is stateful, causing it to have been preserved between renders, despite the re-renders of its parent, and despite the fact that the `placeholder` prop did correctly reflect its parent.

## Changes

This PR adds an effect hook to determine if the "placeholder" value has changed. If so, it updates the `inputValue` stateful variable to match said `placeholder`.

## Screenshots

A Loom video is available [here](https://www.loom.com/share/ffd804e0b6ee4a0e991d3ac640972a8e?sid=81a751ab-cb9e-45b1-9348-9b98909e9100).

## Tests

No tests have been written for this change.
