### PR TITLE
Add codecov.io

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,3 +37,7 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        env:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description

Fixes #1358. This adds codecov.io coverage testing to the repo.

## Changes

Adds codecov.io coverage testing as a part of the GitHub Actions

## Screenshots

N/A

## Tests

N/A
