### PR TITLE
fix: revert commit 4fa4ad9 to fix blog.image error

### DIFF
--- a/src/redesign/components/HomeBlogPreview.jsx
+++ b/src/redesign/components/HomeBlogPreview.jsx
@@ -17,9 +17,7 @@ export default function HomeBlogPreview() {
         (post.tags.includes(countryId) || post.tags.includes("global")),
     ) || [];
   const allPosts = posts.filter(
-    (post) =>
-      (post.tags.includes(countryId) || post.tags.includes("global")) &&
-      !featuredPosts.includes(post),
+    (post) => post.tags.includes(countryId) || post.tags.includes("global"),
   );
   const displayCategory = useDisplayCategory();
   return (


### PR DESCRIPTION
## Description

We fix #1286 by temporarily reverting https://github.com/PolicyEngine/policyengine-app/commit/4fa4ad953712a708d8aea1c8b3ce0e6a20515930.

## Screenshots

Seems to fix the problem on an iPad simulator:

![Simulator Screenshot - myIpad - 2024-01-26 at 22 21 42](https://github.com/PolicyEngine/policyengine-app/assets/31144719/39416d98-8ee5-4a18-8b72-362d532bb6ef)

