### PR TITLE
Improve parameter editor

### DIFF
--- a/src/__tests__/Bisection.test.js
+++ b/src/__tests__/Bisection.test.js
@@ -1,0 +1,49 @@
+const { bisect } = require("algorithms/Bisection");
+
+describe("bisection", () => {
+  test("small cases", () => {
+    expect(bisect([], 1)).toBe(0);
+    expect(bisect([1], 1)).toBe(0);
+    expect(bisect([1], 2)).toBe(1);
+    expect(bisect([1], 1, 0, 1, true)).toBe(1);
+  });
+
+  test("identity", () => {
+    const a = [0, 1, 2, 3, 4, 5];
+    test.each(a, (e) => {
+      expect(bisect(a, e)).toBe(e);
+    });
+  });
+
+  test("successor 1", () => {
+    const a = [0, 1, 2, 3, 4, 5];
+    test.each(a, (e) => {
+      expect(bisect(a, e + 0.5)).toBe(e + 1);
+    });
+  });
+
+  test("successor 2", () => {
+    const a = [0, 1, 2, 3, 4, 5];
+    test.each(a, (e) => {
+      expect(bisect(a, e, 0, a.length, true)).toBe(e + 1);
+    });
+  });
+
+  test("successor 4", () => {
+    const a = [0, 1, 2, 3, 4, 5];
+    test.each(a, (e) => {
+      expect(bisect(a, e + 0.5, 0, a.length, true)).toBe(e + 1);
+    });
+  });
+
+  test("duplicates", () => {
+    const a = [0, 1, 2, 3, 3, 3, 6, 7];
+    expect(bisect(a, 3)).toBe(3);
+    expect(bisect(a, 3, 0, a.length, true)).toBe(6);
+  });
+
+  test("unknown", () => {
+    const a = [-2, -1];
+    expect(bisect(a, 1, 0, a.length, false)).toBe(a.length);
+  });
+});

