### PR TITLE
Display the reformed parameter properly in the `ParameterOverTime` component

### DIFF
--- a/src/api/parameters.js
+++ b/src/api/parameters.js
@@ -141,6 +141,25 @@ export function getReformedParameter(parameter, reforms) {
   return newParameter;
 }
 
+/**
+ *
+ * @param {object} parameter the parameter object
+ * @returns copy of parameter.values with sorted keys
+ *
+ */
+export function getSortedParameterValues(parameter) {
+  const values = parameter.values;
+  if (!values) {
+    return null;
+  }
+  return Object.keys(values)
+    .sort()
+    .reduce((obj, key) => {
+      obj[key] = values[key];
+      return obj;
+    }, {});
+}
+
 export function getNewPolicyId(countryId, newPolicyData, newPolicyLabel) {
   let submission = { data: newPolicyData };
   if (newPolicyLabel) {

--- a/src/api/parameters.js
+++ b/src/api/parameters.js
@@ -1,3 +1,4 @@
+import moment from "moment";
 import { countryApiCall } from "./call";
 
 export function buildParameterTree(parameters) {
@@ -92,6 +93,10 @@ export function getParameterAtInstant(parameter, instant) {
   return null;
 }
 
+function nextDay(date) {
+  return new moment(date, "YYYY-MM-DD").add(1, "d").format("YYYY-MM-DD");
+}
+
 export function getReformedParameter(parameter, reforms) {
   // The reform is specified in the format:
   // { parameter.module.name: { "2022-01-01.2022-12-19": value }, ... }
@@ -124,8 +129,12 @@ export function getReformedParameter(parameter, reforms) {
         }
         // add the new values
         parameterValues[startDate] = value;
-        parameterValues[endDate] = c;
         sortedKeys.splice(i1, i2 - i1 + 1, startDate, endDate);
+        const dayAfterEndDate = nextDay(endDate);
+        if (!Object.keys(parameterValues).includes(dayAfterEndDate)) {
+          parameterValues[dayAfterEndDate] = c;
+          sortedKeys.splice(i1 + 1, 0, dayAfterEndDate);
+        }
       } else if (i1 !== -1) {
         parameterValues[startDate] = value;
         sortedKeys.splice(i1, 0, startDate);
@@ -133,8 +142,9 @@ export function getReformedParameter(parameter, reforms) {
         // sortedKeys[0]] should be.
       } else if (i2 !== -1) {
         parameterValues[startDate] = value;
-        parameterValues[endDate] = parameterValues[sortedKeys[i2]];
-        sortedKeys.splice(i2, 0, startDate, endDate);
+        const dayAfterEndDate = nextDay(endDate);
+        parameterValues[dayAfterEndDate] = parameterValues[sortedKeys[i2]];
+        sortedKeys.splice(i2, 0, startDate, dayAfterEndDate);
       }
     }
   }

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -1,6 +1,9 @@
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
-import { getReformedParameter } from "../../../api/parameters";
+import {
+  getSortedParameterValues,
+  getReformedParameter,
+} from "../../../api/parameters";
 import { getPlotlyAxisFormat } from "../../../api/variables";
 import useMobile from "../../../layout/Responsive";
 import useWindowHeight from "layout/WindowHeight";
@@ -12,19 +15,6 @@ export default function ParameterOverTime(props) {
   const { parameter, policy, metadata } = props;
   const mobile = useMobile();
   const windowHeight = useWindowHeight();
-  let values = parameter.values;
-  if (!values) {
-    return null;
-  }
-
-  // Ensure the line doesn't go back on itself.
-
-  values = Object.keys(values)
-    .sort()
-    .reduce((obj, key) => {
-      obj[key] = values[key];
-      return obj;
-    }, {});
 
   // Extend the last value to 2099 so that the line appears to extend to +inf in
   // the chart
@@ -33,6 +23,7 @@ export default function ParameterOverTime(props) {
     y.push(y[y.length - 1]);
   };
 
+  const values = getSortedParameterValues(parameter);
   let x = Object.keys(values);
   let y = Object.values(values);
   extendForDisplay(x, y);
@@ -40,10 +31,11 @@ export default function ParameterOverTime(props) {
   let reformedY;
 
   if (policy.reform.data[parameter.parameter]) {
-    let reformedValues = getReformedParameter(
+    const reformedParameter = getReformedParameter(
       parameter,
       policy.reform.data,
-    ).values;
+    );
+    const reformedValues = getSortedParameterValues(reformedParameter);
     reformedX = Object.keys(reformedValues);
     reformedY = Object.values(reformedValues);
     extendForDisplay(reformedX, reformedY);


### PR DESCRIPTION
## Description

We fix #1238 by using an object with sorted keys for displaying reformed parameter values. This idea of using an object with sorted keys was already used for the baseline parameter but was not applied to the reformed parameter.

## Changes

- We add a new function `getSortedParameterValues` to `parameter.js`. This function returns a copy of `parameter.values` with sorted keys. This logic was already present in the `ParameterOverTime` component but we move it to `parameter.js` because it is a way to get a canonical representation of `parameter.values`.
- We use `getSortedParameterValues` to get a canonical representation of reformed parameter values instead of using the values directly in the chart.

## Screenshots

<img width="780" alt="Screenshot 2024-01-19 at 9 53 47 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/d0532dfb-d967-4f52-9d58-07f7eb428cb8">


## Tests

We checked that the `ParameterOverTime` was displayed correctly for a couple of parameters.
