### PR TITLE
Disable zoom on y-axis for policy output charts

### DIFF
--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -96,6 +96,7 @@ function ImpactPlot(props) {
         yaxis: {
           title: "Relative change",
           tickformat: `+,.${ytickPrecision}%`,
+          fixedrange: true,
         },
         ...(useHoverCard
           ? {}

--- a/src/pages/policy/output/InequalityImpact.jsx
+++ b/src/pages/policy/output/InequalityImpact.jsx
@@ -85,6 +85,7 @@ function ImpactPlot(props) {
         yaxis: {
           title: "Relative change",
           tickformat: `,.${ytickPrecision}%`,
+          fixedrange: true,
         },
         ...(useHoverCard
           ? {}

--- a/src/pages/policy/output/LaborSupplyResponse.jsx
+++ b/src/pages/policy/output/LaborSupplyResponse.jsx
@@ -53,6 +53,7 @@ function ImpactPlot(props) {
         yaxis: {
           title: "Employment income (bn)",
           tickformat: "$,.1f",
+          fixedrange: true,
         },
         hoverlabel: {
           align: "left",

--- a/src/pages/policy/output/budget/BudgetaryImpact.jsx
+++ b/src/pages/policy/output/budget/BudgetaryImpact.jsx
@@ -78,6 +78,7 @@ function ImpactPlot(props) {
         yaxis: {
           title: "Budgetary impact (bn)",
           tickformat: "$,.1f",
+          fixedrange: true,
         },
         ...(useHoverCard
           ? {}

--- a/src/pages/policy/output/budget/DetailedBudgetaryImpact.jsx
+++ b/src/pages/policy/output/budget/DetailedBudgetaryImpact.jsx
@@ -77,6 +77,7 @@ function ImpactPlot(props) {
         yaxis: {
           title: "Budgetary impact (bn)",
           tickformat: "$,.1f",
+          fixedrange: true,
         },
         ...(useHoverCard
           ? {}

--- a/src/pages/policy/output/decile/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/decile/AverageImpactByDecile.jsx
@@ -76,6 +76,7 @@ export function ImpactPlot(props) {
         yaxis: {
           title: "Average change in household income",
           tickformat: `$,.${ytickPrecision}f`,
+          fixedrange: true,
         },
         ...(useHoverCard
           ? {}

--- a/src/pages/policy/output/decile/IntraDecileImpact.jsx
+++ b/src/pages/policy/output/decile/IntraDecileImpact.jsx
@@ -121,11 +121,13 @@ export function ImpactPlot(props) {
           matches: "x2",
           showgrid: false,
           showticklabels: false,
+          fixedrange: true,
         },
         xaxis2: {
           title: "Population share",
           tickformat: ".0%",
           anchor: "y2",
+          fixedrange: true,
         },
         yaxis2: {
           title: yaxistitle,

--- a/src/pages/policy/output/decile/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/decile/RelativeImpactByDecile.jsx
@@ -68,6 +68,7 @@ export function ImpactPlot(props) {
         yaxis: {
           title: "Relative change in household income",
           tickformat: `+,.${ytickPrecision}%`,
+          fixedrange: true,
         },
         ...(useHoverCard
           ? {}

--- a/src/pages/policy/output/poverty/PovertyImpact.jsx
+++ b/src/pages/policy/output/poverty/PovertyImpact.jsx
@@ -70,6 +70,7 @@ export function ImpactPlot(props) {
         yaxis: {
           title: `Relative change in ${povertyType} rate`,
           tickformat: `+,.${ytickPrecision}%`,
+          fixedrange: true,
         },
         ...(useHoverCard
           ? {}

--- a/src/pages/policy/output/poverty/PovertyImpactByGender.jsx
+++ b/src/pages/policy/output/poverty/PovertyImpactByGender.jsx
@@ -78,6 +78,7 @@ export function ImpactPlot(props) {
         yaxis: {
           title: `Relative change in ${povertyType} rate`,
           tickformat: `+,.${ytickPrecision}%`,
+          fixedrange: true,
         },
         ...(useHoverCard
           ? {}

--- a/src/pages/policy/output/poverty/PovertyImpactByRace.jsx
+++ b/src/pages/policy/output/poverty/PovertyImpactByRace.jsx
@@ -75,6 +75,7 @@ function ImpactPlot(props) {
         yaxis: {
           title: "Relative change in poverty rate",
           tickformat: `+,.${ytickPrecision}%`,
+          fixedrange: true,
         },
         ...(useHoverCard
           ? {}


### PR DESCRIPTION
## Description

We fix #1310 by disabling zoom on the y-axis. The x-axis can still be zoomed:

![Screen Recording 2024-02-02 at 6 29 06 PM](https://github.com/PolicyEngine/policyengine-app/assets/31144719/9ae1cede-fb32-4be5-b03e-75cdb0780f70)
