### PR TITLE
Fix formatting for EITC policy parameters

### DIFF
--- a/src/__tests__/IntervalMap.test.js
+++ b/src/__tests__/IntervalMap.test.js
@@ -62,6 +62,22 @@ describe("IntervalMap construction", () => {
       [10, "f"],
     ]);
   });
+
+  test("unsorted to sorted", () => {
+    const m = new IntervalMap(
+      [
+        [2, "b"],
+        [1, "a"],
+        [3, "c"],
+      ],
+      (x, y) => x - y,
+    );
+    expect(m.toArray()).toStrictEqual([
+      [1, "a"],
+      [2, "b"],
+      [3, "c"],
+    ]);
+  });
 });
 
 describe("IntervalMap operations", () => {

--- a/src/__tests__/IntervalMap.test.js
+++ b/src/__tests__/IntervalMap.test.js
@@ -33,6 +33,35 @@ describe("IntervalMap construction", () => {
       [2, "b"],
     ]);
   });
+
+  test("ten entries, one duplicate", () => {
+    const m = new IntervalMap(
+      [
+        [1, "a"],
+        [2, "b"],
+        [3, "c"],
+        [4, "d"],
+        [5, "e"],
+        [6, "f"],
+        [7, "f"],
+        [8, "h"],
+        [9, "i"],
+        [10, "f"],
+      ],
+      (x, y) => x - y,
+    );
+    expect(m.toArray()).toStrictEqual([
+      [1, "a"],
+      [2, "b"],
+      [3, "c"],
+      [4, "d"],
+      [5, "e"],
+      [6, "f"],
+      [8, "h"],
+      [9, "i"],
+      [10, "f"],
+    ]);
+  });
 });
 
 describe("IntervalMap operations", () => {

--- a/src/algorithms/IntervalMap.js
+++ b/src/algorithms/IntervalMap.js
@@ -26,15 +26,14 @@ export class IntervalMap {
     this.array = [];
     array.sort((a, b) => keyCmp(a[0], b[0]));
     let prevValue;
-    for (const [key, value] in array) {
+    for (const [key, value] of array) {
       if (!valueEq(value, prevValue)) {
-        array.push([key, value]);
+        this.array.push([key, value]);
         prevValue = value;
       }
     }
     // the loop ensures that two consecutive elements do not have duplicates,
     // and the first element does not have an undefined value.
-    this.array = array;
     this.keyCmp = keyCmp;
     this.valueEq = valueEq;
   }
@@ -111,11 +110,26 @@ export class IntervalMap {
    * @param {*} x a point in the domain
    */
   get(x) {
-    // first element with key <= x
-    const element = this.array.findLast(
-      (element) => this.keyCmp(element[0], x) <= 0,
+    const array = this.array;
+    const n = array.length;
+
+    if (n === 0) return;
+
+    const idx = bisect(array, x, 0, n, false, (element, x) =>
+      this.keyCmp(element[0], x),
     );
-    return element?.[1];
+
+    if (idx === n) {
+      return array[idx - 1][1];
+    }
+
+    if (array[idx][0] === x) {
+      return array[idx][1];
+    }
+
+    if (idx > 0) {
+      return array[idx - 1][1];
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

We fix #1336. The root cause is a bug in the `IntervalMap` constructor. The bug is pretty bad, so it is a surprise that the editor was working for some parameters!

## Changes

- create a deduplicated copy of the input array in the `IntervalMap` constructor.
- use bisection in `IntervalMap.get` for efficiency.
- add more tests for `IntervalMap`.

## Screenshots

<img width="800" alt="Screenshot 2024-02-08 at 8 05 16 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/76e6f9b6-e84e-4714-afae-dd4872504fa6">


## Tests

The parameters in #1336 were tested.
