### PR TITLE
Fix Streamlit display

### DIFF
--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -313,10 +313,10 @@ export default function APIDocumentationPage({ metadata }) {
       <Section title="API playground" id="playground">
         <p>Try out the API in this interactive demo.</p>
         <iframe
-          src={`https://policyengine-policyengine-api-demo-app-xy5rgn.streamlit.app/~/+/?embed=true&embed_options=light_theme&mode=${countryId}`}
+          src={`https://policyengine-policyengine-api-demo-app-xy5rgn.streamlit.app/?embed=true&embed_options=light_theme&embed_options=hide_footer&mode=${countryId}`}
           // the demo is in the policyengine-api-demo repository in PolicyEngine
           title="PolicyEngine API demo"
-          height="500px"
+          height="600px"
           width={"100%"}
         />
       </Section>


### PR DESCRIPTION
## Description

Fixes #1289. This PR alters the Streamlit embed link to allow embeds where the button to awaken a sleeping Streamlit app are now visible. It also relies upon changes made within the Streamlit itself that prevent the display of Streamlit's proprietary bottom footer.

## Changes

This PR removes a series of characters in the embed link that had previously prevented display of Streamlit's proprietary bottom footer, but also prevented display of the awaken button. It is accompanied by changes to the Streamlit itself to hide said footer.

## Screenshots

The visible awaken button when run locally:
<img width="1440" alt="Screen Shot 2024-02-12 at 7 00 59 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/658b4bb4-2d3b-4b6c-91d0-3b5a057d421d">

The embedded Streamlit without proprietary footer:
<img width="1440" alt="Screen Shot 2024-02-12 at 7 42 13 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/6d489249-e7be-4255-9100-16fd38bd5f24"> 

## Tests

This has only been tested visually
