### PR TITLE
Fix broken API description

### DIFF
--- a/src/redesign/components/APIDocumentationPage.jsx
+++ b/src/redesign/components/APIDocumentationPage.jsx
@@ -246,8 +246,7 @@ export default function APIDocumentationPage({ metadata }) {
         id="calculate"
         method="POST"
         title="Calculate household-level policy outcomes"
-        description={`Returns household-level policy outcomes. Pass in a household object defining people, groups and any variable values (see the /metadata endpoint for a full list). Then, pass in null values for requested variables- these will be filled in with computed values. It's best ${countryId} === "us" ? "practice" : "practise"
-        } to use the group/name/variable/optional time period/value structure.`}
+        description={`Returns household-level policy outcomes. Pass in a household object defining people, groups and any variable values (see the /metadata endpoint for a full list). Then, pass in null values for requested variables - these will be filled in with computed values. Using the group/name/variable/optional time period/value structure is recommended.`}
         exampleInputJson={{
           household: {
             people: {


### PR DESCRIPTION
## Description

Fix #1410 by changing the description message to:

<img width="1240" alt="Screenshot 2024-02-23 at 9 36 38 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/a0cbaed0-a1b1-43e1-a187-e895efdce5df">

The phrase `It's best practice` was removed since we are not referring to a general technique.