### PR TITLE
Show currency messages correctly in policy output charts for the uk locale

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,12 @@ import "./redesign/style/App.css";
 import PolicyEngine from "./redesign/components/PolicyEngine.jsx";
 import * as serviceWorkerRegistration from "./serviceWorkerRegistration.js";
 import { BrowserRouter as Router } from "react-router-dom";
+import loc_en_gb from "./lang/plotly_locales/locale-en-gb.js";
+import loc_en_us from "./lang/plotly_locales/locale-en-us.js";
 
+var Plotly = require("plotly.js/dist/plotly.js");
+Plotly.register(loc_en_gb);
+Plotly.register(loc_en_us);
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <Router>

--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -29,7 +29,7 @@ function ImpactPlot(props) {
       maximumFractionDigits: 1,
     });
   const formatCur = (x) =>
-    formatCurrencyAbbr(x, metadata, {
+    formatCurrencyAbbr(x, metadata.countryId, {
       maximumFractionDigits: 1,
     });
   const hoverMessage = (x) => {

--- a/src/pages/policy/output/LaborSupplyResponse.jsx
+++ b/src/pages/policy/output/LaborSupplyResponse.jsx
@@ -28,7 +28,7 @@ function ImpactPlot(props) {
               : ["total"],
           textposition: "inside",
           text: values.map((value) =>
-            formatCurrencyAbbr(value * 1e9, metadata, {
+            formatCurrencyAbbr(value * 1e9, metadata.countryId, {
               maximumFractionDigits: 1,
             }),
           ),
@@ -88,7 +88,7 @@ function title(policyLabel, change, metadata) {
   const region = regionName(metadata);
   const regionPhrase = region ? ` in ${region}` : "";
   const term1 = `employment income${regionPhrase}`;
-  const term2 = formatCurrencyAbbr(Math.abs(change * 1e9), metadata, {
+  const term2 = formatCurrencyAbbr(Math.abs(change * 1e9), metadata.countryId, {
     maximumFractionDigits: 1,
   });
   const signTerm = change > 0 ? "increase" : "decrease";

--- a/src/pages/policy/output/budget/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/budget/BudgetaryImpact.jsx
@@ -14,7 +14,7 @@ function ImpactPlot(props) {
   const xArray = labels.length > 0 ? labels : ["Net impact"];
   const yArray = labels.length > 0 ? values : [budgetaryImpact / 1e9];
   const formatCur = (x) =>
-    formatCurrencyAbbr(x, metadata, {
+    formatCurrencyAbbr(x, metadata.countryId, {
       maximumFractionDigits: 1,
     });
   const hoverMessage = (x, y) => {
@@ -130,7 +130,7 @@ function ImpactPlot(props) {
 
 export function title(policyLabel, change, metadata) {
   const term1 = "the budget";
-  const term2 = formatCurrencyAbbr(Math.abs(change), metadata, {
+  const term2 = formatCurrencyAbbr(Math.abs(change), metadata.countryId, {
     maximumFractionDigits: 1,
   });
   const signTerm = change > 0 ? "raise" : "cost";

--- a/src/pages/policy/output/budget/DetailedBudgetaryImpact.jsx
+++ b/src/pages/policy/output/budget/DetailedBudgetaryImpact.jsx
@@ -14,7 +14,7 @@ function ImpactPlot(props) {
     props;
   const setHoverCard = useContext(HoverCardContext);
   const formatCur = (x) =>
-    formatCurrencyAbbr(x, metadata, {
+    formatCurrencyAbbr(x, metadata.countryId, {
       maximumFractionDigits: 1,
     });
   function hoverMessage(x, y) {

--- a/src/redesign/components/PolicyEngine.jsx
+++ b/src/redesign/components/PolicyEngine.jsx
@@ -20,8 +20,6 @@ import Header from "./Header";
 import Testimonials from "./Testimonials";
 import CalculatorInterstitial from "./CalculatorInterstitial";
 import CitizensEconomicCouncil from "./CitizensEconomicCouncil";
-import loc_en_gb from "../../lang/plotly_locales/locale-en-gb.js";
-import loc_en_us from "../../lang/plotly_locales/locale-en-us.js";
 import APIDocumentationPage from "./APIDocumentationPage";
 import CookieConsent from "layout/CookieConsent";
 import TrafwaCalculator from "./TrafwaCalculator";
@@ -40,9 +38,6 @@ function ScrollToTop() {
 }
 
 export default function PolicyEngine({ pathname }) {
-  var Plotly = require("plotly.js/dist/plotly.js");
-  Plotly.register(loc_en_gb);
-  Plotly.register(loc_en_us);
   const COUNTRIES = ["us", "uk", "ca", "ng", "il"];
 
   // First, check if the country is specified (.org/[country]/...)


### PR DESCRIPTION
## Description

We fix #1303 by using `metadata.countryId` in all calls to `formatCurrencyAbbr` instead of `metadata`. This error must have crept in during a refactor.

We also move plotly locale registration to `index.js` -- before this change, the registration was being called on every render of `PolicyEngine`.

## Screenshots

UK locale:

<img width="800" alt="Screenshot 2024-02-01 at 9 46 52 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/6c6ce92f-63bc-4e4f-8230-19c0a0a86ab8">

<img width="800" alt="Screenshot 2024-02-01 at 9 49 06 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/28e47556-f19c-4b00-9b7e-aa4fd228ffc3">

------------

US locale:

<img width="800" alt="Screenshot 2024-02-01 at 9 52 08 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/04b79cda-c3af-4946-baab-adb1c4c058bf">


## Tests

We tested the affected charts on both locales.
