### PR TITLE
Hide abolish switches in policy calculator left-hand search tool

### DIFF
--- a/src/pages/PolicyPage.jsx
+++ b/src/pages/PolicyPage.jsx
@@ -20,6 +20,7 @@ export function ParameterSearch(props) {
   const { metadata, callback } = props;
   const [searchParams, setSearchParams] = useSearchParams();
   const options = Object.values(metadata.parameters)
+    .filter((parameter) => !parameter.parameter.includes("abolitions"))
     .filter((parameter) => parameter.type === "parameter")
     .map((parameter) => ({
       value: parameter.parameter,


### PR DESCRIPTION
## Description

Fixes #1335
While the application hides the majority of "abolish X parameter" options within the main folder page of the policy calculator, it still shows these options within the left-hand search box. This PR is aimed at disabling that.

## Changes

The changes added by this PR aim to bring the left-hand search box into alignment with the folder pages by executing the same filter upon all policy parameters within the metadata. The line that adds a filter is the same as that present within the `buildParameterTree` function of `src/api/parameters.js`.

That said, this still leaves about 10 "abolish" parameters visible within the search tool, at least two of which (shown in the video below, coming from Maryland) seem unlikely to be desirable. I think it's possible that further refactoring should be done, whether it's within the US country package or within `ParameterSearch.jsx`, to do two things:
* Ensure that the items shown within the left-hand search box are the same as those accessible via folders (I don't know if this is the preferred behavior, but it might be)
* Ensure that all "abolish" parameters are correctly tagged as such within `policyengine-us`

Even so, I thought it best to put this code forward, considering the high priority level of this change.

## Screenshots

A video of the changes in action is available below.
https://github.com/PolicyEngine/policyengine-app/assets/14987227/84455787-edde-4151-83fb-8cae7a87dccc

## Tests

No tests have been added to this PR.
