### PR TITLE
Ensure charts update when righthand sidebar values are changed

### DIFF
--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -49,7 +49,10 @@ export function FetchAndDisplayImpact(props) {
   useEffect(() => {
     if (
       areObjectsSame(policy?.reform?.data, policyRef.current?.reform?.data) &&
-      areObjectsSame(policy?.baseline?.data, policyRef.current?.baseline?.data) &&
+      areObjectsSame(
+        policy?.baseline?.data,
+        policyRef.current?.baseline?.data,
+      ) &&
       renamed
     ) {
       return;

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -33,6 +33,7 @@ export function FetchAndDisplayImpact(props) {
   const timePeriod = searchParams.get("timePeriod");
   const reformPolicyId = searchParams.get("reform");
   const baselinePolicyId = searchParams.get("baseline");
+  const renamed = searchParams.get("renamed");
   const [impact, setImpact] = useState(null);
   const [error, setError] = useState(null);
   const [averageImpactTime, setAverageImpactTime] = useState(20);
@@ -48,7 +49,8 @@ export function FetchAndDisplayImpact(props) {
   useEffect(() => {
     if (
       areObjectsSame(policy?.reform?.data, policyRef.current?.reform?.data) &&
-      areObjectsSame(policy?.baseline?.data, policyRef.current?.baseline?.data)
+      areObjectsSame(policy?.baseline?.data, policyRef.current?.baseline?.data) &&
+      renamed
     ) {
       return;
     }


### PR DESCRIPTION
## Description

Fixes #1375 
Changes were introduced in #1367 that aimed to prevent recalculation of policy outputs when users renamed policies by preventing the running of an effect hook if the baseline and reform parameters of the policy were the same before and after the effect hook was called. While this did prevent recalculation when users merely renamed policies, it also prevent recalculation when users changed data that was not stored within the policy object, including year, geography, etc.

## Changes

In addition to the check from #1367 to determine whether policy parameters were changed before recalculating, this PR also checks whether or not the "renamed" URL search parameter has been set to true, a parameter that existed prior to recent changes to the app and API. If this value is true and the policy parameters are the same as previously, the hook does not run, but if "renamed" has not been set or is false, the hook runs, enabling changes to year, geography, etc., to re-enqueue calculation correctly.

## Screenshots

The fixes in action are available in the video below.
https://github.com/PolicyEngine/policyengine-app/assets/14987227/55917585-7f59-49b8-9e3d-1fb52be05581

## Tests

This PR does not add any additional tests. While I would like to write them, they will likely be somewhat complex to write properly, as they are mostly visual, event-driven tests on an effect hook, as opposed to tests of a function. Considering the severity of #1375, I thought it best to open the PR and commit tests separately later, but am happy to mark this as draft until tests have been integrated, if preferred.
