### PR TITLE
Remove unnecessary line in `PolicyBreakdown` component

### DIFF
--- a/src/pages/policy/output/PolicyBreakdown.jsx
+++ b/src/pages/policy/output/PolicyBreakdown.jsx
@@ -10,8 +10,7 @@ export default function PolicyBreakdown(props) {
 
   const title = `Your reform impact in ${regionName} over ${timePeriod}`;
   const bottomText =
-    "Here's how we estimated the society-wide impacts of your " +
-    "reform. Click on an option on the left panel to view more details.";
+    "Click on an option on the left panel to view more details.";
 
   // Define the impact items to be included in the output
   const budgetaryImpact = impact.budget.budgetary_impact;


### PR DESCRIPTION
## Description

Fixes #1244.

## Changes

This removes the unnecessary line flagged in the issue.

## Screenshots

<img width="1440" alt="Screen Shot 2024-01-22 at 9 53 53 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/1b8581d1-0b23-45ef-a71c-516f5ae1d8dd">


## Tests

N/A
