### PR TITLE
Simplify variable editor logic

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -234,8 +234,6 @@ function HouseholdVariableEntityInput(props) {
     defaultValue = inputValue;
   } else if (simulatedValue !== null) {
     defaultValue = simulatedValue;
-  } else if (variable.defaultValue !== undefined) {
-    defaultValue = variable.defaultValue;
   }
 
   if (defaultValue === null) {
@@ -367,20 +365,9 @@ export function addVariable(householdInput, variable, entityPlural, year) {
       possibleEntities.forEach((entity) => {
         // If the variable isn't already stored in the situation...
         if (!(variable.name in householdInput[entityPlural][entity])) {
-          // If the basic input is an "input variable" (input by user)...
-          if (variable.isInputVariable) {
-            // Then add it to the relevant part of the situation, along with
-            // its default value
-            newHouseholdInput[entityPlural][entity][variable.name] = {
-              [year]: variable.defaultValue,
-            };
-          } else {
-            // Otherwise, add it to the relevant part of the situation, along with
-            // a null value
-            newHouseholdInput[entityPlural][entity][variable.name] = {
-              [year]: null,
-            };
-          }
+          newHouseholdInput[entityPlural][entity][variable.name] = {
+            [year]: variable.defaultValue,
+          };
         }
       });
     }


### PR DESCRIPTION
## Description

We fix #1132 by simplifying the logic in the `addVariable` function and the `HouseholdVariableEntityInput` component. As mentioned in the description for #1132, our fix for #1057 violated the Single Responsibility Principle. The current fix addresses #1057 at a deeper level.

## Changes

The cause of #1132 is the failure of `addVariable` to carry out its responsibility of adding variables to entities with good default values. `addVariable` ignores the default value for the `state_name` variable because it is not an "input variable". `state_name` is not an input variable because it has a formula:

https://github.com/PolicyEngine/policyengine-us/blob/e73ce75edac5e7bb88b9ea538a012cae83825f9e/policyengine_us/variables/input/geography.py#L19

and any variable with a formula is not an input variable according to core logic. However, this definition of input variables is irrelevant to the front end. For the front end, if we are showing the variable in the input portion of the household calculator, then it is an input variable. Therefore, we remove the unnecessary check in `addVariable` and the unnecessary branch in `HouseholdVariableEntityInput`.

## Screenshots

<img width="769" alt="Screenshot 2024-01-23 at 7 58 22 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/c5c78b02-5df8-42e0-aeb0-cddee32fb027">


## Tests

We tested the variable editor a few times with different number of household members.
