### PR TITLE
Enable parameter editing indefinitely in the future

### DIFF
--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -140,9 +140,7 @@ export default function ParameterEditor(props) {
           setStartDate(dateStrings[0]);
           setEndDate(dateStrings[1]);
         }}
-        disabledDate={(date) =>
-          date.isBefore("2021-01-01") || date.isAfter("2026-12-31")
-        }
+        disabledDate={(date) => date.isBefore("2021-01-01")}
         separator="→"
       />
       {control}


### PR DESCRIPTION
## Description

We fix #1317 by enabling dates after 2026:

<img width="800" alt="Screenshot 2024-02-02 at 7 47 54 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/1f9ba13b-875d-4baa-b370-18abf5eaacfd">
