### PR TITLE
Don't group major updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,6 @@ updates:
         update-types:
           - minor
           - patch
-      major:
-        patterns:
-          - "*"
-        update-types:
-          - major
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description

Fixes #1390 
Stops grouping major updates within dependabot settings
