### PR TITLE
Replace Athabasca Twitter component with embed

### DIFF
--- a/src/redesign/components/Footer.jsx
+++ b/src/redesign/components/Footer.jsx
@@ -11,7 +11,7 @@ import {
   TwitterOutlined,
   YoutubeFilled,
 } from "@ant-design/icons";
-import React from "react";
+import { createElement, useEffect } from "react";
 
 export default function Footer() {
   const displayCategory = useDisplayCategory();
@@ -47,29 +47,40 @@ function ContactUs() {
 }
 
 function TwitterEmbed() {
-  const displayCategory = useDisplayCategory();
-  const athabascaTwitterLink =
-    "https://www.athabasca.dev/hydra/content/twitteriframes/QOJXetYBdppnFEcjtYUDRuWJmXAMPotTWDeqkkbMQeCkJKwB.html?v=AtCahfJd";
+  const dC = useDisplayCategory();
+
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = "https://platform.twitter.com/widgets.js";
+    script.charset = "utf-8";
+    document.getElementById("twitter-container").appendChild(script);
+  }, []);
+
+  const widths = {
+    mobile: "100%",
+    tablet: "50%",
+    desktop: "33%",
+    default: "33%",
+  };
 
   return (
     <div
+      id="twitter-container"
       style={{
-        marginLeft: 20,
-        marginRight: 20,
+        paddingLeft: 20,
+        paddingRight: 20,
+        width: Object.keys(widths).includes(dC) ? widths[dC] : widths.default,
       }}
     >
-      <iframe
-        title="Twitter timeline"
-        scrolling="no" // This is deprecated, but essential to function correctly
-        height="100%"
-        style={{
-          width: "100%",
-          height: displayCategory === "mobile" ? "500px" : "100%",
-          border: "none",
-          borderRadius: "12px",
-        }}
-        src={athabascaTwitterLink}
-      />
+      <a
+        className="twitter-timeline"
+        data-theme="light"
+        href="https://twitter.com/ThePolicyEngine?ref_src=twsrc%5Etfw"
+        data-width="100%"
+      >
+        Loading tweets by ThePolicyEngine...
+      </a>
     </div>
   );
 }
@@ -172,7 +183,7 @@ export function SocialLink({ icon, url, backgroundColor, color }) {
           marginLeft: displayCategory === "mobile" ? 20 : 0,
         }}
       >
-        {React.createElement(icon, {
+        {createElement(icon, {
           style: {
             color: color || style.colors.BLUE_PRESSED,
             fontSize,


### PR DESCRIPTION
## Description

Fixes #1462.

Previously, in order to allow users without Twitter accounts or those who weren't logged in to their account to view posts, we replaced a broken Twitter embed component with a third-party `iframe` embed from Athabasca Dev. However, this third-party method faced some stability issues (there was a good three-day down period in December or January) as well as an issue with fetching newer tweets. This PR replaces that with a slight modification of Twitter's recommended embedded component.

## Changes

This PR adds the Twitter feed script recommended [here](https://publish.twitter.com/#), but with an effect hook to fetch and inject the Twitter script as required by React, as this appears to have been what failed prior to introduction of the Athabasca Dev component. While it seemed more logical to use a React-based alternative (e.g., [react-twitter-embed](https://www.npmjs.com/package/react-twitter-embed), these also currently fail to function properly, perhaps due to changes on Twitter's end.

## Screenshots

The component in action is viewable in the video below. Note that the load time is required for the script injection, as it's executed after first DOM load.
https://github.com/PolicyEngine/policyengine-app/assets/14987227/6223eaef-c94e-465b-98a0-3d2d87885606

## Tests

None have been added.