--- a/src/__tests__/IntervalMap.test.js
+++ b/src/__tests__/IntervalMap.test.js
@@ -1,0 +1,165 @@
+const { IntervalMap } = require("algorithms/IntervalMap");
+
+describe("IntervalMap construction", () => {
+  test("empty map", () => {
+    const m = new IntervalMap([], (x, y) => x - y);
+    expect(m.get(0)).toBeUndefined();
+    expect(m.toArray()).toStrictEqual([]);
+  });
+
+  test("one entry", () => {
+    const m = new IntervalMap([[1, "a"]], (x, y) => x - y);
+    expect(m.get(0)).toBeUndefined();
+    expect(m.get(1)).toBe("a");
+    expect(m.get(10)).toBe("a");
+    expect(m.toArray()).toStrictEqual([[1, "a"]]);
+  });
+
+  test("two entries", () => {
+    const m = new IntervalMap(
+      [
+        [1, "a"],
+        [2, "b"],
+      ],
+      (x, y) => x - y,
+    );
+    expect(m.get(0)).toBeUndefined();
+    expect(m.get(1)).toBe("a");
+    expect(m.get(1.5)).toBe("a");
+    expect(m.get(2)).toBe("b");
+    expect(m.get(10)).toBe("b");
+    expect(m.toArray()).toStrictEqual([
+      [1, "a"],
+      [2, "b"],
+    ]);
+  });
+});
+
+describe("IntervalMap operations", () => {
+  test("one interval", () => {
+    const m = new IntervalMap([], (x, y) => x - y);
+    m.set(-1, 1, "a");
+    expect(m.toArray()).toStrictEqual([
+      [-1, "a"],
+      [1, undefined],
+    ]);
+  });
+
+  test("disjoint intervals", () => {
+    const m = new IntervalMap([], (x, y) => x - y);
+    m.set(-2, -1, "a");
+    m.set(1, 2, "b");
+    expect(m.toArray()).toStrictEqual([
+      [-2, "a"],
+      [-1, undefined],
+      [1, "b"],
+      [2, undefined],
+    ]);
+  });
+
+  test("adjacent intervals", () => {
+    const m = new IntervalMap([], (x, y) => x - y);
+    m.set(-1, 0, "a");
+    m.set(0, 1, "b");
+    expect(m.toArray()).toStrictEqual([
+      [-1, "a"],
+      [0, "b"],
+      [1, undefined],
+    ]);
+  });
+
+  test("adjacent intervals added in reverse order", () => {
+    const m = new IntervalMap([], (x, y) => x - y);
+    m.set(0, 1, "b");
+    m.set(-1, 0, "a");
+    expect(m.toArray()).toStrictEqual([
+      [-1, "a"],
+      [0, "b"],
+      [1, undefined],
+    ]);
+  });
+
+  test("intersecting intervals", () => {
+    const m = new IntervalMap([], (x, y) => x - y);
+    m.set(-2, 1, "a");
+    m.set(-1, 2, "b");
+    expect(m.toArray()).toStrictEqual([
+      [-2, "a"],
+      [-1, "b"],
+      [2, undefined],
+    ]);
+  });
+
+  test("nested intervals", () => {
+    const m = new IntervalMap([], (x, y) => x - y);
+    m.set(-2, 2, "a");
+    m.set(-1, 1, "b");
+    expect(m.toArray()).toStrictEqual([
+      [-2, "a"],
+      [-1, "b"],
+      [1, "a"],
+      [2, undefined],
+    ]);
+  });
+
+  test("adjacent intervals with same value", () => {
+    const m = new IntervalMap([], (x, y) => x - y);
+    m.set(-1, 0, "a");
+    m.set(0, 1, "a");
+    expect(m.toArray()).toStrictEqual([
+      [-1, "a"],
+      [1, undefined],
+    ]);
+  });
+
+  test("nested intervals with same value", () => {
+    const m = new IntervalMap([], (x, y) => x - y);
+    m.set(-3, 3, "a");
+    m.set(-2, 2, "a");
+    m.set(-1, 1, "a");
+    expect(m.toArray()).toStrictEqual([
+      [-3, "a"],
+      [3, undefined],
+    ]);
+  });
+
+  test("nested intervals with same value in reverse order", () => {
+    const m = new IntervalMap([], (x, y) => x - y);
+    m.set(-1, 1, "a");
+    m.set(-2, 2, "a");
+    m.set(-3, 3, "a");
+    expect(m.toArray()).toStrictEqual([
+      [-3, "a"],
+      [3, undefined],
+    ]);
+  });
+
+  test("nested intervals with same value in third order", () => {
+    const m = new IntervalMap([], (x, y) => x - y);
+    m.set(-1, 1, "a");
+    m.set(-3, 3, "a");
+    m.set(-2, 2, "a");
+    expect(m.toArray()).toStrictEqual([
+      [-3, "a"],
+      [3, undefined],
+    ]);
+  });
+
+  test("minimal size", () => {
+    const m = new IntervalMap([], (x, y) => x - y);
+    m.set(-3, 3, "a");
+    m.set(-2, 2, "b");
+    m.set(-2.5, 0, "a");
+    expect(m.toArray()).toStrictEqual([
+      [-3, "a"],
+      [0, "b"],
+      [2, "a"],
+      [3, undefined],
+    ]);
+    m.set(0, 2, "a");
+    expect(m.toArray()).toStrictEqual([
+      [-3, "a"],
+      [3, undefined],
+    ]);
+  });
+});

--- a/src/algorithms/Bisection.js
+++ b/src/algorithms/Bisection.js
@@ -1,0 +1,43 @@
+/**
+ *
+ * @callback cmpCallback
+ * @param {*} element1
+ * @param {*} element2
+ */
+
+/**
+ *
+ * Locate the leftmost insertion point for x in arr to maintain sorted order.
+ *
+ * @param {Array} a a sorted array
+ * @param {*} x a value
+ * @param {number} lo the insertion point is found in [lo, hi); 0 by default
+ * @param {number} hi the insertion point is found in [lo, hi); a.length by default
+ * @param {bool} findRightMost return rightmost insertion point if true; false by default
+ * @param {cmpCallback} cmp comparator for values
+ *
+ */
+export function bisect(
+  a,
+  x,
+  lo = 0,
+  hi = a.length,
+  findRightMost = false,
+  cmp = (a, b) => a - b,
+) {
+  if (hi < lo || hi > a.length || lo < 0) return;
+  if (hi === lo) return lo;
+  if (hi === lo + 1) {
+    const c = cmp(a[lo], x);
+    if (c < 0) return hi;
+    if (c > 0) return lo;
+    if (cmp(a[lo], x) === 0 && findRightMost) return hi;
+    return lo;
+  }
+  const mid = Math.floor((lo + hi) / 2.0);
+  const c = cmp(a[mid], x);
+  if (c < 0 || (c === 0 && findRightMost)) {
+    return bisect(a, x, mid + 1, hi, findRightMost, cmp);
+  }
+  return bisect(a, x, lo, mid, findRightMost, cmp);
+}

