### PR TITLE
Downgrade codecov actions version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,6 +42,4 @@ jobs:
       - name: Test repository
         run: npm test -- --coverage
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        env:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   REACT_APP_OPENAI_API_KEY: ${{ secrets.REACT_APP_OPENAI_API_KEY }}
-  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
   test:
@@ -25,11 +24,9 @@ jobs:
       - name: Run tests
         run: npm test -- --coverage
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v3
         with:
           verbose: true
-        env:
-          CODECOV_TOKEN: ${{ env.CODECOV_TOKEN }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
         with:


### PR DESCRIPTION
## Description

Fixes #1399. It appears that codecov fails to run in `push.yml` because we're running a merge action from a branch of a forked repo into the master branch of the app repo, and the forked repo's branch doesn't have access to the codecov token. It would appear that the only solutions to this are:

1. Downgrade codecov actions to v3
2. Rewrite our entire `push.yml` process to instead quash PRs and merge based upon that, but it's not 100% clear that that would solve the problem, and it feels like overkill for a code coverage package
