### PR TITLE
Add proper error handling to getNewPolicyId

### DIFF
--- a/src/api/parameters.js
+++ b/src/api/parameters.js
@@ -70,6 +70,17 @@ export function buildParameterTree(parameters) {
   return tree.children.find((child) => child.name === "gov");
 }
 
+/**
+ * Creates new policy record within API and returns the record's ID,
+ * or an error message
+ * @param {String} countryId 
+ * @param {Object} newPolicyData The new policy's data object
+ * @param {String} newPolicyLabel The new policy's label
+ * @returns {Object} An object with three keys: "status", which is 
+ * the "status" value returned by the request; "message", the message 
+ * returned by the API; and "policy_id", the ID of the record created 
+ * by the API
+ */
 export function getNewPolicyId(countryId, newPolicyData, newPolicyLabel) {
   let submission = { data: newPolicyData };
   if (newPolicyLabel) {
@@ -78,10 +89,15 @@ export function getNewPolicyId(countryId, newPolicyData, newPolicyLabel) {
   return countryApiCall(countryId, "/policy", submission, "POST")
     .then((response) => response.json())
     .then((data) => {
-      if (data.status === "error") {
-        return data;
+      let result = {};
+      if (data.status === "ok") {
+        result.policy_id = data.result.policy_id;
+      } else {
+        result.policy_id = undefined;
       }
-      return data.result.policy_id;
+      result.message = data.message
+      result.status = data.status;
+      return result;
     });
 }
 

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -215,7 +215,7 @@ function PolicyNamer(props) {
           onChange={(name) => {
             getNewPolicyId(metadata.countryId, policy.reform.data, name).then(
               (data) => {
-                if (data.status) {
+                if (data.status !== "ok") {
                   setError(data.message);
                   let newSearch = copySearchParams(searchParams);
                   newSearch.set("renamed", true);

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -61,10 +61,15 @@ export default function ParameterEditor(props) {
     } else {
       const newReforms = { ...policy.reform.data };
       newReforms[parameterName] = diffData;
-      getNewPolicyId(metadata.countryId, newReforms).then((newPolicyId) => {
-        let newSearch = copySearchParams(searchParams);
-        newSearch.set("reform", newPolicyId);
-        setSearchParams(newSearch);
+      getNewPolicyId(metadata.countryId, newReforms).then((result) => {
+        if (result.status !== "ok") {
+          console.error("ParameterEditor: In attempting to fetch new " +
+          "policy, the following error occurred: " + result.message);
+        } else {
+          let newSearch = copySearchParams(searchParams);
+          newSearch.set("reform", result.policy_id);
+          setSearchParams(newSearch);
+        }
       });
     }
   }


### PR DESCRIPTION
## Description

Fixes #1293. Currently, `getNewPolicyId` fetches a policy ID correctly, but does so in a manner that introduces two issues:
1. Errors are returned in an opaque manner, making it difficult for the developer to determine if an error has occurred within the API call this function opens
2. Only the policy ID is returned, which seems strange, considering that in the case of an error, an entire data object is returned

## Changes

This PR changes the function so that it returns an object containing three things:
* The "message" parameter of the API response
* The "status" parameter of the API response
* The policy ID of the record created by the API call, unless an error occurred, in which case `undefined` is returned

This should allow the function caller to merely check if `output.status` doesn't equal "ok". This PR also changes the two points at which this function is called to ensure its proper usage.

While this PR isn't essential to #1165, #1166, #1167, and #972, it would be extremely beneficial, especially considering its small size, as it would simplify error testing.

## Screenshots

The changes in action are visible in the Loom video [here](https://www.loom.com/share/bd1d5347725144e2b9a607be953dd341?sid=aa8471cc-287a-4ac6-9e80-eae466f3290f). The video is meant to demonstrate that, in the two components where `getNewPolicyId` is currently in use (`ParameterEditor` and `PolicyNamer`), each component works as it did previously.

## Tests

No tests have been added.
