### PR TITLE
Improve PolicyNamer

### DIFF
--- a/src/__tests__/InputText.test.js
+++ b/src/__tests__/InputText.test.js
@@ -46,6 +46,6 @@ describe("Should take inputs", () => {
     expect(testProps.onPressEnter).not.toHaveBeenCalled();
 
     fireEvent.keyDown(input, { key: "Enter" });
-    expect(testProps.onPressEnter).toHaveBeenCalled();
+    expect(testProps.onPressEnter).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/InputText.test.js
+++ b/src/__tests__/InputText.test.js
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import InputField from "../controls/InputField";
+import InputText from "../controls/InputText";
 import { useSearchParams } from "react-router-dom";
 
 jest.mock("react-router-dom", () => {
@@ -24,7 +24,7 @@ describe("Should take inputs", () => {
     };
 
     setup = (props) => {
-      const utils = render(<InputField {...props} />);
+      const utils = render(<InputText {...props} />);
       const input = screen.getByPlaceholderText(testProps.placeholder);
 
       return {

--- a/src/__tests__/InputText.test.js
+++ b/src/__tests__/InputText.test.js
@@ -10,7 +10,6 @@ jest.mock("react-router-dom", () => {
     useSearchParams: jest.fn(),
   };
 });
-const patternProp = { pattern: "%" };
 const testInput = "Test Input";
 
 describe("Should take inputs", () => {
@@ -20,7 +19,7 @@ describe("Should take inputs", () => {
   beforeEach(() => {
     testProps = {
       placeholder: "Test Placeholder",
-      onChange: jest.fn(),
+      onPressEnter: jest.fn(),
     };
 
     setup = (props) => {
@@ -34,7 +33,7 @@ describe("Should take inputs", () => {
     };
   });
 
-  test("Should handle non-percent input & submit on blur", () => {
+  test("Should handle input & submit on enter, but not other keys", () => {
     useSearchParams.mockImplementation(() => {
       const get = () => "gov.irs.ald.loss.capital.max.HEAD_OF_HOUSEHOLD";
       return [{ get }];
@@ -42,23 +41,11 @@ describe("Should take inputs", () => {
     const { input } = setup(testProps);
     fireEvent.change(input, { target: { value: testInput } });
     expect(input.value).toBe(testInput);
-    expect(testProps.onChange).not.toHaveBeenCalled();
 
-    fireEvent.blur(input);
-    expect(testProps.onChange).toHaveBeenCalledWith(testInput);
-  });
+    fireEvent.keyDown(input, { key: "A" });
+    expect(testProps.onPressEnter).not.toHaveBeenCalled();
 
-  test("Should append '%' for percent pattern & submit on blur", () => {
-    useSearchParams.mockImplementation(() => {
-      const get = () => "gov.irs.ald.loss.capital.max.HEAD_OF_HOUSEHOLD";
-      return [{ get }];
-    });
-    const { input } = setup({ ...testProps, ...patternProp });
-    fireEvent.change(input, { target: { value: testInput } });
-    expect(input.value).toBe(testInput + "%");
-    expect(testProps.onChange).not.toHaveBeenCalled();
-
-    fireEvent.blur(input);
-    expect(testProps.onChange).toHaveBeenCalledWith(testInput + "%");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(testProps.onPressEnter).toHaveBeenCalled();
   });
 });

--- a/src/controls/Button.jsx
+++ b/src/controls/Button.jsx
@@ -1,7 +1,7 @@
 import styles from "../redesign/style";
 import { HoverBox } from "../redesign/components/HoverBox";
 
-const buttonStyles = {
+export const buttonStyles = {
   primary: {
     hoverBackgroundColor: styles.colors.TEAL_PRESSED,
     standardBackgroundColor: styles.colors.TEAL_ACCENT,

--- a/src/controls/InputField.jsx
+++ b/src/controls/InputField.jsx
@@ -18,7 +18,7 @@ export default function InputField(props) {
     boxStyle,
     buttonText,
     buttonStyle,
-    isDisabled=false
+    disableOnEmpty,
   } = props;
 
   const [inputValue, setInputValue] = useState(initialValue ? initialValue : "");
@@ -52,10 +52,12 @@ export default function InputField(props) {
         {inputElement}
         <Button 
           type="primary"
-          disabled={isDisabled}
+          disabled={disableOnEmpty && !inputValue}
           style={{
-            backgroundColor: !isDisabled && buttonStyles[buttonStyle].standardBackgroundColor,
-            border: !isDisabled && "none",
+            backgroundColor: !(disableOnEmpty && !inputValue) && buttonStyles[buttonStyle].standardBackgroundColor,
+            // This line is added instead of "none" because the disabled style also has a 1px border, causing
+            // visual ticks if transitioning between the two
+            border: !(disableOnEmpty && !inputValue) && `1px solid ${buttonStyles[buttonStyle].standardBackgroundColor}`,
           }}
           onClick={(e) => onClick?.(e, inputValue)}
         >

--- a/src/controls/InputField.jsx
+++ b/src/controls/InputField.jsx
@@ -1,5 +1,4 @@
 import { Button, Input, Space } from "antd";
-import style from "../redesign/style";
 import { buttonStyles } from "./Button";
 import { motion } from "framer-motion";
 import useMobile from "../layout/Responsive";
@@ -28,6 +27,8 @@ export default function InputField(props) {
     buttonStyle = "default";
   }
 
+  const isDisabled = disableOnEmpty && !inputValue;
+
   const inputElement = (
     <Input
       style={boxStyle}
@@ -52,14 +53,30 @@ export default function InputField(props) {
         {inputElement}
         <Button 
           type="primary"
-          disabled={disableOnEmpty && !inputValue}
+          disabled={isDisabled}
           style={{
-            backgroundColor: !(disableOnEmpty && !inputValue) && buttonStyles[buttonStyle].standardBackgroundColor,
+            backgroundColor: !isDisabled && buttonStyles[buttonStyle].standardBackgroundColor,
             // This line is added instead of "none" because the disabled style also has a 1px border, causing
             // visual ticks if transitioning between the two
-            border: !(disableOnEmpty && !inputValue) && `1px solid ${buttonStyles[buttonStyle].standardBackgroundColor}`,
+            border: !isDisabled && `1px solid ${buttonStyles[buttonStyle].standardBackgroundColor}`,
           }}
           onClick={(e) => onClick?.(e, inputValue)}
+          onMouseOver={(e) => {
+            if (!isDisabled) {
+              (e.currentTarget.style.backgroundColor =
+                buttonStyles[buttonStyle].hoverBackgroundColor) &&
+              (e.currentTarget.style.borderColor =
+                buttonStyles[buttonStyle].hoverBackgroundColor)
+            }
+          }}
+          onMouseOut={(e) => {
+            if (!isDisabled) {
+              (e.currentTarget.style.backgroundColor =
+                buttonStyles[buttonStyle].standardBackgroundColor) &&
+              (e.currentTarget.style.borderColor =
+                buttonStyles[buttonStyle].standardBackgroundColor)
+            }
+          }}
         >
           {buttonText}
         </Button>

--- a/src/controls/InputField.jsx
+++ b/src/controls/InputField.jsx
@@ -1,8 +1,67 @@
+import { Button, Input, Space } from "antd";
+import style from "../redesign/style";
+import { buttonStyles } from "./Button";
 import { motion } from "framer-motion";
 import useMobile from "../layout/Responsive";
-import style from "../style";
 import { useState, useEffect } from "react";
 
+export default function InputField(props) {
+  let {
+    onChange,
+    width,
+    type,
+    value,
+    placeholder,
+    componentStyle,
+    boxStyle,
+    buttonText,
+    buttonStyle,
+    isDisabled=false
+  } = props;
+
+  // Assign fallback values for styling if button included
+  if (!buttonStyle || !(Object.keys(buttonStyles).includes(buttonStyle))) {
+    buttonStyle = "default";
+  }
+
+  const inputElement = (
+    <Input
+      style={boxStyle}
+    />
+  );
+
+  if (buttonText) {
+    return (
+      <Space.Compact
+        style={{
+          ...componentStyle,
+          width: width || "100%"
+        }}
+      >
+        {inputElement}
+        <Button 
+          type="primary"
+          disabled={isDisabled}
+          style={{
+            backgroundColor: !isDisabled && buttonStyles[buttonStyle].standardBackgroundColor,
+            border: !isDisabled && "none",
+          }}
+        >
+          {buttonText}
+        </Button>
+      </Space.Compact>
+    )
+  }
+
+  return (
+    <>
+      {inputElement}
+    </>
+  );
+
+}
+
+/*
 export default function InputField(props) {
   const {
     onChange,
@@ -83,3 +142,4 @@ export default function InputField(props) {
     />
   );
 }
+*/

--- a/src/controls/InputField.jsx
+++ b/src/controls/InputField.jsx
@@ -10,7 +10,7 @@ export default function InputField(props) {
     onChange,
     width,
     type,
-    value,
+    initialValue,
     placeholder,
     componentStyle,
     boxStyle,
@@ -18,6 +18,8 @@ export default function InputField(props) {
     buttonStyle,
     isDisabled=false
   } = props;
+
+  const [inputValue, setInputValue] = useState(initialValue ? initialValue : "");
 
   // Assign fallback values for styling if button included
   if (!buttonStyle || !(Object.keys(buttonStyles).includes(buttonStyle))) {
@@ -27,6 +29,8 @@ export default function InputField(props) {
   const inputElement = (
     <Input
       style={boxStyle}
+      placeholder={placeholder}
+      onChange={(e) => setInputValue(e.target.value)}
     />
   );
 

--- a/src/controls/InputField.jsx
+++ b/src/controls/InputField.jsx
@@ -8,6 +8,8 @@ import { useState, useEffect } from "react";
 export default function InputField(props) {
   let {
     onChange,
+    onPressEnter,
+    onClick,
     width,
     type,
     initialValue,
@@ -30,7 +32,12 @@ export default function InputField(props) {
     <Input
       style={boxStyle}
       placeholder={placeholder}
-      onChange={(e) => setInputValue(e.target.value)}
+      onChange={(e) => {
+          setInputValue(e.target.value);
+          onChange?.(e);
+        }
+      }
+      onPressEnter={(e) => onPressEnter?.(e, inputValue)}
     />
   );
 
@@ -50,6 +57,7 @@ export default function InputField(props) {
             backgroundColor: !isDisabled && buttonStyles[buttonStyle].standardBackgroundColor,
             border: !isDisabled && "none",
           }}
+          onClick={(e) => onClick?.(e, inputValue)}
         >
           {buttonText}
         </Button>

--- a/src/controls/InputField.jsx
+++ b/src/controls/InputField.jsx
@@ -18,6 +18,7 @@ export default function InputField(props) {
     buttonText,
     buttonStyle,
     disableOnEmpty,
+    error
   } = props;
 
   const [inputValue, setInputValue] = useState(initialValue ? initialValue : "");
@@ -38,6 +39,7 @@ export default function InputField(props) {
           onChange?.(e);
         }
       }
+      status={error && "error"}
       onPressEnter={(e) => onPressEnter?.(e, inputValue)}
     />
   );

--- a/src/controls/InputText.jsx
+++ b/src/controls/InputText.jsx
@@ -4,13 +4,12 @@ import { motion } from "framer-motion";
 import useMobile from "../layout/Responsive";
 import { useState, useEffect } from "react";
 
-export default function InputField(props) {
+export default function InputText(props) {
   let {
     onChange,
     onPressEnter,
     onClick,
     width,
-    type,
     initialValue,
     placeholder,
     componentStyle,

--- a/src/controls/InputText.jsx
+++ b/src/controls/InputText.jsx
@@ -1,8 +1,6 @@
 import { Button, Input, Space } from "antd";
 import { buttonStyles } from "./Button";
-import { motion } from "framer-motion";
-import useMobile from "../layout/Responsive";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 
 export default function InputText(props) {
   let {
@@ -17,13 +15,15 @@ export default function InputText(props) {
     buttonText,
     buttonStyle,
     disableOnEmpty,
-    error
+    error,
   } = props;
 
-  const [inputValue, setInputValue] = useState(initialValue ? initialValue : "");
+  const [inputValue, setInputValue] = useState(
+    initialValue ? initialValue : "",
+  );
 
   // Assign fallback values for styling if button included
-  if (!buttonStyle || !(Object.keys(buttonStyles).includes(buttonStyle))) {
+  if (!buttonStyle || !Object.keys(buttonStyles).includes(buttonStyle)) {
     buttonStyle = "default";
   }
 
@@ -34,10 +34,9 @@ export default function InputText(props) {
       style={boxStyle}
       placeholder={placeholder}
       onChange={(e) => {
-          setInputValue(e.target.value);
-          onChange?.(e);
-        }
-      }
+        setInputValue(e.target.value);
+        onChange?.(e);
+      }}
       status={error && "error"}
       onPressEnter={(e) => onPressEnter?.(e, inputValue)}
     />
@@ -48,130 +47,45 @@ export default function InputText(props) {
       <Space.Compact
         style={{
           ...componentStyle,
-          width: width || "100%"
+          width: width || "100%",
         }}
       >
         {inputElement}
-        <Button 
+        <Button
           type="primary"
           disabled={isDisabled}
           style={{
-            backgroundColor: !isDisabled && buttonStyles[buttonStyle].standardBackgroundColor,
+            backgroundColor:
+              !isDisabled && buttonStyles[buttonStyle].standardBackgroundColor,
             // This line is added instead of "none" because the disabled style also has a 1px border, causing
             // visual ticks if transitioning between the two
-            border: !isDisabled && `1px solid ${buttonStyles[buttonStyle].standardBackgroundColor}`,
+            border:
+              !isDisabled &&
+              `1px solid ${buttonStyles[buttonStyle].standardBackgroundColor}`,
           }}
           onClick={(e) => onClick?.(e, inputValue)}
           onMouseOver={(e) => {
             if (!isDisabled) {
               (e.currentTarget.style.backgroundColor =
                 buttonStyles[buttonStyle].hoverBackgroundColor) &&
-              (e.currentTarget.style.borderColor =
-                buttonStyles[buttonStyle].hoverBackgroundColor)
+                (e.currentTarget.style.borderColor =
+                  buttonStyles[buttonStyle].hoverBackgroundColor);
             }
           }}
           onMouseOut={(e) => {
             if (!isDisabled) {
               (e.currentTarget.style.backgroundColor =
                 buttonStyles[buttonStyle].standardBackgroundColor) &&
-              (e.currentTarget.style.borderColor =
-                buttonStyles[buttonStyle].standardBackgroundColor)
+                (e.currentTarget.style.borderColor =
+                  buttonStyles[buttonStyle].standardBackgroundColor);
             }
           }}
         >
           {buttonText}
         </Button>
       </Space.Compact>
-    )
+    );
   }
 
-  return (
-    <>
-      {inputElement}
-    </>
-  );
-
+  return <>{inputElement}</>;
 }
-
-/*
-export default function InputField(props) {
-  const {
-    onChange,
-    padding,
-    width,
-    type,
-    inputmode,
-    pattern,
-    value,
-    placeholder,
-  } = props;
-  const [inputValue, setInputValue] = useState(value ? value : "");
-  const mobile = useMobile();
-  const re = /^[0-9\b]*[.]?[0-9\b]*?$/;
-
-  useEffect(() => {
-    setInputValue("");
-  }, [placeholder]);
-
-  const onInput = (e) => {
-    let value = e.target.value === "" ? placeholder : e.target.value;
-    onChange(value);
-  };
-  return (
-    <motion.input
-      // On iOS, should show a keyboard with a blue "Go" button
-      style={{
-        padding: padding || 20,
-        marginLeft: padding || 20,
-        marginRight: padding || 20,
-        width: width || 200,
-        borderWidth: 1,
-        borderStyle: "solid",
-        borderColor: style.colors.GRAY,
-        marginTop: mobile ? 0 : -10,
-      }}
-      type={type || "tel"}
-      inputMode={inputmode || "decimal"}
-      whileFocus={{ scale: 1.05 }}
-      onBlur={onInput}
-      onKeyUp={(e) => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          let value = e.target.value;
-          if (value !== "") {
-            onChange(value);
-          }
-          if (!mobile) {
-            e.target.blur();
-          }
-        }
-      }}
-      onChange={(e) => {
-        let { value } = e.target;
-
-        // evaluating percentage input
-        if (pattern === "%") {
-          if (!value.includes("%") && value !== "") {
-            e.target.value += "%";
-          } else if (value !== "") {
-            let val = value.slice(0, e.target.value.length - 1);
-            e.target.value = val + "%";
-          }
-          e.target.setSelectionRange(
-            e.target.value.length - 1,
-            e.target.value.length - 1,
-          );
-        } else if (pattern === "number") {
-          if (value !== "" && !re.test(value)) {
-            const val = value.replace(/[^\d.]+/g, "");
-            e.target.value = val.includes(".") ? parseFloat(val) : val;
-          }
-        }
-        setInputValue(e.target.value);
-      }}
-      value={inputValue}
-      placeholder={placeholder}
-    />
-  );
-}
-*/

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -543,7 +543,7 @@ export default function PolicyRightSidebar(props) {
         />
       }
       {showReformSearch ? (
-        <div style={{ display: "flex", alignItems: "center", padding: 10 }}>
+        <div style={{ display: "flex", alignItems: "center", padding: "10px 20px" }}>
           <PolicySearch
             metadata={metadata}
             policy={policy}

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -201,6 +201,26 @@ function PolicyNamer(props) {
   const [searchParams, setSearchParams] = useSearchParams();
   const label = policy.reform.label || `Policy #${searchParams.get("reform")}`;
   const [error, setError] = useState(null);
+
+  function handleSubmit(name) {
+    getNewPolicyId(metadata.countryId, policy.reform.data, name).then(
+      (data) => {
+        let newSearch = copySearchParams(searchParams);
+        newSearch.set("renamed", true);
+        if (data.status === "ok") {
+          newSearch.set("reform", data.policy_id);
+        }
+        setSearchParams(newSearch);
+
+        if (data.status !== "ok") {
+          setError(data.message);
+        } else {
+          setError(null);
+        }
+      },
+    );
+  }
+
   return (
     <>
       <div style={{ display: "flex", alignItems: "center"}}>
@@ -217,24 +237,8 @@ function PolicyNamer(props) {
           boxStyle={{
             padding: "0px 10px",
           }}
-          onChange={(name) => {
-            getNewPolicyId(metadata.countryId, policy.reform.data, name).then(
-              (data) => {
-                let newSearch = copySearchParams(searchParams);
-                newSearch.set("renamed", true);
-                if (data.status === "ok") {
-                  newSearch.set("reform", data.policy_id);
-                }
-                setSearchParams(newSearch);
-
-                if (data.status !== "ok") {
-                  setError(data.message);
-                } else {
-                  setError(null);
-                }
-              },
-            );
-          }}
+          onPressEnter={(e, name) => handleSubmit(name)}
+          onClick={(e, name) => handleSubmit(name)}
         />
       </div>
       {error && (

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -203,6 +203,11 @@ function PolicyNamer(props) {
   const [error, setError] = useState(null);
 
   function handleSubmit(name) {
+    if (!validateSubmit(name)) {
+      setError("Error: Policy name invalid");
+      return;
+    }
+
     getNewPolicyId(metadata.countryId, policy.reform.data, name).then(
       (data) => {
         let newSearch = copySearchParams(searchParams);
@@ -221,6 +226,13 @@ function PolicyNamer(props) {
     );
   }
 
+  function validateSubmit(input) {
+    if (!input) {
+      return false;
+    }
+    return true;
+  }
+
   return (
     <>
       <div style={{ display: "flex", alignItems: "center"}}>
@@ -235,6 +247,7 @@ function PolicyNamer(props) {
           componentStyle={{
             margin: "10px 20px"
           }}
+          error={error}
           boxStyle={{
             padding: "0px 10px",
           }}

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -227,6 +227,7 @@ function PolicyNamer(props) {
         <InputField
           type="text"
           inputmode="text"
+          disableOnEmpty
           width="100%"
           key={label}
           buttonText="Rename"

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -205,11 +205,9 @@ function PolicyNamer(props) {
     <>
       <div style={{ display: "flex", alignItems: "center"}}>
         <InputField
-          placeholder={label}
           type="text"
           inputmode="text"
           width="100%"
-          value={label}
           key={label}
           buttonText="Rename"
           buttonStyle="default"
@@ -516,6 +514,9 @@ export default function PolicyRightSidebar(props) {
 
   return (
     <div style={{ paddingTop: 10 }}>
+      <h6 style={{ margin: "10px 20px 0px 20px", fontWeight: 400 }}>
+        {policy.reform.label || `Policy #${searchParams.get("reform")}`}
+      </h6>
       {
         <PolicyNamer
           policy={policy}

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -235,7 +235,7 @@ function PolicyNamer(props) {
 
   return (
     <>
-      <div style={{ display: "flex", alignItems: "center"}}>
+      <div style={{ display: "flex", alignItems: "center" }}>
         <InputText
           disableOnEmpty
           width="100%"
@@ -243,7 +243,7 @@ function PolicyNamer(props) {
           buttonText="Rename"
           buttonStyle="default"
           componentStyle={{
-            margin: "10px 20px"
+            margin: "10px 20px",
           }}
           error={error}
           boxStyle={{
@@ -541,7 +541,13 @@ export default function PolicyRightSidebar(props) {
         />
       }
       {showReformSearch ? (
-        <div style={{ display: "flex", alignItems: "center", padding: "10px 20px" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            padding: "10px 20px",
+          }}
+        >
           <PolicySearch
             metadata={metadata}
             policy={policy}

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -203,15 +203,22 @@ function PolicyNamer(props) {
   const [error, setError] = useState(null);
   return (
     <>
-      <div style={{ display: "flex", alignItems: "center", padding: 10 }}>
+      <div style={{ display: "flex", alignItems: "center"}}>
         <InputField
           placeholder={label}
           type="text"
           inputmode="text"
-          padding={10}
           width="100%"
           value={label}
           key={label}
+          buttonText="Rename"
+          buttonStyle="default"
+          componentStyle={{
+            margin: "10px 20px"
+          }}
+          boxStyle={{
+            padding: "0px 10px",
+          }}
           onChange={(name) => {
             getNewPolicyId(metadata.countryId, policy.reform.data, name).then(
               (data) => {

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -7,7 +7,7 @@ import { getNewPolicyId } from "../../api/parameters";
 import { formatVariableValue } from "../../api/variables";
 import { getParameterAtInstant } from "../../api/parameters";
 import Button from "../../controls/Button";
-import InputField from "../../controls/InputField";
+import InputText from "../../controls/InputText";
 import SearchOptions from "../../controls/SearchOptions";
 import SearchParamNavButton from "../../controls/SearchParamNavButton";
 import style from "../../style";
@@ -236,9 +236,7 @@ function PolicyNamer(props) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center"}}>
-        <InputField
-          type="text"
-          inputmode="text"
+        <InputText
           disableOnEmpty
           width="100%"
           key={label}


### PR DESCRIPTION
## Description

Fixes #1165
Fixes #1166
Fixes #1190
Fixes #1292 

## Changes

Previously, when a user would attempt to rename policies, various issues would arise: numerous duplicates would be created; if a policy already had been renamed, it couldn't successfully be renamed again; and it was unclear for users that there even was a method to rename. 

While some of these issues were diminished in previous API improvements, many continued to emerge from the `InputField` component, which had various limitations. This PR replaces `InputField` (which is currently only utilized in the `PolicyNamer` component on the policy calculator pages) with the `InputText` component, aimed purely at textual input, thereby limiting its scope from the prior `InputField`. The rewritten component does the following:

* Replaces the previous custom-built input field with a standardized Ant Design version
* Builds in an optional right-hand submit button, which the `PolicyNamer` component is rewritten to utilize
* Replaces `PolicyNamer`'s use of `onChange` props with `onPressEnter` and `onClick` events so as to make clear when submit events are firing
* Removes any use of `blur` events, as these are fired very frequently and are not the clearest input method for the user
* Adds validation to `PolicyNamer`, which is currently only used to prevent renaming a policy to an empty string, but could be employed in the future to deal with #972 
* Removes the title from the rename box and places it above to make it clear to the user what the purpose of the `PolicyNamer` component is
* Builds in optional disabling of the submit button when the input field is empty, which the `PolicyNamer` component is written to utilize
* Adds margin to the "search for a policy" box to align it with all other elements

## Screenshots

A video of the component in action is available below. This video also demonstrates that only one renamed policy is created.
https://github.com/PolicyEngine/policyengine-app/assets/14987227/d4a12f8d-4db1-418d-841f-ca49f6bb71a9

## Tests

The existing test for `InputField` has been renamed to `InputText` and updated to match the new desired behavior.
