### PR TITLE
Update api documentation

### DIFF
--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -218,9 +218,10 @@ export default function APIDocumentationPage({ metadata }) {
           PolicyEngine&apos;s REST API 
           (<a href="https://household.api.policyengine.org">https://household.api.policyengine.org</a>) 
           simulates tax-benefit policy outcomes and reform impacts for households. Access 
-          to the API requires an authentication token, which can be requested from PolicyEngine. 
-          This token will expire periodically. For more information, please feel free to 
-          contact PolicyEngine at <a href="mailto: hello@policyengine.org">hello@policyengine.org</a>.
+          to the API requires an authentication token, which will expire monthly for security reasons.
+          This token must be passed within the authorization heading of each request you make to the API. 
+          For more information or to request your own token, feel free to reach out to
+          PolicyEngine at <a href="mailto: hello@policyengine.org">hello@policyengine.org</a>.
         </p>
         <br />
         <h4>On this page</h4>

--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { Container } from "react-bootstrap";
 import { Input, Card, Divider, Tag, Drawer } from "antd";
 import { Helmet } from "react-helmet";
+import { defaultYear } from "data/constants";
 
 function APIResultCard(props) {
   const { metadata, type, setSelectedCard } = props;
@@ -168,8 +169,6 @@ function VariableParameterExplorer(props) {
             caretColor: style.colors.BLACK,
             marginLeft: 0,
           }}
-          // Auto-focus
-          autoFocus={true}
         />
         <Divider />
 
@@ -216,14 +215,16 @@ export default function APIDocumentationPage({ metadata }) {
         backgroundColor={style.colors.BLUE_98}
       >
         <p>
-          PolicyEngine&apos;s REST API (https://api.policyengine.org) simulates
-          tax-benefit policy outcomes for households and populations.
+          PolicyEngine&apos;s REST API 
+          (<a href="https://household.api.policyengine.org">https://household.api.policyengine.org</a>) 
+          simulates tax-benefit policy outcomes and reform impacts for households. Access 
+          to the API requires an authentication token, which can be requested from PolicyEngine. 
+          This token will expire periodically. For more information, please feel free to 
+          contact PolicyEngine at <a href="mailto: hello@policyengine.org">hello@policyengine.org</a>.
         </p>
+        <br />
         <h4>On this page</h4>
         <ul>
-          <li>
-            <a href="#metadata">Get country-level metadata</a>
-          </li>
           <li>
             <a href="#calculate">Calculate household-level policy outcomes</a>
           </li>
@@ -233,110 +234,32 @@ export default function APIDocumentationPage({ metadata }) {
         </ul>
       </Section>
       <APIEndpoint
-        pattern={`/${countryId}/metadata`}
-        method="GET"
-        title="Get country-level metadata"
-        description="Returns country-level metadata."
-        exampleOutputJson={{
-          status: "ok",
-          message: null,
-          result: {
-            basicInputs: [
-              "variables in the default household questionnaire",
-              "age",
-            ],
-            current_law_id: "current-law policy ID",
-            economy_options: {
-              region: [
-                {
-                  name: "identifier of a geography, e.g. 'ut'",
-                  label: "sentence-safe label of a geography, e.g. 'Utah'",
-                },
-              ],
-              time_period: [
-                {
-                  name: "identifier of a time period, e.g. '2022'",
-                  label: "sentence-safe label, e.g. '2022'",
-                },
-              ],
-            },
-            entities: {
-              "entity name": {
-                doc: "entity description",
-                is_person: "whether the entity is a person or group",
-                key: "entity name",
-                label: "entity label",
-                plural: "entity plural",
-                roles: {
-                  "role name": {
-                    doc: "role description",
-                    label: "role label",
-                    plural: "role plural",
-                  },
-                },
-              },
-            },
-            parameters: {
-              "parameter name": {
-                description: "parameter description",
-                economy:
-                  "whether the parameter can be simulated for populations",
-                household:
-                  "whether the parameter can be simulated for households",
-                label: "parameter label",
-                parameter: "parameter address",
-                period: "period",
-                type: "parameter type",
-                unit: "parameter unit",
-                values: {
-                  "YYYY-MM-DD start date": "value",
-                },
-              },
-            },
-            variables: {
-              "variable name": {
-                adds: "summing variables if applicable",
-                category: "variable category",
-                defaultValue: "default value",
-                definitionPeriod: "definition period",
-                documentation: "variable description",
-                entity: "applicable entity key",
-                hidden_input: "whether the variable is hidden in the UI",
-                indexInModule: "index in parent folder",
-                isInputVariable: "whether the variable is an input variable",
-                label: "variable label",
-                moduleName: "folder name",
-                name: "variable name",
-                subtracts: "subtracting variables if applicable",
-                unit: "variable unit",
-                valueType: "variable type",
-              },
-            },
-            version: "version number",
-          },
-        }}
-      ></APIEndpoint>
-      <APIEndpoint
         pattern={`/${countryId}/calculate`}
         method="POST"
         title="Calculate household-level policy outcomes"
-        description="Returns household-level policy outcomes. Pass in a household object defining people, groups and any variable values (see the /metadata endpoint for a full list). Then, pass in null values for requested variables- these will be filled in with computed values. It's best practise to use the group/name/variable/optional time period/value structure."
+        description={`Returns household-level policy outcomes. Pass in a household object defining people, groups and any variable values (see the /metadata endpoint for a full list). Then, pass in null values for requested variables- these will be filled in with computed values. It's best ${metadata.countryId === "us" ? "practice" : "practise"} to use the group/name/variable/optional time period/value structure.`}
         exampleInputJson={{
           household: {
             people: {
               parent: {
-                age: 30,
-                employment_income: 20_000,
+                age: {
+                  [defaultYear]: 30
+                },
+                employment_income: {
+                  [defaultYear]: 20_000
+                }
               },
               child: {
-                age: 5,
+                age: {
+                  [defaultYear]: 5
+                }
               },
             },
             spm_units: {
               spm_unit: {
                 members: ["parent", "child"],
                 snap: {
-                  2024: null,
+                  [defaultYear]: null,
                 },
               },
             },
@@ -348,18 +271,24 @@ export default function APIDocumentationPage({ metadata }) {
           result: {
             people: {
               parent: {
-                age: 30,
-                employment_income: 20_000,
+                age: {
+                  [defaultYear]: 30
+                },
+                employment_income: {
+                  [defaultYear]: 20_000
+                }
               },
               child: {
-                age: 5,
+                age: {
+                  [defaultYear]: 5
+                }
               },
             },
             spm_units: {
               spm_unit: {
                 members: ["parent", "child"],
                 snap: {
-                  2024: 2833.5,
+                  [defaultYear]: 2833.5,
                 },
               },
             },

--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -84,7 +84,7 @@ function APIVariableCard(props) {
 }
 
 function VariableParameterExplorer(props) {
-  const { metadata } = props;
+  const { metadata, id } = props;
   const [query, setQuery] = useState("");
   const [selectedCardData, setSelectedCardData] = useState(null);
 
@@ -156,7 +156,7 @@ function VariableParameterExplorer(props) {
             marginLeft: 8,
           }}
         >
-          <h3>Variables and parameters</h3>
+          <h3 id={id}>Variables and parameters</h3>
         </div>
         <Input
           value={query}
@@ -232,10 +232,14 @@ export default function APIDocumentationPage({ metadata }) {
           <li>
             <a href="#variables">Variable and parameter metadata search</a>
           </li>
+          <li>
+            <a href="#playground">API playground</a>
+          </li>
         </ul>
       </Section>
       <APIEndpoint
         pattern={`/${countryId}/calculate`}
+        id="calculate"
         method="POST"
         title="Calculate household-level policy outcomes"
         description={`Returns household-level policy outcomes. Pass in a household object defining people, groups and any variable values (see the /metadata endpoint for a full list). Then, pass in null values for requested variables- these will be filled in with computed values. It's best ${metadata.countryId === "us" ? "practice" : "practise"} to use the group/name/variable/optional time period/value structure.`}
@@ -296,8 +300,8 @@ export default function APIDocumentationPage({ metadata }) {
           },
         }}
       />
-      <VariableParameterExplorer countryId={countryId} metadata={metadata} />
-      <Section title="API playground">
+      <VariableParameterExplorer id="variables" countryId={countryId} metadata={metadata} />
+      <Section title="API playground" id="playground">
         <p>Try out the API in this interactive demo.</p>
         <iframe
           src={`https://policyengine-policyengine-api-demo-app-xy5rgn.streamlit.app/~/+/?embed=true&embed_options=light_theme&mode=${countryId}`}
@@ -337,12 +341,13 @@ function APIEndpoint({
   children,
   exampleInputJson,
   exampleOutputJson,
+  id
 }) {
   const hasInput = Boolean(exampleInputJson);
 
   return (
     <Section>
-      <h3>{title}</h3>
+      <h3 id={id}>{title}</h3>
       <h5>
         <code>
           {method} {pattern}

--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -215,13 +215,17 @@ export default function APIDocumentationPage({ metadata }) {
         backgroundColor={style.colors.BLUE_98}
       >
         <p>
-          PolicyEngine&apos;s REST API 
-          (<a href="https://household.api.policyengine.org">https://household.api.policyengine.org</a>) 
-          simulates tax-benefit policy outcomes and reform impacts for households. Access 
-          to the API requires an authentication token, which will expire monthly for security reasons.
-          This token must be passed within the authorization heading of each request you make to the API. 
-          For more information or to request your own token, feel free to reach out to
-          PolicyEngine at <a href="mailto: hello@policyengine.org">hello@policyengine.org</a>.
+          PolicyEngine&apos;s REST API (
+          <a href="https://household.api.policyengine.org">
+            https://household.api.policyengine.org
+          </a>
+          ) simulates tax-benefit policy outcomes and reform impacts for
+          households. Access to the API requires an authentication token, which
+          will expire monthly for security reasons. This token must be passed
+          within the authorization heading of each request you make to the API.
+          For more information or to request your own token, feel free to reach
+          out to PolicyEngine at{" "}
+          <a href="mailto: hello@policyengine.org">hello@policyengine.org</a>.
         </p>
         <br />
         <h4>On this page</h4>
@@ -242,22 +246,24 @@ export default function APIDocumentationPage({ metadata }) {
         id="calculate"
         method="POST"
         title="Calculate household-level policy outcomes"
-        description={`Returns household-level policy outcomes. Pass in a household object defining people, groups and any variable values (see the /metadata endpoint for a full list). Then, pass in null values for requested variables- these will be filled in with computed values. It's best ${metadata.countryId === "us" ? "practice" : "practise"} to use the group/name/variable/optional time period/value structure.`}
+        description={`Returns household-level policy outcomes. Pass in a household object defining people, groups and any variable values (see the /metadata endpoint for a full list). Then, pass in null values for requested variables- these will be filled in with computed values. It's best ${
+          metadata.countryId === "us" ? "practice" : "practise"
+        } to use the group/name/variable/optional time period/value structure.`}
         exampleInputJson={{
           household: {
             people: {
               parent: {
                 age: {
-                  [defaultYear]: 30
+                  [defaultYear]: 30,
                 },
                 employment_income: {
-                  [defaultYear]: 20_000
-                }
+                  [defaultYear]: 20_000,
+                },
               },
               child: {
                 age: {
-                  [defaultYear]: 5
-                }
+                  [defaultYear]: 5,
+                },
               },
             },
             spm_units: {
@@ -277,16 +283,16 @@ export default function APIDocumentationPage({ metadata }) {
             people: {
               parent: {
                 age: {
-                  [defaultYear]: 30
+                  [defaultYear]: 30,
                 },
                 employment_income: {
-                  [defaultYear]: 20_000
-                }
+                  [defaultYear]: 20_000,
+                },
               },
               child: {
                 age: {
-                  [defaultYear]: 5
-                }
+                  [defaultYear]: 5,
+                },
               },
             },
             spm_units: {
@@ -300,7 +306,11 @@ export default function APIDocumentationPage({ metadata }) {
           },
         }}
       />
-      <VariableParameterExplorer id="variables" countryId={countryId} metadata={metadata} />
+      <VariableParameterExplorer
+        id="variables"
+        countryId={countryId}
+        metadata={metadata}
+      />
       <Section title="API playground" id="playground">
         <p>Try out the API in this interactive demo.</p>
         <iframe
@@ -341,7 +351,7 @@ function APIEndpoint({
   children,
   exampleInputJson,
   exampleOutputJson,
-  id
+  id,
 }) {
   const hasInput = Boolean(exampleInputJson);
 

--- a/src/redesign/components/Section.jsx
+++ b/src/redesign/components/Section.jsx
@@ -9,6 +9,7 @@ export default function Section({
   children,
   centeredTitle,
   titleStyle,
+  id
 }) {
   const displayCategory = useDisplayCategory();
   const sideMargin = {
@@ -61,7 +62,7 @@ export default function Section({
               alignItems: centeredTitle ? "center" : "baseline",
             }}
           >
-            <h2 style={{ color: "inherit", ...titleStyle }}>{title}</h2>
+            <h2 id={id} style={{ color: "inherit", ...titleStyle }}>{title}</h2>
           </div>
         )}
         {children}

--- a/src/redesign/components/Section.jsx
+++ b/src/redesign/components/Section.jsx
@@ -9,7 +9,7 @@ export default function Section({
   children,
   centeredTitle,
   titleStyle,
-  id
+  id,
 }) {
   const displayCategory = useDisplayCategory();
   const sideMargin = {
@@ -62,7 +62,9 @@ export default function Section({
               alignItems: centeredTitle ? "center" : "baseline",
             }}
           >
-            <h2 id={id} style={{ color: "inherit", ...titleStyle }}>{title}</h2>
+            <h2 id={id} style={{ color: "inherit", ...titleStyle }}>
+              {title}
+            </h2>
           </div>
         )}
         {children}


### PR DESCRIPTION
## Description

* Fixes #1259 by updating the API documentation to reflect our shift toward providing the household API publicly and using our own to host the PolicyEngine website
* Fixes #1265 by removing the `focus` parameter from the variable search input, preventing the app from immediately scrolling downward
* Fixes #1266 by correcting the API sample objects to include each variable's year
* Fixes #1267 by adding `id`'s to each section to ensure the internal links work properly

## Changes

In order to bring the API documentation up to date, this PR removes the fetch to our internal API's `metadata` endpoint and adds references to the need for an authentication token. However, I'm hoping the reviewers can confirm a couple things:
* Is the wording provided in the heading section satisfactory? And should there be more highlighting of the need for an authentication token?
* Should this updated page explicitly include code blocks demonstrate how to fetch the auth token via `client_id`, thereby enabling partners to do their own back-end token updating? Or should we ignore this and merely ask partners to request an updated token from us every month?

## Screenshots

Loom video available at https://www.loom.com/share/31aedce810144936a40f3306ac7548dd?sid=c795698a-1b81-4543-a77d-95782bc17730.

## Tests

N/A
