### PR TITLE
Rename codecov token in push.yml

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         env:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
         with:


### PR DESCRIPTION
## Description

Fixes #1383 by renaming the codecov token in the `push.yml` file to CODECOV_TOKEN, based upon the guide [here](https://docs.codecov.com/docs/adding-the-codecov-token). This does not change the `pr.yml`, which is working correctly despite the token there being referred to as "token".