--- a/src/algorithms/IntervalMap.js
+++ b/src/algorithms/IntervalMap.js
@@ -1,0 +1,135 @@
+/**
+ *
+ * @callback keyCmpCallback
+ * @param {*} element1
+ * @param {*} element2
+ */
+
+/**
+ *
+ * @callback valueEqCallback
+ * @param {*} element1
+ * @param {*} element2
+ */
+
+export class IntervalMap {
+  /**
+   *
+   * @param {array} array an object that maps keys to values
+   * @param {keyCmpCallback} keyCmp comparator for keys
+   * @param {valueEqCallback} valueEq equality checker for values
+   * @returns an interval map with useful operations
+   */
+  constructor(array, keyCmp = (x, y) => x - y, valueEq = (x, y) => x === y) {
+    this.array = [];
+    array.sort((a, b) => keyCmp(a[0], b[0]));
+    let prevValue;
+    for (const [key, value] in array) {
+      if (!valueEq(value, prevValue)) {
+        array.push([key, value]);
+        prevValue = value;
+      }
+    }
+    // the loop ensures that two consecutive elements do not have duplicates,
+    // and the first element does not have an undefined value.
+    this.array = array;
+    this.keyCmp = keyCmp;
+    this.valueEq = valueEq;
+  }
+
+  /**
+   *
+   * Map the interval [x1, x2) to y
+   * @param {*} x1 the left endpoint of the interval
+   * @param {*} x2 the right endpoint of the interval
+   * @param {*} y the value that the interval [x1, x2) maps to
+   */
+  set(x1, x2, y) {
+    const array = this.array;
+    const keyCmp = this.keyCmp;
+    const valueEq = this.valueEq;
+
+    // empty interval
+    if (keyCmp(x1, x2) >= 0) return;
+
+    // empty array
+    if (array.length === 0) {
+      array.push([x1, y], [x2, undefined]);
+      return;
+    }
+
+    // nonempty interval and array here
+
+    let idx1 = array.findIndex((element) => keyCmp(element[0], x1) >= 0);
+    if (idx1 === -1) {
+      // all elements have keys < x1 < x2
+      const v = array[array.length - 1][1];
+      if (!valueEq(y, v)) {
+        array.push([x1, y], [x2, v]);
+      }
+      return;
+    }
+
+    let idx2 = array.findLastIndex((element) => keyCmp(element[0], x2) <= 0);
+    if (idx2 === -1) {
+      // all elements have keys > x2 > x1
+      if (!valueEq(y, undefined)) {
+        array.splice(0, 0, [x1, y], [x2, undefined]);
+      }
+      return;
+    }
+
+    // idx1 is the index of the first element with key >= x1
+    // idx2 is the index of the last element with key <= x2
+
+    const insert1 = !(idx1 > 0 && valueEq(array[idx1 - 1][1], y));
+    const insert2 = !valueEq(array[idx2][1], y);
+
+    if (insert1 && insert2) {
+      array.splice(idx1, idx2 - idx1 + 1, [x1, y], [x2, array[idx2][1]]);
+    } else if (insert1) {
+      array.splice(idx1, idx2 - idx1 + 1, [x1, y]);
+    } else if (insert2) {
+      array.splice(idx1, idx2 - idx1 + 1, [x2, array[idx2][1]]);
+    } else {
+      array.splice(idx1, idx2 - idx1 + 1);
+    }
+  }
+
+  /**
+   *
+   * Get value at x
+   * @param {*} x a point in the domain
+   */
+  get(x) {
+    // first element with key <= x
+    const element = this.array.findLast(
+      (element) => this.keyCmp(element[0], x) <= 0,
+    );
+    return element?.[1];
+  }
+
+  /**
+   *
+   * @returns number of intervals
+   */
+  size() {
+    return this.array.length;
+  }
+
+  /**
+   *
+   * @returns the keys in the map
+   */
+  keys() {
+    return this.array.map((element) => element[0]);
+  }
+
+  /**
+   *
+   * @returns an array representation of the map
+   */
+  toArray() {
+    return this.array;
+  }
+}

