### PR TITLE
Add codecov secret as action-wide

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   REACT_APP_OPENAI_API_KEY: ${{ secrets.REACT_APP_OPENAI_API_KEY }}
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
   test:
@@ -25,8 +26,6 @@ jobs:
         run: npm test -- --coverage
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
         with:


### PR DESCRIPTION
## Description

Fixes #1387 by adding the codecov token as an action-wide environment variable, instead of specifically tied to the action itself, based on the second response [here](https://stackoverflow.com/questions/67861379/codecov-fails-in-github-actions).
