### PR TITLE
Add codecov as env token, then use within push.yml

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,6 +26,8 @@ jobs:
         run: npm test -- --coverage
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
+        with:
+          CODECOV_TOKEN: ${{ env.CODECOV_TOKEN }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
         with:


### PR DESCRIPTION
## Description

Fixes #1389. Attempts to solve the issue of codecov not authenticating properly with `push.yml` by approximating what a contributor did [here](https://github.com/blackhorse2313/react-kanban/commit/da0a0e7848b5bf5a540c3441c832330de1a22c56), as it's possible that `push.yml` fails since the action merges a branch off a fork into the master branch of the main repo.