--- a/src/algorithms/IntervalMap.js
+++ b/src/algorithms/IntervalMap.js
@@ -127,9 +127,25 @@ export class IntervalMap {
 
   /**
    *
+   * @returns the values in the map
+   */
+  values() {
+    return this.array.map((element) => element[1]);
+  }
+
+  /**
+   *
    * @returns an array representation of the map
    */
   toArray() {
-    return this.array;
+    return this.array.map((element) => element);
+  }
+
+  /**
+   *
+   * @returns a copy
+   */
+  copy() {
+    return new IntervalMap(this.toArray(), this.keyCmp, this.valueEq);
   }
 }

--- a/src/algorithms/IntervalMap.js
+++ b/src/algorithms/IntervalMap.js
@@ -1,3 +1,5 @@
+import { bisect } from "./Bisection";
+
 /**
  *
  * @callback keyCmpCallback
@@ -60,8 +62,11 @@ export class IntervalMap {
 
     // nonempty interval and array here
 
-    let idx1 = array.findIndex((element) => keyCmp(element[0], x1) >= 0);
-    if (idx1 === -1) {
+    let idx1 = bisect(array, x1, 0, array.length, false, (element, x) =>
+      keyCmp(element[0], x),
+    );
+
+    if (idx1 === array.length) {
       // all elements have keys < x1 < x2
       const v = array[array.length - 1][1];
       if (!valueEq(y, v)) {
@@ -70,7 +75,11 @@ export class IntervalMap {
       return;
     }
 
-    let idx2 = array.findLastIndex((element) => keyCmp(element[0], x2) <= 0);
+    let idx2 =
+      bisect(array, x2, 0, array.length, true, (element, x) =>
+        keyCmp(element[0], x),
+      ) - 1;
+
     if (idx2 === -1) {
       // all elements have keys > x2 > x1
       if (!valueEq(y, undefined)) {

--- a/src/algorithms/README.md
+++ b/src/algorithms/README.md
@@ -1,3 +1,3 @@
 # Description
 
-This folder contains common data structures and algorithms. Currently, we only have an interval map data structure but more structures and algorithms can be added here.
+This folder contains common data structures and algorithms. Currently, we have an interval map data structure and a bisection algorithm for sorted arrays but more structures and algorithms can be added here.

--- a/src/algorithms/README.md
+++ b/src/algorithms/README.md
@@ -1,0 +1,3 @@
+# Description
+
+This folder contains common data structures and algorithms. Currently, we only have an interval map data structure but more structures and algorithms can be added here.

--- a/src/controls/StableInputNumber.jsx
+++ b/src/controls/StableInputNumber.jsx
@@ -42,8 +42,8 @@ export default function StableInputNumber(props) {
     <InputNumber
       defaultValue={defaultValue}
       onChange={setValue}
-      onPressEnter={(e) => onPressEnter(e, value)}
-      onBlur={(e) => onBlur(e, value)}
+      onPressEnter={(e) => onPressEnter?.(e, value)}
+      onBlur={(e) => onBlur?.(e, value)}
       {...others}
     />
   );

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,3 +1,3 @@
 export const defaultYear = new Date().getFullYear();
 export const defaultStartDate = defaultYear.toString().concat("-01-01");
-export const defaultEndDate = (defaultYear + 5).toString().concat("-12-31");
+export const defaultEndDate = defaultYear.toString().concat("-12-31");

--- a/src/lang/stringDates.js
+++ b/src/lang/stringDates.js
@@ -1,0 +1,21 @@
+import moment from "moment";
+
+export function prevDay(date) {
+  return new moment(date, "YYYY-MM-DD").add(-1, "day").format("YYYY-MM-DD");
+}
+
+export function nextDay(date) {
+  return new moment(date, "YYYY-MM-DD").add(1, "day").format("YYYY-MM-DD");
+}
+
+export function cmpDates(d1, d2) {
+  d1 = new moment(d1, "YYYY-MM-DD");
+  d2 = new moment(d2, "YYYY-MM-DD");
+  if (d1.isBefore(d2, "day")) {
+    return -1;
+  }
+  if (d2.isBefore(d1, "day")) {
+    return 1;
+  }
+  return 0;
+}

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -52,7 +52,6 @@ export default function ParameterEditor(props) {
   };
 
   function onChange(value) {
-    console.log(parameter.parameter);
     reformMap.set(startDate, nextDay(endDate), value);
     const diffData = diff();
     if (Object.keys(diffData).length === 0) {

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -124,7 +124,7 @@ export default function ParameterEditor(props) {
       }}
     >
       <RangePicker
-        value={[moment(startDate), moment(endDate)]}
+        defaultValue={[moment(startDate), moment(endDate)]}
         onChange={(_, dateStrings) => {
           setStartDate(dateStrings[0]);
           setEndDate(dateStrings[1]);

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -52,7 +52,7 @@ export default function ParameterEditor(props) {
   };
 
   function onChange(value) {
-    reformMap.set(startDate, endDate, value);
+    reformMap.set(startDate, nextDay(endDate), value);
     const diffData = diff();
     if (Object.keys(diffData).length === 0) {
       let newSearch = copySearchParams(searchParams);

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -110,6 +110,9 @@ export default function ParameterEditor(props) {
           setStartDate(dateStrings[0]);
           setEndDate(dateStrings[1]);
         }}
+        disabledDate={(date) =>
+          date.isBefore("2021-01-01") || date.isAfter("2026-12-31")
+        }
         separator="→"
         style={{ padding: 20, marginBottom: 10 }}
       />

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -1,9 +1,5 @@
 import Plot from "react-plotly.js";
 import { ChartLogo } from "../../../api/charts";
-import {
-  getSortedParameterValues,
-  getReformedParameter,
-} from "../../../api/parameters";
 import { getPlotlyAxisFormat } from "../../../api/variables";
 import useMobile from "../../../layout/Responsive";
 import useWindowHeight from "layout/WindowHeight";
@@ -12,7 +8,7 @@ import { plotLayoutFont } from "pages/policy/output/utils";
 import { localeCode } from "lang/format";
 
 export default function ParameterOverTime(props) {
-  const { parameter, policy, metadata } = props;
+  const { baseMap, reformMap, parameter, metadata } = props;
   const mobile = useMobile();
   const windowHeight = useWindowHeight();
 
@@ -23,23 +19,13 @@ export default function ParameterOverTime(props) {
     y.push(y[y.length - 1]);
   };
 
-  const values = getSortedParameterValues(parameter);
-  let x = Object.keys(values);
-  let y = Object.values(values);
+  const x = baseMap.keys();
+  const y = baseMap.values();
   extendForDisplay(x, y);
-  let reformedX;
-  let reformedY;
 
-  if (policy.reform.data[parameter.parameter]) {
-    const reformedParameter = getReformedParameter(
-      parameter,
-      policy.reform.data,
-    );
-    const reformedValues = getSortedParameterValues(reformedParameter);
-    reformedX = Object.keys(reformedValues);
-    reformedY = Object.values(reformedValues);
-    extendForDisplay(reformedX, reformedY);
-  }
+  const reformedX = reformMap ? reformMap.keys() : [];
+  const reformedY = reformMap ? reformMap.values() : [];
+  if (reformMap) extendForDisplay(reformedX, reformedY);
 
   let xaxisValues = reformedX ? x.concat(reformedX) : x;
   xaxisValues = xaxisValues.filter(
@@ -66,7 +52,7 @@ export default function ParameterOverTime(props) {
             },
             name: "Current law",
           },
-          policy.reform.data[parameter.parameter] && {
+          reformMap && {
             x: reformedX,
             y: reformedY.map((y) => +y),
             type: "line",
@@ -78,9 +64,7 @@ export default function ParameterOverTime(props) {
             },
             name: "Reform",
           },
-        ]
-          .reverse()
-          .filter((x) => x)}
+        ].filter((x) => x)}
         layout={{
           xaxis: { ...xaxisFormat },
           yaxis: { ...yaxisFormat },

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -54,7 +54,6 @@ export default function ParameterOverTime(props) {
             type: "line",
             line: {
               shape: "hv",
-              dash: "dot",
             },
             marker: {
               color: style.colors.GRAY,
@@ -67,6 +66,7 @@ export default function ParameterOverTime(props) {
             type: "line",
             line: {
               shape: "hv",
+              dash: "dot",
             },
             marker: {
               color: style.colors.BLUE,

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -5,10 +5,19 @@ import useMobile from "../../../layout/Responsive";
 import useWindowHeight from "layout/WindowHeight";
 import style from "../../../style";
 import { plotLayoutFont } from "pages/policy/output/utils";
-import { localeCode } from "lang/format";
+import { localeCode } from "lang/format"; /**
+ *
+ * @param {object} policy the policy object
+ * @returns the reform policy label
+ */
+function getReformPolicyLabel(policy) {
+  const urlParams = new URLSearchParams(window.location.search);
+  const reformPolicyId = urlParams.get("reform");
+  return reformPolicyId ? `Policy #${reformPolicyId}` : "reform";
+}
 
 export default function ParameterOverTime(props) {
-  const { baseMap, reformMap, parameter, metadata } = props;
+  const { baseMap, reformMap, parameter, policy, metadata } = props;
   const mobile = useMobile();
   const windowHeight = useWindowHeight();
 
@@ -62,7 +71,7 @@ export default function ParameterOverTime(props) {
             marker: {
               color: style.colors.BLUE,
             },
-            name: "Reform",
+            name: getReformPolicyLabel(policy),
           },
         ].filter((x) => x)}
         layout={{

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -11,6 +11,7 @@ import { localeCode } from "lang/format"; /**
  * @returns the reform policy label
  */
 function getReformPolicyLabel(policy) {
+  if (policy.reform.label) return policy.reform.label;
   const urlParams = new URLSearchParams(window.location.search);
   const reformPolicyId = urlParams.get("reform");
   return reformPolicyId ? `Policy #${reformPolicyId}` : "reform";


### PR DESCRIPTION
## Description

- We fix #1240 by
  - reducing the default range for the date picker in `ParameterEditor` to the current year
  - changing the allowed range for the date picker in `ParameterEditor` to `"2021-01-01" -> "2026-12-31"`.
- We fix #1241 by placing `Current law` before `Reform`
- We fix #1242 by changing `Reform` to `Policy #...`.
- We refactor the function `getReformedParameter` in `parameter.js` into an `IntervalMap` data structure. This leads to
  - simpler code for functions and components such as `getParameterAtInstant` and `ParameterEditor`, and
  - fewer errors because the data structure is tested thoroughly in `IntervalMap.test.js` (more tests should be added because `IntervalMap` is quite complex).
 - We remove `getSortedParameterValues` from `parameter.js` because `IntervalMap` provides sorted values.
 - We remove the `useEffect` block for setting dates in `ParameterEditor` because the heuristic of reading the first reform does not work: try changing a range such as `2027->2028` to a new value in [this example](https://policyengine.org/us/policy?reform=44823&focus=gov.irs.credits.ctc.refundable.individual_max&region=us&timePeriod=2024&baseline=2) and the dates erroneously jump back to `2023`.
 - We fix #1262 by changing the styles of the lines in the chart.
 - We fix #1285 by not changing the URL on blur.
 - We fix #967 and fix #1275 by using the `StableInputNumber` component instead of the `InputField` component.
 - We fix #1214 by using `defaultValue` in `RangePicker`.

## Screenshots

<img width="769" alt="Screenshot 2024-01-22 at 1 58 53 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/9f70c894-73e7-4462-90ca-aa04aeaa23a7">

Note that this is the screenshot for the initial set of commits -- see discussion below for updated screenshots.

## Tests

Tests have been added for `IntervalMap`.
For the remaining changes, basic tests have been performed on the parameter editor but I am looking for feedback.
