### PR TITLE
Ensure Jest covers all files when measuring coverage

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Build package
         run: npm run build
       - name: Test repository
-        run: npm test -- --coverage
+        run: make test
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install repository
         run: npm ci
       - name: Run tests
-        run: npm test -- --coverage
+        run: make test
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -36,7 +36,5 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
           create_credentials_file: true
-      - name: Install dependencies
-        run: make install
       - name: Deploy
         run: make deploy

--- a/jest.config.js
+++ b/jest.config.js
@@ -63,4 +63,8 @@ module.exports = {
       "<rootDir>/src/__tests__/setup/fileMock.js",
     "\\.(css|less)$": "<rootDir>/src/__tests__/setup/fileMock.js",
   },
+  collectCoverage: true,
+  collectCoverageFrom: [
+    "src/**/*.{js,jsx}"
+  ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -64,7 +64,5 @@ module.exports = {
     "\\.(css|less)$": "<rootDir>/src/__tests__/setup/fileMock.js",
   },
   collectCoverage: true,
-  collectCoverageFrom: [
-    "src/**/*.{js,jsx}"
-  ]
+  collectCoverageFrom: ["src/**/*.{js,jsx}"],
 };


### PR DESCRIPTION
## Description

Fixes #1401. Jest does not cover all files by default when measuring coverage, only those that tests somehow touch upon, requiring a config option to ensure full coverage. This PR also moves the `--coverage` flag that was added in `package.json` into the Jest config file to ensure the file serves as a single source of truth for all Jest config options.
