### PR TITLE
Clear reform only when all parameters are deleted or reset to baseline

### DIFF
--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -54,12 +54,15 @@ export default function ParameterEditor(props) {
   function onChange(value) {
     reformMap.set(startDate, nextDay(endDate), value);
     const diffData = diff();
-    if (Object.keys(diffData).length === 0) {
+    const newReforms = { ...policy.reform.data };
+    if (
+      Object.keys(diffData).length === 0 &&
+      Object.keys(newReforms).length === 1
+    ) {
       let newSearch = copySearchParams(searchParams);
       newSearch.delete("reform");
       setSearchParams(newSearch);
     } else {
-      const newReforms = { ...policy.reform.data };
       newReforms[parameterName] = diffData;
       getNewPolicyId(metadata.countryId, newReforms).then((result) => {
         if (result.status !== "ok") {


### PR DESCRIPTION
## Description

We fix #1316 by deleting the reform only when the last parameter is reset to baseline. The bug was due to deleting the reform when the *current* parameter is reset to baseline. Now, we also check that the current parameter is the *last* parameter before deletion.

## Tests

We tested the change on a couple of walkthroughs.
