### PR TITLE
Fix household charts

### DIFF
--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -485,7 +485,7 @@ function BaselineReformDeltaPlot(props) {
               : `Absolute change in ${variableLabel}`,
             tickformat: showPercentage ? ".0%" : ".2s",
             ...getPlotlyAxisFormat(
-              showPercentage ? "%" : metadata.variables[variable].unit,
+              showPercentage ? "/1" : metadata.variables[variable].unit,
               showPercentage
                 ? percentageDeltaArray
                 : deltaArray.concat(currentDelta),

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -293,12 +293,10 @@ function BaselineAndReformTogetherPlot(props) {
               metadata.variables.employment_income.unit,
               earningsArray.concat(currentEarnings),
             ),
-            uirevision: metadata.variables.employment_income.unit,
           },
           yaxis: {
             title: capitalize(variableLabel),
             ...yaxisFormat,
-            uirevision: metadata.variables.household_net_income.unit,
           },
           ...(useHoverCard
             ? {}
@@ -480,7 +478,6 @@ function BaselineReformDeltaPlot(props) {
               metadata.variables.employment_income.unit,
               earningsArray.concat(currentEarnings),
             ),
-            uirevision: metadata.variables.employment_income.unit,
           },
           yaxis: {
             title: showPercentage
@@ -493,7 +490,6 @@ function BaselineReformDeltaPlot(props) {
                 ? percentageDeltaArray
                 : deltaArray.concat(currentDelta),
             ),
-            uirevision: metadata.variables[variable].unit,
           },
           ...(useHoverCard
             ? {}

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -104,23 +104,6 @@ export default function BaselineAndReformChart(props) {
       </div>
     );
 
-    const getPlotComponent = (viewMode, sharedProps) => {
-      switch (viewMode) {
-        case "baselineAndReform":
-          return <BaselineAndReformTogetherPlot {...sharedProps} />;
-        case "absoluteChange":
-          return (
-            <BaselineReformDeltaPlot {...sharedProps} showPercentage={false} />
-          );
-        case "relativeChange":
-          return (
-            <BaselineReformDeltaPlot {...sharedProps} showPercentage={true} />
-          );
-        default:
-          return <div>Unknown view mode</div>;
-      }
-    };
-
     let sharedProps = {
       earningsArray,
       baselineArray,
@@ -134,12 +117,20 @@ export default function BaselineAndReformChart(props) {
       policy,
     };
 
-    let plot = getPlotComponent(viewMode, sharedProps);
-
     return (
       <>
         {toggle}
-        <HoverCard>{plot}</HoverCard>
+        <HoverCard>
+          {viewMode === "baselineAndReform" && (
+            <BaselineAndReformTogetherPlot {...sharedProps} />
+          )}
+          {viewMode === "absoluteChange" && (
+            <BaselineReformDeltaPlot {...sharedProps} showPercentage={false} />
+          )}
+          {viewMode === "relativeChange" && (
+            <BaselineReformDeltaPlot {...sharedProps} showPercentage={true} />
+          )}
+        </HoverCard>
       </>
     );
   }

--- a/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineAndReformChart.jsx
@@ -195,9 +195,10 @@ function BaselineAndReformTogetherPlot(props) {
       x: earningsArray,
       y: baselineArray,
       type: "line",
-      name: `Baseline ${variableLabel}`,
+      name: "Baseline",
+      legendgroup: "Baseline",
       line: {
-        color: style.colors.MEDIUM_DARK_GRAY,
+        color: style.colors.GRAY,
       },
       ...(useHoverCard
         ? {
@@ -215,9 +216,11 @@ function BaselineAndReformTogetherPlot(props) {
       x: earningsArray,
       y: reformArray,
       type: "line",
-      name: `Reform ${variableLabel}`,
+      name: "Reform",
+      legendgroup: "Reform",
       line: {
         color: style.colors.BLUE,
+        dash: "dot",
       },
       ...(useHoverCard
         ? {
@@ -233,33 +236,14 @@ function BaselineAndReformTogetherPlot(props) {
     },
     {
       x: [currentEarnings],
-      y: [currentValue],
-      type: "scatter",
-      mode: "markers",
-      name: `Your reform ${variableLabel}`,
-      line: {
-        color: style.colors.BLUE,
-      },
-      ...(useHoverCard
-        ? {
-            hoverinfo: "none",
-          }
-        : {
-            hovertemplate:
-              `<b>Your reform ${variableLabel}</b><br><br>` +
-              `If you earn %{x}, your reform<br>` +
-              `${variableLabel} will be %{y}.` +
-              `<extra></extra>`,
-          }),
-    },
-    {
-      x: [currentEarnings],
       y: [baselineValue],
       type: "scatter",
       mode: "markers",
-      name: `Your baseline ${variableLabel}`,
-      line: {
-        color: style.colors.MEDIUM_DARK_GRAY,
+      legendgroup: "Baseline",
+      showlegend: false,
+      marker: {
+        color: style.colors.GRAY,
+        size: 7,
       },
       ...(useHoverCard
         ? {
@@ -269,6 +253,29 @@ function BaselineAndReformTogetherPlot(props) {
             hovertemplate:
               `<b>Your baseline ${variableLabel}</b><br><br>` +
               `If you earn %{x}, your baseline<br>` +
+              `${variableLabel} will be %{y}.` +
+              `<extra></extra>`,
+          }),
+    },
+    {
+      x: [currentEarnings],
+      y: [currentValue],
+      type: "scatter",
+      mode: "markers",
+      legendgroup: "Reform",
+      showlegend: false,
+      marker: {
+        color: style.colors.BLUE,
+        size: 6,
+      },
+      ...(useHoverCard
+        ? {
+            hoverinfo: "none",
+          }
+        : {
+            hovertemplate:
+              `<b>Your reform ${variableLabel}</b><br><br>` +
+              `If you earn %{x}, your reform<br>` +
               `${variableLabel} will be %{y}.` +
               `<extra></extra>`,
           }),
@@ -412,6 +419,7 @@ function BaselineReformDeltaPlot(props) {
       line: {
         color: style.colors.BLUE,
       },
+      showlegend: false,
       hoverinfo: "text",
       text: earningsArray.map((earnings, index) => {
         const deltaValue = showPercentage
@@ -444,6 +452,7 @@ function BaselineReformDeltaPlot(props) {
       line: {
         color: style.colors.BLUE,
       },
+      showlegend: false,
       ...(useHoverCard
         ? {
             hoverinfo: "none",
@@ -495,11 +504,6 @@ function BaselineReformDeltaPlot(props) {
                   font: { size: "16" },
                 },
               }),
-          legend: {
-            // Position above the plot
-            y: 1.2,
-            orientation: "h",
-          },
           margin: {
             t: 0,
           },

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -89,7 +89,7 @@ export default function BaselineOnlyChart(props) {
                 x: earningsArray,
                 y: baselineArray,
                 type: "line",
-                name: capitalize(variableLabel),
+                showlegend: false,
                 line: {
                   color: style.colors.BLUE,
                 },
@@ -110,7 +110,7 @@ export default function BaselineOnlyChart(props) {
                 y: [currentBaseline],
                 type: "line",
                 mode: "markers",
-                name: `Your current ${variableLabel}`,
+                showlegend: false,
                 line: {
                   color: style.colors.BLUE,
                 },

--- a/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
+++ b/src/pages/household/output/EarningsVariation/BaselineOnlyChart.jsx
@@ -134,14 +134,12 @@ export default function BaselineOnlyChart(props) {
                   metadata.variables.employment_income.unit,
                   earningsArray.concat(currentEarnings),
                 ),
-                uirevision: metadata.variables.employment_income.unit,
               },
               yaxis: {
                 title: {
                   text: capitalize(variableLabel),
                 },
                 ...yaxisFormat,
-                uirevision: metadata.variables[variable].unit,
               },
               ...(useHoverCard
                 ? {}


### PR DESCRIPTION
## Description

- We fix #1437.
- We fix #1441.
- We fix #1442.
- We fix #1443.
- We fix #1446.

## Changes

- For `BaselineAndReformTogetherPlot`,
  - We do not display legends for the current baseline and reform markers and remove the variable name from the legends. This fixes #1437.
  - We add the two baseline traces (array, current marker) to the same legend group so that double-clicking on the legend displays/hides the two traces simultaneously. We do the same for the two reform traces.
  - We change the style of the reform array trace to a dotted line to see the baseline and reform traces together when they overlap. This fixes #1441.
  - We change the sizes of the current baseline and current reform markers slightly so that we can see the two markers together when they overlap.
  - We remove the `uirevision` attribute from the axes because it was causing Plotly to maintain its state when switching between absolute and relative plots. This fixes #1443.
  - We pass the unit `\1` to `getPlotlyAxisFormat` instead of `%` for the relative case because that is what the function expects. This fixes #1442.
  - We render the three plots in different locations to ensure that the plots are updated correctly. This idiom is described [here](https://react.dev/learn/preserving-and-resetting-state#option-1-rendering-a-component-in-different-positions). This fixes #1446.
- For `BaselineOnlyChart` and `BaselineReformDeltaPlot`,
  - We don't display legends any more. This is done to maintain consistency with `BaselineAndReformTogetherPlot`.
  - We remove `uirevision` from the axes to maintain consistency with `BaselineAndReformTogetherPlot`.


## Screenshots

Less info in legends:

<img width="715" alt="Screenshot 2024-03-18 at 2 26 23 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/cc554dbd-549e-4766-983c-cc6d1d30a3ec">

Overlapping lines:

<img width="715" alt="Screenshot 2024-03-18 at 2 29 56 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/65ee78c7-8fba-4619-a196-be0e1a6d881b">

Correct axis ticks:

<img width="715" alt="Screenshot 2024-03-18 at 2 31 00 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/a1839da0-82a6-44c3-85e1-71cdae0a8a7a">

## Tests

The changes were tested against three households.
