### PR TITLE
Hide featured stories from non-featured blog post display

### DIFF
--- a/src/redesign/components/HomeBlogPreview.jsx
+++ b/src/redesign/components/HomeBlogPreview.jsx
@@ -17,7 +17,9 @@ export default function HomeBlogPreview() {
         (post.tags.includes(countryId) || post.tags.includes("global")),
     ) || [];
   const allPosts = posts.filter(
-    (post) => post.tags.includes(countryId) || post.tags.includes("global"),
+    (post) =>
+      (post.tags.includes(countryId) || post.tags.includes("global")) &&
+      !featuredPosts.includes(post),
   );
   const displayCategory = useDisplayCategory();
   return (

--- a/src/redesign/components/HomeBlogPreview.jsx
+++ b/src/redesign/components/HomeBlogPreview.jsx
@@ -83,7 +83,7 @@ function ReadMore() {
 
 function DesktopBlogPreview({ featuredPosts, allPosts }) {
   const rightColumnPosts = allPosts?.slice(0, 4);
-  const firstRowPosts = allPosts?.slice(6, 9);
+  const firstRowPosts = allPosts?.slice(4, 7);
 
   return (
     <SectionBottom backgroundColor={style.colors.LIGHT_GRAY}>
@@ -139,6 +139,10 @@ function DesktopBlogPreview({ featuredPosts, allPosts }) {
 }
 
 function TabletBlogPreview({ featuredPosts, allPosts }) {
+  const smallPosts = allPosts.slice(0, 4);
+  const leftHandPost = allPosts.slice(4,5);
+  const bottomPosts = allPosts.slice(5,7);
+
   return (
     <SectionBottom>
       <div style={{ marginTop: 50, display: "flex", flexDirection: "row" }}>
@@ -153,7 +157,7 @@ function TabletBlogPreview({ featuredPosts, allPosts }) {
         }}
       >
         <div style={{ flex: 1 }}>
-          <MediumBlogPreview blog={allPosts[4]} />
+          <MediumBlogPreview blog={leftHandPost[0]} />
         </div>
         <div style={{ width: 40 }} />
         <div
@@ -164,13 +168,16 @@ function TabletBlogPreview({ featuredPosts, allPosts }) {
             justifyContent: "space-between",
           }}
         >
-          <SmallBlogPreview blog={allPosts[0]} />
-          <div style={{ height: 40 }} />
-          <SmallBlogPreview blog={allPosts[1]} />
-          <div style={{ height: 40 }} />
-          <SmallBlogPreview blog={allPosts[2]} />
-          <div style={{ height: 40 }} />
-          <SmallBlogPreview blog={allPosts[3]} />
+          {smallPosts?.map((post, index) => (
+            <>
+              <SmallBlogPreview key={post.slug} blog={post} />
+              {
+                index !== smallPosts.length - 1 && (
+                  <div style={{ height: 40 }} />
+                )
+              }
+            </>
+          ))}
         </div>
       </div>
       <div
@@ -181,9 +188,16 @@ function TabletBlogPreview({ featuredPosts, allPosts }) {
           marginTop: 40,
         }}
       >
-        <MediumBlogPreview blog={allPosts[7]} />
-        <div style={{ width: 40 }} />
-        <MediumBlogPreview blog={allPosts[8]} />
+        {bottomPosts?.map((post, index) => (
+          <>
+            <MediumBlogPreview key={post.slug} blog={post} />
+            {
+              index !== bottomPosts.length - 1 && (
+                <div style={{ width: 40 }} />
+              )
+            }
+          </>
+        ))}
       </div>
       <ReadMore />
     </SectionBottom>
@@ -191,6 +205,7 @@ function TabletBlogPreview({ featuredPosts, allPosts }) {
 }
 
 function MobileBlogPreview({ featuredPosts, allPosts }) {
+  const smallPosts = allPosts.slice(0, 4);
   return (
     <div>
       <div
@@ -202,7 +217,7 @@ function MobileBlogPreview({ featuredPosts, allPosts }) {
         }}
       >
         <div style={{ minWidth: 20 }} />
-        {featuredPosts.map((blog, i) => (
+        {featuredPosts.map((post, i) => (
           <div
             key={i}
             style={{
@@ -212,7 +227,7 @@ function MobileBlogPreview({ featuredPosts, allPosts }) {
               height: "100%",
             }}
           >
-            <MediumBlogPreview blog={blog} />
+            <MediumBlogPreview blog={post} />
           </div>
         ))}
         <div style={{ minWidth: 20 }} />
@@ -226,13 +241,16 @@ function MobileBlogPreview({ featuredPosts, allPosts }) {
             justifyContent: "space-between",
           }}
         >
-          <SmallBlogPreview blog={allPosts[5]} />
-          <div style={{ height: 40 }} />
-          <SmallBlogPreview blog={allPosts[6]} />
-          <div style={{ height: 40 }} />
-          <SmallBlogPreview blog={allPosts[7]} />
-          <div style={{ height: 40 }} />
-          <SmallBlogPreview blog={allPosts[8]} />
+          {smallPosts?.map((post, index) => (
+            <>
+              <SmallBlogPreview key={post.slug} blog={post} />
+              {
+                index !== smallPosts.length - 1 && (
+                  <div style={{ height: 40 }} />
+                )
+              }
+            </>
+          ))}
         </div>
         <ReadMore />
       </SectionBottom>
@@ -337,7 +355,7 @@ export function FeaturedBlogPreview({ blogs, width, imageHeight }) {
       >
         <img
           src={imageUrl}
-          alt={currentBlog.coverAltText || `{blog.title} cover image`}
+          alt={currentBlog.coverAltText || `${currentBlog.title} cover image`}
           width="100%"
           height={imageHeight || (displayCategory === "desktop" ? 450 : 400)}
           style={{
@@ -395,7 +413,7 @@ export function MediumBlogPreview({ blog, minHeight }) {
       <div>
         <img
           src={imageUrl}
-          alt={blog.coverAltText || `{blog.title} cover image`}
+          alt={blog.coverAltText || `${blog.title} cover image`}
           height={300}
           width="100%"
           style={{

--- a/src/redesign/components/HomeBlogPreview.jsx
+++ b/src/redesign/components/HomeBlogPreview.jsx
@@ -140,8 +140,8 @@ function DesktopBlogPreview({ featuredPosts, allPosts }) {
 
 function TabletBlogPreview({ featuredPosts, allPosts }) {
   const smallPosts = allPosts.slice(0, 4);
-  const leftHandPost = allPosts.slice(4,5);
-  const bottomPosts = allPosts.slice(5,7);
+  const leftHandPost = allPosts.slice(4, 5);
+  const bottomPosts = allPosts.slice(5, 7);
 
   return (
     <SectionBottom>
@@ -171,11 +171,9 @@ function TabletBlogPreview({ featuredPosts, allPosts }) {
           {smallPosts?.map((post, index) => (
             <>
               <SmallBlogPreview key={post.slug} blog={post} />
-              {
-                index !== smallPosts.length - 1 && (
-                  <div style={{ height: 40 }} />
-                )
-              }
+              {index !== smallPosts.length - 1 && (
+                <div style={{ height: 40 }} />
+              )}
             </>
           ))}
         </div>
@@ -191,11 +189,7 @@ function TabletBlogPreview({ featuredPosts, allPosts }) {
         {bottomPosts?.map((post, index) => (
           <>
             <MediumBlogPreview key={post.slug} blog={post} />
-            {
-              index !== bottomPosts.length - 1 && (
-                <div style={{ width: 40 }} />
-              )
-            }
+            {index !== bottomPosts.length - 1 && <div style={{ width: 40 }} />}
           </>
         ))}
       </div>
@@ -244,11 +238,9 @@ function MobileBlogPreview({ featuredPosts, allPosts }) {
           {smallPosts?.map((post, index) => (
             <>
               <SmallBlogPreview key={post.slug} blog={post} />
-              {
-                index !== smallPosts.length - 1 && (
-                  <div style={{ height: 40 }} />
-                )
-              }
+              {index !== smallPosts.length - 1 && (
+                <div style={{ height: 40 }} />
+              )}
             </>
           ))}
         </div>


### PR DESCRIPTION
## Description

Fixes #1158 
Fixes #1325 
Fixes #1326 
Fixes #1202 
Currently, if a story in the homepage blog preview section is marked as "featured," it is displayed twice: once as a "featured" story (either in a larger box or in a carousel on mobile), then once in the lineup of general articles. The `HomeBlogPreview` component also incorrectly assigns alt text values to images if one isn't provided due to a syntax error, and the desktop and tablet previews illogically assign indices to which articles should be displayed, leaving out some of our most recent ones.

## Changes

This PR filters stories included within the featured list from those displayed more generally. The filter function utilized within is essentially a duplicate of @dotslashbit's #1162, which was reverted as part of #1288 due to #1286. However, this PR also employs `Array.slice()` throughout to ensure that if the length of the post array is smaller than expected (e.g., when the app has yet to successfully determine `countryId` via an effect hook, as present in #1202), that the the app displays nothing as opposed to crashing. 

In practice, this does nothing to change the actual display of the articles to the end user. Indeed, an effort was made to ensure that the articles were displayed the same way as in the production app, hence the awkward conditional addition of spacer `div` elements, which were present previously.

This PR also corrects the syntax error in image alt text properties and changes the slice indices to ensure the most recent articles are displayed.

## Screenshots

The revised code in action is visible in the video below.
https://github.com/PolicyEngine/policyengine-app/assets/14987227/776d0b0a-3287-4f53-b97b-6f06ab4abacb

## Tests

None have been added