### PR TITLE
Prevent display of enhanced_us on component load from URL

### DIFF
--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -30,7 +30,14 @@ function RegionSelector(props) {
   // standard US data
   options = options.filter((option) => option.value !== "enhanced_us");
 
-  const [value] = useState(searchParams.get("region") || options[0].value);
+  // These lines are also a temporary solution; if user accesses the component
+  // with the enhanced_us region via URL, the component should instead display
+  // the US
+  let inputRegion = searchParams.get("region");
+  if (inputRegion === "enhanced_us") {
+    inputRegion = "us";
+  }
+  const [value] = useState(inputRegion || options[0].value);
 
   return (
     <SearchOptions


### PR DESCRIPTION
## Description

Fixes #1220. Previously, the `PolicyRightSidebar` component removed the `enhanced_us` option from the region selector display, but failed to update the initial region state setter function when a user loaded an `enhanced_us` policy, resulting in the awkward display of "enhanced_us" as region.

## Changes

This PR adds a conditional check for the region within the search params on component load, and if that region is `enhanced_us`, it instead treats its default region as `us`. Like the initial creation of the `DatasetSelector` component in a previous PR, these changes should be treated as temporary until it's possible to separate dataset type from region within the back end.

## Screenshots

A Loom video of the component in action is available at https://www.loom.com/share/885ab95d86bd495092aeba26ac78447b?sid=d6ab3e16-8f37-43cd-9637-ec0e7e73a244.

## Tests

No additional tests were added.
