### PR TITLE
Fix tests on push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+      - name: Install repository
+        run: npm ci
       - name: Run tests
         run: npm test -- --coverage
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
## Description

Fixes #1381 

Fixes tests on the `push.yml` GitHub Action by installing the repo before testing
