### PR TITLE
Pass year parameter through to VariableArithmetic component from NetIncomeBreakdown

### DIFF
--- a/src/pages/household/output/NetIncomeBreakdown.jsx
+++ b/src/pages/household/output/NetIncomeBreakdown.jsx
@@ -194,6 +194,7 @@ function VariableArithmetic(props) {
       householdReform={householdReform}
       metadata={metadata}
       key={variable}
+      year={year}
       // Every node increases (positive),
       // decreases (negative), or does nothing
       // to income (neutral).
@@ -209,6 +210,7 @@ function VariableArithmetic(props) {
     .filter(shouldShowVariable)
     .map((variable) => (
       <VariableArithmetic
+        year={year}
         variableName={variable}
         householdBaseline={householdBaseline}
         householdReform={householdReform}
@@ -313,7 +315,8 @@ function VariableArithmetic(props) {
 }
 
 export default function NetIncomeBreakdown(props) {
-  const { metadata, householdBaseline, householdReform, policyLabel } = props;
+  const { metadata, householdBaseline, householdReform, policyLabel, year } =
+    props;
   const hasReform = !!householdReform;
   const getValue = (variable) =>
     getValueFromHousehold(variable, null, null, householdBaseline, metadata);
@@ -362,6 +365,7 @@ export default function NetIncomeBreakdown(props) {
       >
         <div style={{ height: 10 }} />
         <VariableArithmetic
+          year={year}
           variableName="household_net_income"
           householdBaseline={householdBaseline}
           householdReform={householdReform}


### PR DESCRIPTION
## Description

Fixes #1297. For each household, the `VariableArithmetic` component recursively creates subsets of itself to build the dropdown menu visible within the `NetIncomeBreakdown` component by assembling a list of variables that add to or subtract from the household's net income. In certain cases (where a particular variable is a `parameter` within the country tax model), this requires determining a value from the household. When these variables were passed to the `getParameterAtInstant` function, the function would fail, returning `undefined`, causing the runtime error when the app would later attempt to derive a value from `undefined`.

## Changes

This PR passes the `year` prop from `NetIncomeBreakdown` to `VariableArithmetic` to allow for the proper passing of an "instant" parameter to the `getParameterAtInstant` function. This, in turn, allows it to properly fetch values from the household.

## Screenshots

A Loom video of the changes in action is available [here](https://www.loom.com/share/78626d584db441bdbcaf76f22edbb8cb?sid=9172fb83-cee6-4871-b2b9-26956585aaea).

## Tests

None have been added.
