### PR TITLE
Revert "Repair Reproduce in Python code"

### DIFF
--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -1,5 +1,12 @@
-export function getReformDefinitionCode(policy) {
-  let lines = ["def modify_parameters(parameters):"];
+export function getReformDefinitionCode(metadata, policy) {
+  let lines = [
+    "from policyengine_core.reforms import Reform",
+    "from policyengine_core.periods import instant",
+    "import pandas as pd",
+    "",
+    "",
+    "def modify_parameters(parameters):",
+  ];
 
   if (Object.keys(policy.reform.data).length === 0) {
     lines.pop();
@@ -15,9 +22,15 @@ export function getReformDefinitionCode(policy) {
         value = "True";
       }
       lines.push(
-        `    parameters.${parameterName}.update(`,
-        `        start=instant("${start}"), stop=instant("${end}"),`,
-        `        value=${value})`,
+        "    parameters." +
+          parameterName +
+          '.update(start=instant("' +
+          start +
+          '"), stop=instant("' +
+          end +
+          '"), value=' +
+          value +
+          ")",
       );
     }
   }

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -22,7 +22,7 @@ export default function PolicyOutput(props) {
   if (impactType === "codeReproducibility") {
     return (
       <LowLevelDisplay {...props}>
-        <PolicyReproducibility metadata={metadata} policy={policy} />
+        <PolicyReproducibility metadata={metadata} policy={policy} />;
       </LowLevelDisplay>
     );
   } else if (impactType === "cliffImpact") {

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -1,23 +1,23 @@
 import CodeBlock from "layout/CodeBlock";
 import { getReformDefinitionCode } from "data/reformDefinitionCode";
 import { defaultYear } from "data/constants";
-import { useSearchParams } from "react-router-dom";
 import colors from "../../../redesign/style/colors";
-
-const US_REGIONS = ["us", "enhanced_us"];
 
 export default function PolicyReproducibility(props) {
   const { policy, metadata } = props;
-  const [searchParams] = useSearchParams();
-  const timePeriod = searchParams.get("timePeriod");
-  const region = searchParams.get("region");
 
-  let codeLines = [
-    ...getHeaderLines(metadata),
-    ...getBaselineDefinitionCode(region, policy),
-    ...getReformDefinitionCode(policy),
-    ...getImplementationCode(region, timePeriod),
-  ];
+  let initialLines = ["from " + metadata.package + " import Microsimulation"];
+
+  initialLines = initialLines.concat(getReformDefinitionCode(metadata, policy));
+
+  initialLines = initialLines.concat([
+    "baseline = Microsimulation()",
+    "reformed = Microsimulation(reform=reform)",
+    'HOUSEHOLD_VARIABLES = ["person_id", "household_id", "age", "household_net_income", "household_income_decile", "in_poverty", "household_tax", "household_benefits"]',
+    `baseline_person_df = baseline.calculate_dataframe(HOUSEHOLD_VARIABLES, ${defaultYear})`,
+    `reformed_person_df = reformed.calculate_dataframe(HOUSEHOLD_VARIABLES, ${defaultYear})`,
+    "difference_person_df = reformed_person_df - baseline_person_df",
+  ]);
 
   const colabLink =
     metadata.countryId === "uk"
@@ -48,7 +48,7 @@ export default function PolicyReproducibility(props) {
         Run the code below in a {notebookLink} to reproduce the microsimulation
         results.
       </p>
-      <CodeBlock lines={codeLines} language={"python"} />
+      <CodeBlock lines={initialLines} language={"python"} />
       <div
         style={{
           display: "flex",
@@ -59,73 +59,4 @@ export default function PolicyReproducibility(props) {
       ></div>
     </>
   );
-}
-
-function getHeaderLines(metadata) {
-  return [
-    "from " + metadata.package + " import Microsimulation",
-    "from policyengine_core.reforms import Reform",
-    "from policyengine_core.periods import instant",
-    "import pandas as pd",
-    "",
-    "",
-  ];
-}
-
-function getBaselineDefinitionCode(region, policy) {
-  if (!US_REGIONS.includes(region)) {
-    return [];
-  }
-
-  // Calculate the earliest start date and latest end date for
-  // the policies included in the simulation
-  let earliestStart = null;
-  let latestEnd = null;
-
-  for (const parameter of Object.keys(policy.reform.data)) {
-    for (const instant of Object.keys(policy.reform.data[parameter])) {
-      const [start, end] = instant.split(".");
-      if (!earliestStart || Date.parse(start) < Date.parse(earliestStart)) {
-        earliestStart = start;
-      }
-      if (!latestEnd || Date.parse(end) > Date.parse(latestEnd)) {
-        latestEnd = end;
-      }
-    }
-  }
-
-  return [
-    `"""`,
-    "In US nationwide simulations,",
-    "use reported state income tax liabilities",
-    `"""`,
-    "def modify_baseline(parameters):",
-    "    parameters.simulation.reported_state_income_tax.update(",
-    `        start=instant("${earliestStart}"), stop=instant("${latestEnd}"),`,
-    "        value=True)",
-    "    return parameters",
-    "",
-    "",
-    "class baseline_reform(Reform):",
-    "    def apply(self):",
-    "        self.modify_parameters(modify_baseline)",
-    "",
-    "",
-  ];
-}
-
-function getImplementationCode(region, timePeriod) {
-  const isCountryUS = US_REGIONS.includes(region);
-
-  return [
-    `baseline = Microsimulation(${
-      isCountryUS ? "reform=baseline_reform" : ""
-    })`,
-    "reformed = Microsimulation(reform=reform)",
-    `baseline_person = baseline.calc("household_net_income",`,
-    `    period=${timePeriod || defaultYear}, map_to="person")`,
-    `reformed_person = reformed.calc("household_net_income",`,
-    `    period=${timePeriod || defaultYear}, map_to="person")`,
-    "difference_person = reformed_person - baseline_person",
-  ];
 }


### PR DESCRIPTION
Fixes #1273. This reverts PolicyEngine/policyengine-app#1249, which introduced a bug by assuming that `reformDefinitionCode` was utilized only by the policy calculator side of the app and not the household, as well.