### PR TITLE
Properly refer to country ID in API documentation page

### DIFF
--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -247,7 +247,7 @@ export default function APIDocumentationPage({ metadata }) {
         method="POST"
         title="Calculate household-level policy outcomes"
         description={`Returns household-level policy outcomes. Pass in a household object defining people, groups and any variable values (see the /metadata endpoint for a full list). Then, pass in null values for requested variables- these will be filled in with computed values. It's best ${
-          metadata.countryId === "us" ? "practice" : "practise"
+          countryId} === "us" ? "practice" : "practise"
         } to use the group/name/variable/optional time period/value structure.`}
         exampleInputJson={{
           household: {

--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -246,8 +246,7 @@ export default function APIDocumentationPage({ metadata }) {
         id="calculate"
         method="POST"
         title="Calculate household-level policy outcomes"
-        description={`Returns household-level policy outcomes. Pass in a household object defining people, groups and any variable values (see the /metadata endpoint for a full list). Then, pass in null values for requested variables- these will be filled in with computed values. It's best ${
-          countryId} === "us" ? "practice" : "practise"
+        description={`Returns household-level policy outcomes. Pass in a household object defining people, groups and any variable values (see the /metadata endpoint for a full list). Then, pass in null values for requested variables- these will be filled in with computed values. It's best ${countryId} === "us" ? "practice" : "practise"
         } to use the group/name/variable/optional time period/value structure.`}
         exampleInputJson={{
           household: {


### PR DESCRIPTION
## Description

Fixes #1311. In a previous PR, some code to localize text on the page erroneously refers to `metadata.countryId`, which does not exist. This would return `null`, causing the page to crash. The code now correctly refers to the `countryId` that comes from the URL parameters

## Changes

Reactivates the API documentation page by referring to the correct country ID code

## Screenshots

A Loom video demonstrating the restored component is available at https://www.loom.com/share/2c0506ce5c8e40b8b3745ae28da9bba9.

## Tests

None have been added at this time.
