### PR TITLE
Temporarily disable the download png button for policy output charts

### DIFF
--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -12,7 +12,7 @@ import Analysis from "./Analysis";
 import useMobile from "layout/Responsive";
 import ErrorPage from "layout/Error";
 import ResultActions from "layout/ResultActions";
-import { downloadCsv, downloadPng } from "./utils";
+import { downloadCsv } from "./utils";
 import { useReactToPrint } from "react-to-print";
 import PolicyBreakdown from "./PolicyBreakdown";
 import { Helmet } from "react-helmet";

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -127,7 +127,7 @@ export function DisplayImpact(props) {
   const policyLabel = getPolicyLabel(policy);
   const mobile = useMobile();
   const filename = impactType + `${policyLabel}`;
-  let pane, downloadCsvFn, downloadPngFn;
+  let pane, downloadCsvFn;
   if (impactType === "analysis") {
     pane = (
       <Analysis
@@ -166,7 +166,6 @@ export function DisplayImpact(props) {
     if (csv) {
       downloadCsvFn = () => downloadCsv(csv(), filename);
     }
-    downloadPngFn = () => downloadPng(filename);
   }
   return (
     <>
@@ -176,7 +175,6 @@ export function DisplayImpact(props) {
         </title>
       </Helmet>
       <LowLevelDisplay
-        downloadPng={downloadPngFn}
         downloadCsv={downloadCsvFn}
         metadata={metadata}
         policy={policy}


### PR DESCRIPTION
## Description

We fixed #1222 by not displaying the download png button for policy output charts.

## Screenshots

Normally the "download csv" button is the second button but now that we don't display the png button it is in first place:

<img width="783" alt="Screenshot 2024-01-19 at 7 30 04 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/f7236cc7-c468-4d06-a944-4b5918fa2d3e">

## Tests

We tested that the button was not visible for 5 policy output charts.
