### PR TITLE
Fix Reproduce in Python page

### DIFF
--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -22,15 +22,9 @@ export function getReformDefinitionCode(metadata, policy) {
         value = "True";
       }
       lines.push(
-        "    parameters." +
-          parameterName +
-          '.update(start=instant("' +
-          start +
-          '"), stop=instant("' +
-          end +
-          '"), value=' +
-          value +
-          ")",
+        `    parameters.${parameterName}.update(`,
+        `        start=instant("${start}"), stop=instant("${end}"),`,
+        `        value=${value})`,
       );
     }
   }

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -22,7 +22,7 @@ export default function PolicyOutput(props) {
   if (impactType === "codeReproducibility") {
     return (
       <LowLevelDisplay {...props}>
-        <PolicyReproducibility metadata={metadata} policy={policy} />;
+        <PolicyReproducibility metadata={metadata} policy={policy} />
       </LowLevelDisplay>
     );
   } else if (impactType === "cliffImpact") {

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -68,9 +68,7 @@ function getHeaderLines(metadata) {
   // the overlap between household and policy, as long as HouseholdReproducibility
   // also is
 
-  return [
-    "from " + metadata.package + " import Microsimulation",
-  ];
+  return ["from " + metadata.package + " import Microsimulation"];
 }
 
 function getBaselineDefinitionCode(region, policy) {

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -1,23 +1,23 @@
 import CodeBlock from "layout/CodeBlock";
 import { getReformDefinitionCode } from "data/reformDefinitionCode";
 import { defaultYear } from "data/constants";
+import { useSearchParams } from "react-router-dom";
 import colors from "../../../redesign/style/colors";
+
+const US_REGIONS = ["us", "enhanced_us"];
 
 export default function PolicyReproducibility(props) {
   const { policy, metadata } = props;
+  const [searchParams] = useSearchParams();
+  const timePeriod = searchParams.get("timePeriod");
+  const region = searchParams.get("region");
 
-  let initialLines = ["from " + metadata.package + " import Microsimulation"];
-
-  initialLines = initialLines.concat(getReformDefinitionCode(metadata, policy));
-
-  initialLines = initialLines.concat([
-    "baseline = Microsimulation()",
-    "reformed = Microsimulation(reform=reform)",
-    'HOUSEHOLD_VARIABLES = ["person_id", "household_id", "age", "household_net_income", "household_income_decile", "in_poverty", "household_tax", "household_benefits"]',
-    `baseline_person_df = baseline.calculate_dataframe(HOUSEHOLD_VARIABLES, ${defaultYear})`,
-    `reformed_person_df = reformed.calculate_dataframe(HOUSEHOLD_VARIABLES, ${defaultYear})`,
-    "difference_person_df = reformed_person_df - baseline_person_df",
-  ]);
+  let codeLines = [
+    ...getHeaderLines(metadata),
+    ...getReformDefinitionCode(metadata, policy),
+    ...getBaselineDefinitionCode(region, policy),
+    ...getImplementationCode(region, timePeriod),
+  ];
 
   const colabLink =
     metadata.countryId === "uk"
@@ -48,7 +48,7 @@ export default function PolicyReproducibility(props) {
         Run the code below in a {notebookLink} to reproduce the microsimulation
         results.
       </p>
-      <CodeBlock lines={initialLines} language={"python"} />
+      <CodeBlock lines={codeLines} language={"python"} />
       <div
         style={{
           display: "flex",
@@ -59,4 +59,74 @@ export default function PolicyReproducibility(props) {
       ></div>
     </>
   );
+}
+
+function getHeaderLines(metadata) {
+  // Note that all other header lines are currently provided by getReformDefinitionCode;
+  // this could be refactored in the future to create clearer distinctions between
+  // code segments and/or create a shared "Reproducibility" component, considering
+  // the overlap between household and policy, as long as HouseholdReproducibility
+  // also is
+
+  return [
+    "from " + metadata.package + " import Microsimulation",
+  ];
+}
+
+function getBaselineDefinitionCode(region, policy) {
+  if (!US_REGIONS.includes(region)) {
+    return [];
+  }
+
+  // Calculate the earliest start date and latest end date for
+  // the policies included in the simulation
+  let earliestStart = null;
+  let latestEnd = null;
+
+  for (const parameter of Object.keys(policy.reform.data)) {
+    for (const instant of Object.keys(policy.reform.data[parameter])) {
+      const [start, end] = instant.split(".");
+      if (!earliestStart || Date.parse(start) < Date.parse(earliestStart)) {
+        earliestStart = start;
+      }
+      if (!latestEnd || Date.parse(end) > Date.parse(latestEnd)) {
+        latestEnd = end;
+      }
+    }
+  }
+
+  return [
+    `"""`,
+    "In US nationwide simulations,",
+    "use reported state income tax liabilities",
+    `"""`,
+    "def modify_baseline(parameters):",
+    "    parameters.simulation.reported_state_income_tax.update(",
+    `        start=instant("${earliestStart}"), stop=instant("${latestEnd}"),`,
+    "        value=True)",
+    "    return parameters",
+    "",
+    "",
+    "class baseline_reform(Reform):",
+    "    def apply(self):",
+    "        self.modify_parameters(modify_baseline)",
+    "",
+    "",
+  ];
+}
+
+function getImplementationCode(region, timePeriod) {
+  const isCountryUS = US_REGIONS.includes(region);
+
+  return [
+    `baseline = Microsimulation(${
+      isCountryUS ? "reform=baseline_reform" : ""
+    })`,
+    "reformed = Microsimulation(reform=reform)",
+    `baseline_person = baseline.calc("household_net_income",`,
+    `    period=${timePeriod || defaultYear}, map_to="person")`,
+    `reformed_person = reformed.calc("household_net_income",`,
+    `    period=${timePeriod || defaultYear}, map_to="person")`,
+    "difference_person = reformed_person - baseline_person",
+  ];
 }


### PR DESCRIPTION
## Description

Fixes #1179. 

## Changes

Like the previously reverted PR, #1249, this PR refactors the `PolicyReproducibility` component, but unlike it, it avoids refactoring `reformDefinitionCode.js` in favor of placing the reform definition elements above the baseline definition within US policy contexts. Though a more comprehensive refactor could be beneficial, I feel that the proper direction (to merge both household and policy into a shared component, considering the overlap in the two outputs, and then determining whether or not a reform definition is needed within the resulting component) is too invasive for this PR, considering the risk of such an overhaul introducing buggy outputs. This is especially true considering that the alternative, placing the baseline definition below the reform, is an incredibly minor difference from the originally desired output.

## Screenshots

A Loom video of the component in action is available [here](https://www.loom.com/share/6419ef27e13c4b98aa4d9a73ae2c1137?sid=4d219613-5386-46da-be4d-3c5c6880b9f4).

## Tests

None have been added in this PR.
