### PR TITLE
Add `embed=true` to API playground Streamlit URL

### DIFF
--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -370,7 +370,7 @@ export default function APIDocumentationPage({ metadata }) {
       <Section title="API playground">
         <p>Try out the API in this interactive demo.</p>
         <iframe
-          src={`https://policyengine-policyengine-api-demo-app-xy5rgn.streamlit.app/~/+/?mode=${countryId}`}
+          src={`https://policyengine-policyengine-api-demo-app-xy5rgn.streamlit.app/~/+/?embed=true&embed_options=light_theme&mode=${countryId}`}
           // the demo is in the policyengine-api-demo repository in PolicyEngine
           title="PolicyEngine API demo"
           height="500px"


### PR DESCRIPTION
## Description

We fix #1229 by adding `?embed=true` to the API playground Streamlit URL.

## Screenshots

The playground is still visible after adding the parameter:

<img width="1295" alt="Screenshot 2024-01-19 at 12 51 55 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/83b3a310-6849-431c-9412-b5f9d84b0f55">

## Tests

It is hard to test this change -- it is hypothesized in https://github.com/PolicyEngine/policyengine-app/issues/1229#issuecomment-1900715529 that this will enable the user to see the hibernating Streamlit app and wake it up.  We will know whether this fix works or not once Streamlit sleeps again. If it does not work, the issue will need to be reopened.