### PR TITLE
Fix calculator issues

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -250,6 +250,9 @@ function HouseholdVariableEntityInput(props) {
   let control;
   if (variable.valueType === "float" || variable.valueType === "int") {
     const isCurrency = Object.keys(currencyMap).includes(variable.unit);
+    const maximumFractionDigits = isCurrency ? 2 : 16;
+    const onPressEnter = (_, value) =>
+      submitValue(+value.toFixed(maximumFractionDigits));
     control = (
       <StableInputNumber
         style={{
@@ -267,14 +270,16 @@ function HouseholdVariableEntityInput(props) {
                 const isInteger = Number.isInteger(n);
                 return n.toLocaleString(localeCode(metadata.countryId), {
                   minimumFractionDigits: userTyping || isInteger ? 0 : 2,
-                  maximumFractionDigits: userTyping ? 16 : 2,
+                  maximumFractionDigits: userTyping
+                    ? 16
+                    : maximumFractionDigits,
                 });
               },
             }
           : {})}
         defaultValue={defaultValue}
-        onPressEnter={(_, value) => submitValue(value)}
-        onBlur={(_, value) => submitValue(value)}
+        onPressEnter={onPressEnter}
+        onBlur={onPressEnter}
       />
     );
   } else if (variable.valueType === "bool") {

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -82,6 +82,7 @@ export default function ParameterEditor(props) {
     const isPercent = parameter.unit === "/1";
     const scale = isPercent ? 100 : 1;
     const isCurrency = Object.keys(currencyMap).includes(parameter.unit);
+    const maximumFractionDigits = isCurrency ? 2 : 16;
     control = (
       <StableInputNumber
         key={"input for" + parameter.parameter}
@@ -100,11 +101,13 @@ export default function ParameterEditor(props) {
           const isInteger = Number.isInteger(n);
           return n.toLocaleString(localeCode(metadata.countryId), {
             minimumFractionDigits: userTyping || isInteger ? 0 : 2,
-            maximumFractionDigits: userTyping || !isCurrency ? 16 : 2,
+            maximumFractionDigits: userTyping ? 16 : maximumFractionDigits,
           });
         }}
         defaultValue={Number(startValue) * scale}
-        onPressEnter={(_, value) => onChange(parseFloat(value) / scale)}
+        onPressEnter={(_, value) =>
+          onChange(+value.toFixed(maximumFractionDigits) / scale)
+        }
       />
     );
   }

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -100,7 +100,7 @@ export default function ParameterEditor(props) {
           const isInteger = Number.isInteger(n);
           return n.toLocaleString(localeCode(metadata.countryId), {
             minimumFractionDigits: userTyping || isInteger ? 0 : 2,
-            maximumFractionDigits: userTyping ? 16 : 2,
+            maximumFractionDigits: userTyping || !isCurrency ? 16 : 2,
           });
         }}
         defaultValue={Number(startValue) * scale}

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -80,7 +80,7 @@ export default function ParameterOverTime(props) {
           yaxis: { ...yaxisFormat },
           legend: {
             // Position above the plot
-            y: 1.1,
+            y: 1.2,
             orientation: "h",
           },
           ...ChartLogo,

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -5,7 +5,10 @@ import useMobile from "../../../layout/Responsive";
 import useWindowHeight from "layout/WindowHeight";
 import style from "../../../style";
 import { plotLayoutFont } from "pages/policy/output/utils";
-import { localeCode } from "lang/format"; /**
+import { localeCode } from "lang/format";
+import { defaultEndDate, defaultStartDate } from "../../../data/constants";
+
+/**
  *
  * @param {object} policy the policy object
  * @returns the reform policy label
@@ -41,6 +44,8 @@ export default function ParameterOverTime(props) {
   xaxisValues = xaxisValues.filter(
     (e) => e !== "0000-01-01" && e !== "2099-12-31",
   );
+  xaxisValues.push(defaultStartDate);
+  xaxisValues.push(defaultEndDate);
   const yaxisValues = reformedY ? y.concat(reformedY) : y;
   const xaxisFormat = getPlotlyAxisFormat("date", xaxisValues);
   const yaxisFormat = getPlotlyAxisFormat(parameter.unit, yaxisValues);


### PR DESCRIPTION
## Description

- We fix #1354 by increasing the maximum number of fractional digits for non-currency parameters temporarily. Instead of increasing the precision, we could also have scaled the number by `100`, as suggested in #1355. However, #1355 requires changes to be made in the API repo. So, the maximum number of fractional digits can be reverted to two in the fix for #1355.
- We fix #1357 by also rounding the values in the `OnEnter` attribute for the input field in the policy and household calculators.
- We fix #1361 by moving the legend up.
- We fix #1366 by including the default start and end dates in the x-axis range.

## Screenshots

current year included on x-axis:

<img width="771" alt="Screenshot 2024-02-16 at 9 09 52 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/fe86a8e9-b331-4b72-a963-344a44f25121">

legend is higher:

<img width="771" alt="Screenshot 2024-02-16 at 9 15 03 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/9ebbc7e2-f2d7-4722-924c-1995dcde6483">


consistent views in input field and graph + increased precision:

<img width="771" alt="Screenshot 2024-02-16 at 9 11 41 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/d1792164-039d-4e39-aaff-5141aea85552">

