### PR TITLE
Repair Reproduce in Python code

### DIFF
--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -1,12 +1,5 @@
 export function getReformDefinitionCode(metadata, policy) {
-  let lines = [
-    "from policyengine_core.reforms import Reform",
-    "from policyengine_core.periods import instant",
-    "import pandas as pd",
-    "",
-    "",
-    "def modify_parameters(parameters):",
-  ];
+  let lines = ["def modify_parameters(parameters):"];
 
   if (Object.keys(policy.reform.data).length === 0) {
     lines.pop();
@@ -37,7 +30,6 @@ export function getReformDefinitionCode(metadata, policy) {
   lines.push("    return parameters");
 
   lines = lines.concat([
-    "",
     "",
     "class reform(Reform):",
     "    def apply(self):",

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -1,4 +1,4 @@
-export function getReformDefinitionCode(metadata, policy) {
+export function getReformDefinitionCode(policy) {
   let lines = ["def modify_parameters(parameters):"];
 
   if (Object.keys(policy.reform.data).length === 0) {

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -25,6 +25,7 @@ export function getReformDefinitionCode(policy) {
 
   lines = lines.concat([
     "",
+    "",
     "class reform(Reform):",
     "    def apply(self):",
     "        self.modify_parameters(modify_parameters)",

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -15,15 +15,9 @@ export function getReformDefinitionCode(policy) {
         value = "True";
       }
       lines.push(
-        "    parameters." +
-          parameterName +
-          '.update(start=instant("' +
-          start +
-          '"), stop=instant("' +
-          end +
-          '"), value=' +
-          value +
-          ")",
+        `    parameters.${parameterName}.update(`,
+        `        start=instant("${start}"), stop=instant("${end}"),`,
+        `        value=${value})`,
       );
     }
   }

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -22,7 +22,7 @@ export default function PolicyOutput(props) {
   if (impactType === "codeReproducibility") {
     return (
       <LowLevelDisplay {...props}>
-        <PolicyReproducibility metadata={metadata} policy={policy} />;
+        <PolicyReproducibility metadata={metadata} policy={policy} />
       </LowLevelDisplay>
     );
   } else if (impactType === "cliffImpact") {

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -106,6 +106,7 @@ function getBaselineDefinitionCode(region, policy) {
     "        value=True)",
     "    return parameters",
     "",
+    "",
     "class baseline_reform(Reform):",
     "    def apply(self):",
     "        self.modify_parameters(modify_baseline)",

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -56,8 +56,7 @@ export default function PolicyReproducibility(props) {
           paddingTop: 30,
           marginBottom: 30,
         }}
-      >
-      </div>
+      ></div>
     </>
   );
 }

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -4,6 +4,8 @@ import { defaultYear } from "data/constants";
 import { useSearchParams } from "react-router-dom";
 import colors from "../../../redesign/style/colors";
 
+const US_REGIONS = ["us", "enhanced_us"];
+
 export default function PolicyReproducibility(props) {
   const { policy, metadata } = props;
   const [searchParams] = useSearchParams();
@@ -72,7 +74,7 @@ function getHeaderLines(metadata) {
 }
 
 function getBaselineDefinitionCode(region, policy) {
-  if (region !== "us" && region !== "enhanced_us") {
+  if (!US_REGIONS.includes(region)) {
     return [];
   }
 
@@ -95,10 +97,13 @@ function getBaselineDefinitionCode(region, policy) {
 
   return [
     `"""`,
-    "In US nationwide simulations, use reported state income tax liabilities",
+    "In US nationwide simulations,",
+    "use reported state income tax liabilities",
     `"""`,
     "def modify_baseline(parameters):",
-    `    parameters.simulation.reported_state_income_tax.update(start=instant("${earliestStart}"), stop=instant("${latestEnd}"), value=True)`,
+    "    parameters.simulation.reported_state_income_tax.update(",
+    `        start=instant("${earliestStart}"), stop=instant("${latestEnd}"),`,
+    "        value=True)",
     "    return parameters",
     "",
     "class baseline_reform(Reform):",
@@ -110,20 +115,17 @@ function getBaselineDefinitionCode(region, policy) {
 }
 
 function getImplementationCode(region, timePeriod) {
-  const isCountryUS =
-    region === "us" || region === "enhanced_us";
+  const isCountryUS = US_REGIONS.includes(region);
 
   return [
     `baseline = Microsimulation(${
       isCountryUS ? "reform=baseline_reform" : ""
     })`,
     "reformed = Microsimulation(reform=reform)",
-    `baseline_person = baseline.calc("household_net_income", period=${
-      timePeriod || defaultYear
-    }, map_to="person")`,
-    `reformed_person = reformed.calc("household_net_income", period=${
-      timePeriod || defaultYear
-    }, map_to="person")`,
+    `baseline_person = baseline.calc("household_net_income",`,
+    `    period=${timePeriod || defaultYear}, map_to="person")`,
+    `reformed_person = reformed.calc("household_net_income",`,
+    `    period=${timePeriod || defaultYear}, map_to="person")`,
     "difference_person = reformed_person - baseline_person",
   ];
 }

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -1,23 +1,20 @@
 import CodeBlock from "layout/CodeBlock";
 import { getReformDefinitionCode } from "data/reformDefinitionCode";
 import { defaultYear } from "data/constants";
+import { useSearchParams } from "react-router-dom";
 import colors from "../../../redesign/style/colors";
 
 export default function PolicyReproducibility(props) {
   const { policy, metadata } = props;
+  const [searchParams] = useSearchParams();
+  const timePeriod = searchParams.get("timePeriod");
 
-  let initialLines = ["from " + metadata.package + " import Microsimulation"];
-
-  initialLines = initialLines.concat(getReformDefinitionCode(metadata, policy));
-
-  initialLines = initialLines.concat([
-    "baseline = Microsimulation()",
-    "reformed = Microsimulation(reform=reform)",
-    'HOUSEHOLD_VARIABLES = ["person_id", "household_id", "age", "household_net_income", "household_income_decile", "in_poverty", "household_tax", "household_benefits"]',
-    `baseline_person_df = baseline.calculate_dataframe(HOUSEHOLD_VARIABLES, ${defaultYear})`,
-    `reformed_person_df = reformed.calculate_dataframe(HOUSEHOLD_VARIABLES, ${defaultYear})`,
-    "difference_person_df = reformed_person_df - baseline_person_df",
-  ]);
+  let codeLines = [
+    ...getHeaderLines(metadata),
+    ...getBaselineDefinitionCode(metadata, policy),
+    ...getReformDefinitionCode(metadata, policy),
+    ...getImplementationCode(metadata, timePeriod),
+  ];
 
   const colabLink =
     metadata.countryId === "uk"
@@ -48,7 +45,7 @@ export default function PolicyReproducibility(props) {
         Run the code below in a {notebookLink} to reproduce the microsimulation
         results.
       </p>
-      <CodeBlock lines={initialLines} language={"python"} />
+      <CodeBlock lines={codeLines} language={"python"} />
       <div
         style={{
           display: "flex",
@@ -56,7 +53,76 @@ export default function PolicyReproducibility(props) {
           paddingTop: 30,
           marginBottom: 30,
         }}
-      ></div>
+      >
+      </div>
     </>
   );
+}
+
+function getHeaderLines(metadata) {
+  return [
+    "from " + metadata.package + " import Microsimulation",
+    "from policyengine_core.reforms import Reform",
+    "from policyengine_core.periods import instant",
+    "import pandas as pd",
+    "",
+    "",
+  ];
+}
+
+function getBaselineDefinitionCode(metadata, policy) {
+  if (metadata.countryId !== "us" && metadata.countryId !== "enhanced_us") {
+    return [];
+  }
+
+  // Calculate the earliest start date and latest end date for
+  // the policies included in the simulation
+  let earliestStart = null;
+  let latestEnd = null;
+
+  for (const parameter of Object.keys(policy.reform.data)) {
+    for (const instant of Object.keys(policy.reform.data[parameter])) {
+      const [start, end] = instant.split(".");
+      if (!earliestStart || Date.parse(start) < Date.parse(earliestStart)) {
+        earliestStart = start;
+      }
+      if (!latestEnd || Date.parse(end) > Date.parse(latestEnd)) {
+        latestEnd = end;
+      }
+    }
+  }
+
+  return [
+    `"""`,
+    "In US simulations, use reported state income tax liabilities",
+    `"""`,
+    "def modify_baseline(parameters):",
+    `    parameters.simulation.reported_state_income_tax.update(start=instant("${earliestStart}"), stop=instant("${latestEnd}"), value=True)`,
+    "    return parameters",
+    "",
+    "class baseline_reform(Reform):",
+    "    def apply(self):",
+    "        self.modify_parameters(modify_baseline)",
+    "",
+    "",
+  ];
+}
+
+function getImplementationCode(metadata, timePeriod) {
+  const isCountryUS =
+    metadata.countryId === "us" || metadata.countryId === "enhanced_us";
+
+  return [
+    `baseline = Microsimulation(${
+      isCountryUS ? "reform=baseline_reform" : ""
+    })`,
+    "reformed = Microsimulation(reform=reform)",
+    `baseline_person = baseline.calc("household_net_income", period=${
+      timePeriod || defaultYear
+    }, map_to="person")`,
+    `reformed_person = reformed.calc("household_net_income", period=${
+      timePeriod || defaultYear
+    }, map_to="person")`,
+    "difference_person = reformed_person - baseline_person",
+  ];
 }

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -8,12 +8,13 @@ export default function PolicyReproducibility(props) {
   const { policy, metadata } = props;
   const [searchParams] = useSearchParams();
   const timePeriod = searchParams.get("timePeriod");
+  const region = searchParams.get("region");
 
   let codeLines = [
     ...getHeaderLines(metadata),
-    ...getBaselineDefinitionCode(metadata, policy),
-    ...getReformDefinitionCode(metadata, policy),
-    ...getImplementationCode(metadata, timePeriod),
+    ...getBaselineDefinitionCode(region, policy),
+    ...getReformDefinitionCode(policy),
+    ...getImplementationCode(region, timePeriod),
   ];
 
   const colabLink =
@@ -70,8 +71,8 @@ function getHeaderLines(metadata) {
   ];
 }
 
-function getBaselineDefinitionCode(metadata, policy) {
-  if (metadata.countryId !== "us" && metadata.countryId !== "enhanced_us") {
+function getBaselineDefinitionCode(region, policy) {
+  if (region !== "us" && region !== "enhanced_us") {
     return [];
   }
 
@@ -94,7 +95,7 @@ function getBaselineDefinitionCode(metadata, policy) {
 
   return [
     `"""`,
-    "In US simulations, use reported state income tax liabilities",
+    "In US nationwide simulations, use reported state income tax liabilities",
     `"""`,
     "def modify_baseline(parameters):",
     `    parameters.simulation.reported_state_income_tax.update(start=instant("${earliestStart}"), stop=instant("${latestEnd}"), value=True)`,
@@ -108,9 +109,9 @@ function getBaselineDefinitionCode(metadata, policy) {
   ];
 }
 
-function getImplementationCode(metadata, timePeriod) {
+function getImplementationCode(region, timePeriod) {
   const isCountryUS =
-    metadata.countryId === "us" || metadata.countryId === "enhanced_us";
+    region === "us" || region === "enhanced_us";
 
   return [
     `baseline = Microsimulation(${


### PR DESCRIPTION
## Description

Fixes #1179, fixes #653, fixes #1248. Previously, the code included in the `Reproduce in Python` page of the policy reform calculator displayed non-working code. 

## Changes

This PR repairs this code by ensuring that US contexts (those with region of "us" and "enhanced_us") have additional lines aimed at ensuring the baseline policy sets the parameter `simulation.use_reported_state_income_tax` to true. It also shifts from using `calculate_dataframe` to `calc` in order to prevent bugs associated with that operation, and removes a trailing semicolon from a different component. Finally, it ensures that the `year` property of the displayed code updates properly, and for policies with multiple parameters of different time periods, it ensures that `use_reported_state_income_tax` applies to the entire simulated period by iterating over the parameter list and setting its time period based upon that.

## Screenshots

A Loom video is available at https://www.loom.com/share/795b31c44954498f829a5690ebd53250?sid=a1d64b72-cdd0-49b6-9b66-b085ab5a5444.

## Tests

None have been included.
