### PR TITLE
Add testing and code coverage reporting to push actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,10 +33,14 @@ jobs:
         with:
           cache: npm
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run build
-      - run: npm test -- --coverage
+      - name: Install repository
+        run: npm ci
+      - name: Lint repository
+        run: npm run lint
+      - name: Build package
+        run: npm run build
+      - name: Test repository
+        run: npm test -- --coverage
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,6 +19,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+      - name: Run tests
+        run: npm test -- --coverage
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        env:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
         with:


### PR DESCRIPTION
## Description

Fixes #1376.
This adds testing to the GitHub push action, in addition to its current location in the PR action, so as to extend codecov coverage reporting to the `master` branch, as opposed to merely feature branches.

## Changes

Adds testing and codecov reporting to the GitHub `push.yml` actions file.

## Screenshots

N/A

## Tests

N/A
