### PR TITLE
Ensure that policies with numbers in name are correctly added to Reproduce in Python

### DIFF
--- a/src/__tests__/data/countries.test.js
+++ b/src/__tests__/data/countries.test.js
@@ -1,0 +1,5 @@
+import { countryNames } from "../../data/countries";
+
+test("Country names exists", () => {
+  expect(countryNames).toBeTruthy()
+});

--- a/src/__tests__/data/countries.test.js
+++ b/src/__tests__/data/countries.test.js
@@ -1,5 +1,5 @@
 import { countryNames } from "../../data/countries";
 
 test("Country names exists", () => {
-  expect(countryNames).toBeTruthy()
+  expect(countryNames).toBeTruthy();
 });

--- a/src/__tests__/data/reformDefinitionCode.test.js
+++ b/src/__tests__/data/reformDefinitionCode.test.js
@@ -74,7 +74,6 @@ describe("Test getHeaderCode", () => {
     expect(output).toBeInstanceOf(Array);
     expect(output.length).toBe(3);
   });
-
 });
 
 describe("Test getBaselineCode", () => {

--- a/src/__tests__/data/reformDefinitionCode.test.js
+++ b/src/__tests__/data/reformDefinitionCode.test.js
@@ -1,0 +1,271 @@
+import fetch from "node-fetch";
+import {
+  getReproducibilityCodeBlock,
+  getHeaderCode,
+  getBaselineCode,
+  getReformCode,
+  getSituationCode,
+  getImplementationCode,
+} from "data/reformDefinitionCode";
+import {
+  baselinePolicyUS,
+  baselinePolicyUK,
+  reformPolicyUS,
+  reformPolicyUK,
+  householdUS,
+} from "../__setup__/sampleData";
+
+let metadataUS = null;
+
+beforeAll(async () => {
+  const res = await fetch("https://api.policyengine.org/us/metadata");
+  const metadataRaw = await res.json();
+  metadataUS = metadataRaw.result;
+});
+
+const numberedPolicyUS = {
+  baseline: {
+    data: {},
+    label: "Current law",
+    id: 2,
+  },
+  reform: {
+    data: {
+      "sample.reform.item.2": {
+        "2020.01.01": 15,
+        "2022.01.01": 20,
+      },
+    },
+    label: "Sample reform",
+    id: 0,
+  },
+};
+
+describe("Test getReproducibilityCodeBlock", () => {
+  test("Properly outputs array of values from functions it calls", () => {
+    const output = getReproducibilityCodeBlock(
+      "household",
+      metadataUS,
+      reformPolicyUS,
+      "us",
+      2024,
+      householdUS,
+    );
+
+    expect(output).toBeInstanceOf(Array);
+  });
+});
+
+describe("Test getHeaderCode", () => {
+  test("Properly format household without reform", () => {
+    const output = getHeaderCode("household", metadataUS, baselinePolicyUS);
+    expect(output).toBeInstanceOf(Array);
+    expect(output.length).toBe(1);
+  });
+
+  test("Properly format household with reform", () => {
+    const output = getHeaderCode("household", metadataUS, reformPolicyUS);
+    expect(output).toBeInstanceOf(Array);
+    expect(output.length).toBe(3);
+  });
+
+  test("Properly format standard policy", () => {
+    const output = getHeaderCode("policy", metadataUS, reformPolicyUS);
+    expect(output).toBeInstanceOf(Array);
+    expect(output.length).toBe(3);
+  });
+
+});
+
+describe("Test getBaselineCode", () => {
+  test("Output nothing for household type", () => {
+    const output = getBaselineCode("household", baselinePolicyUS, "us");
+    expect(output).toBeInstanceOf(Array);
+    expect(output.length).toBe(0);
+  });
+  test("Output nothing for non-US", () => {
+    const output = getBaselineCode("policy", baselinePolicyUK, "uk");
+    expect(output).toBeInstanceOf(Array);
+    expect(output.length).toBe(0);
+  });
+  test("Output baseline override for US policies", () => {
+    const output = getBaselineCode("policy", reformPolicyUS, "us");
+    expect(output).toBeInstanceOf(Array);
+    expect(output).toContain(
+      "    parameters.simulation.reported_state_income_tax.update(",
+    );
+  });
+});
+describe("Test getReformCode", () => {
+  test("Output nothing if there's no reform", () => {
+    const output = getReformCode("household", baselinePolicyUS, "us");
+    expect(output).toBeInstanceOf(Array);
+    expect(output.length).toBe(0);
+  });
+  test("Ensure normal output for non-US policy", () => {
+    const output = getReformCode("policy", reformPolicyUK, "uk");
+    expect(output).toBeInstanceOf(Array);
+
+    const paramAccessor = Object.keys(reformPolicyUK.reform.data)[0];
+    expect(output).toContain(`    parameters.${paramAccessor}.update(`);
+    expect(output).toContain(`        value=True)`);
+  });
+  test("Ensure addition of use_reported_state_income_tax for US policy", () => {
+    const output = getReformCode("policy", reformPolicyUS, "us");
+    expect(output).toBeInstanceOf(Array);
+    expect(output).toContain(
+      "    parameters.simulation.reported_state_income_tax.update(",
+    );
+    const paramName = Object.keys(reformPolicyUS.reform.data)[0];
+    const paramAccessor = `parameters.${paramName}`;
+    expect(output).toContain(`    ${paramAccessor}.update(`);
+    expect(output).toContain(`        value=False)`);
+  });
+  test("Ensure proper formatting for policies with numbers", () => {
+    const output = getReformCode("policy", numberedPolicyUS, "us");
+    expect(output).toBeInstanceOf(Array);
+    expect(output).toContain(
+      "    parameters.simulation.reported_state_income_tax.update(",
+    );
+    const paramName = Object.keys(numberedPolicyUS.reform.data)[0];
+    let nameParts = paramName.split(".");
+    let numPart = nameParts[nameParts.length - 1];
+    numPart = `children["${numPart}"]`;
+    nameParts[nameParts.length - 1] = numPart;
+    const sanitizedName = nameParts.join(".");
+
+    expect(output).toContain(`    parameters.${sanitizedName}.update(`);
+  });
+});
+describe("Test getSituationCode", () => {
+  test("Policy type returns empty array", () => {
+    const output = getSituationCode(
+      "policy",
+      metadataUS,
+      baselinePolicyUS,
+      2024,
+    );
+    expect(output).toBeInstanceOf(Array);
+    expect(output.length).toBe(0);
+  });
+  test("Null variables deleted", () => {
+    let testHousehold = JSON.parse(JSON.stringify(householdUS));
+    const testVarName = Object.keys(metadataUS.variables).filter(
+      (variable) => metadataUS.variables[variable].isInputVariable,
+    )[150];
+    const testVar = metadataUS.variables[testVarName];
+
+    testHousehold.people.you = {
+      ...testHousehold.people.you,
+      [testVar.name]: {
+        2024: null,
+      },
+    };
+
+    const output = getSituationCode(
+      "household",
+      metadataUS,
+      baselinePolicyUS,
+      2024,
+      testHousehold,
+    );
+    expect(output).toBeInstanceOf(Array);
+    expect(output).not.toContain(testVar.name);
+  });
+  test("Inclusion of earning variation adds axes", () => {
+    let testHousehold = JSON.parse(JSON.stringify(householdUS));
+
+    const output = getSituationCode(
+      "household",
+      metadataUS,
+      baselinePolicyUS,
+      2024,
+      testHousehold,
+      true,
+    );
+
+    let includedString = "axes";
+    let passing = false;
+
+    for (const line of output) {
+      if (line.includes(includedString)) {
+        passing = true;
+        break;
+      }
+    }
+
+    expect(output).toBeInstanceOf(Array);
+    expect(passing).toBe(true);
+  });
+  test("Code is sanitized for Python", () => {
+    let testHousehold = JSON.parse(JSON.stringify(householdUS));
+
+    const output = getSituationCode(
+      "household",
+      metadataUS,
+      baselinePolicyUS,
+      2024,
+      testHousehold,
+    );
+
+    let excludedStrings = ["true", "false", "null"];
+    let passing = true;
+
+    for (const line of output) {
+      for (const string of excludedStrings) {
+        if (line.includes(string)) {
+          passing = false;
+          break;
+        }
+      }
+    }
+
+    expect(output).toBeInstanceOf(Array);
+    expect(passing).toBe(true);
+  });
+  test("Reform code added if reform exists", () => {
+    let testHousehold = JSON.parse(JSON.stringify(householdUS));
+
+    const output = getSituationCode(
+      "household",
+      metadataUS,
+      reformPolicyUS,
+      2024,
+      testHousehold,
+    );
+
+    let includedString = "reform";
+    let passing = false;
+
+    for (const line of output) {
+      if (line.includes(includedString)) {
+        passing = true;
+        break;
+      }
+    }
+
+    expect(output).toBeInstanceOf(Array);
+    expect(passing).toBe(true);
+  });
+});
+describe("Test getImplementationCode", () => {
+  test("If not a policy type, return empty array", () => {
+    const output = getImplementationCode("household", "us", 2024);
+    expect(output).toBeInstanceOf(Array);
+    expect(output.length).toBe(0);
+  });
+  test("If not US, return lines without state tax overrides", () => {
+    const output = getImplementationCode("policy", "uk", 2024);
+    expect(output).toBeInstanceOf(Array);
+    expect(output).not.toContain(
+      "baseline = Microsimulation(reform=baseline_reform)",
+    );
+  });
+  test("If US, return lines with state tax overrides", () => {
+    const output = getImplementationCode("policy", "us", 2024);
+    expect(output).toBeInstanceOf(Array);
+    expect(output).toContain(
+      "baseline = Microsimulation(reform=baseline_reform)",
+    );
+  });
+});

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -105,13 +105,17 @@ export function getReformCode(type, policy, region) {
     );
   }
 
-  for (const [parameterName, parameter] of Object.entries(policy.reform.data)) {
+  for (let [parameterName, parameter] of Object.entries(policy.reform.data)) {
     for (let [instant, value] of Object.entries(parameter)) {
       const [start, end] = instant.split(".");
       if (value === false) {
         value = "False";
       } else if (value === true) {
         value = "True";
+      }
+      // If param name contains number, transform into valid Python
+      if (doesParamNameContainNumber(parameterName)) {
+        parameterName = transformNumberedParamName(parameterName);
       }
       lines.push(
         `    parameters.${parameterName}.update(`,
@@ -243,6 +247,32 @@ export function getStartEndDates(policy) {
     earliestStart: earliestStart,
     latestEnd: latestEnd,
   };
+}
+
+/**
+ * Transforms a parameter name with a number in the name
+ * into valid Python syntax
+ * @param {String} paramName
+ * @returns {String} the transformed name
+ */
+export function transformNumberedParamName(paramName) {
+
+  // Break the paramName into an array of dot-separated 
+  // components
+  const NAME_ACCESSOR = ".";
+  const nameParts = paramName.split(NAME_ACCESSOR);
+
+  // Isolate number within the array and reformat
+  const sanitizedParts = nameParts.map((word) => {
+    if (Number(word)) {
+      word = `children["${word}"]`;
+    }
+    return word;
+  });
+
+  // Re-join the array into a string and return
+  return sanitizedParts.join(".");
+
 }
 
 /**

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -256,8 +256,7 @@ export function getStartEndDates(policy) {
  * @returns {String} the transformed name
  */
 export function transformNumberedParamName(paramName) {
-
-  // Break the paramName into an array of dot-separated 
+  // Break the paramName into an array of dot-separated
   // components
   const NAME_ACCESSOR = ".";
   const nameParts = paramName.split(NAME_ACCESSOR);
@@ -272,7 +271,6 @@ export function transformNumberedParamName(paramName) {
 
   // Re-join the array into a string and return
   return sanitizedParts.join(".");
-
 }
 
 /**

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -31,7 +31,7 @@ export function getReproducibilityCodeBlock(
   ];
 }
 
-function getHeaderCode(type, metadata, policy) {
+export function getHeaderCode(type, metadata, policy) {
   let lines = [];
 
   // Add lines depending upon type of block
@@ -243,4 +243,30 @@ export function getStartEndDates(policy) {
     earliestStart: earliestStart,
     latestEnd: latestEnd,
   };
+}
+
+/**
+ * Determines whether a parameter name (a ParameterNode
+ * object from a country package, accessed via country metadata)
+ * contains a number in the name, making it impossible to access
+ * through standard Python dot notation syntax
+ * @param {String} paramName
+ * @returns {Boolean} "true" if parameter name contains a number
+ * (as defined as a String, successfully casted to a Number),
+ * otherwise false
+ */
+export function doesParamNameContainNumber(paramName) {
+  const JOIN_TOKEN = ".";
+
+  // Take the param name and break it by its joining token
+  const paramNameArray = paramName.split(JOIN_TOKEN);
+
+  // Iterate over the resulting array
+  for (const name of paramNameArray) {
+    if (Number(name)) {
+      return true;
+    }
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Description

Fixes #1392.

The root of this issue lies in policyengine-core and the country packages, and I think that further discussion is warranted to determine if we shouldn't write a check within the ParameterNode class initializer in core to prevent this.

At present, there are a few parameters (including the quite useful IRS tax parameters in the US package) that utilize a raw integer as a name. While Python allows users to name an attribute as such, it is not possible to access the resulting attribute using dot notation.

This PR attempts to solve this issue for users by utilizing the syntax recommended by @nikhilwoodruff within the original issue. This fix should be short-term, as addressing the underlying problem in the data packages would be a more effective solution, but this PR ensures that any users (especially those unfamiliar with Python syntax) are still able to easily reproduce code output in a Colab notebook, etc.

## Changes

Adds two functions that together determine if a parameter name contains an invalid number, and if so, wraps that number in `children["<number>"]` before outputting the parameter name.

## Screenshots

A video of the changes in action is available below. This shows three cases - a parameter with an invalid number (IRS tax brackets), a parameter without a number that doesn't change as a result of this PR, and a parameter in the UK with a valid number (Higher Rate rate increase), which also doesn't change as a result of this PR.

## Tests

Tests have been added that cover nearly all lines in the component, as well as a constant that for some reason was shown as needing coverage.
