### PR TITLE
Change poverty rate wording on policy overview page

### DIFF
--- a/src/pages/policy/output/PolicyBreakdown.jsx
+++ b/src/pages/policy/output/PolicyBreakdown.jsx
@@ -258,7 +258,7 @@ function formatDesc(value, type) {
   // to enable proper string construction
   const templateStrings = {
     budgetaryImpact: [`${action}`, ""],
-    povertyRateChange: [`${action} the poverty rate by`, ""],
+    povertyRateChange: [`${action} poverty by`, ""],
     winnersPercent:
       "Your reform would raise the net income for this percent " +
       "of the population:",


### PR DESCRIPTION
## Description

Fixes #1271.

## Changes

This PR changes the wording of the poverty rate change section of the `PolicyBreakdown` (overview) component to `(Raises | Lowers) poverty by X%`.

## Screenshots

Screenshot below
<img width="1440" alt="Screen Shot 2024-01-24 at 5 14 09 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/16ddec14-70bc-48d5-b2be-a34024b6b4c7">

## Tests

No tests have been added.
