### PR TITLE
Rename title in PolicyBreakdown component

### DIFF
--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -142,6 +142,7 @@ export function DisplayImpact(props) {
   } else if (impactType === "policyBreakdown") {
     pane = (
       <PolicyBreakdown
+        policyLabel={policyLabel}
         metadata={metadata}
         impact={impact}
         timePeriod={timePeriod}

--- a/src/pages/policy/output/PolicyBreakdown.jsx
+++ b/src/pages/policy/output/PolicyBreakdown.jsx
@@ -1,14 +1,14 @@
 import style from "../../../style";
 
 export default function PolicyBreakdown(props) {
-  const { metadata, impact, timePeriod, region } = props;
+  const { policyLabel, metadata, impact, timePeriod, region } = props;
 
   const regionObj = metadata.economy_options.region.find(
     (elem) => elem.name === region,
   );
   const regionName = regionObj ? regionObj.label : "undefined region";
 
-  const title = `Your reform impact in ${regionName} over ${timePeriod}`;
+  const title = `${policyLabel} in ${regionName}, ${timePeriod}`;
   const bottomText =
     "Click on an option on the left panel to view more details.";
 


### PR DESCRIPTION
## Description

Fixes #1245.

## Changes

I basically passed policyLabel prop to PolicyBreakdown component from Display component and changed the title.

## Screenshots
![image](https://github.com/PolicyEngine/policyengine-app/assets/59489624/18309e4d-94ee-47fa-abf4-12c8f6e79507)
![image](https://github.com/PolicyEngine/policyengine-app/assets/59489624/2adf1cdc-9607-4aef-ae8a-d4b4d8021825)

## Tests

With make test. All tests passed