### PR TITLE
Prevent unnecessary re-renders by removing autofocus param from `VariableEditor`

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -275,7 +275,6 @@ function HouseholdVariableEntityInput(props) {
             }
           : {})}
         defaultValue={defaultValue}
-        autoFocus
         onPressEnter={(_, value) => submitValue(value)}
         onBlur={(_, value) => submitValue(value)}
       />


### PR DESCRIPTION
## Description

Fixes #1234. At present, `VariableEditor` iterates over all possible time periods for a policy to take effect, then over all possible entities affected, and generates an input box for each combo. It sets an `autofocus` param for each, but when the next is created, the focus is shifted to that one, causing the `onBlur` handler to trigger. For large families, this means as many as 6 separate POST requests to the household endpoint to create new households and request an ID.

## Changes

This PR removes the `autofocus` param from the inputs. Considering #1171, it opts to not provide any `autofocus`, instead opening a separate issue whereby we set all variable input pages to automatically scroll to the top on render.

## Screenshots

A Loom video displaying the current component in action, followed by the edited, is available at https://www.loom.com/share/890284e4cf3642d2a5c586fe96505214?sid=ac1f8576-d7f4-4bfd-872d-23b977b6a691.

## Tests

No tests have been included
