### PR TITLE
Clarify reproduce code

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -63,7 +63,8 @@ module.exports = {
       "<rootDir>/src/__tests__/__setup__/fileMock.js",
     "\\.(css|less)$": "<rootDir>/src/__tests__/__setup__/fileMock.js",
   },
-  modulePathIgnorePatterns: ["<rootDir>/src/__tests__/__setup__"],
+  coveragePathIgnorePatterns: ["<rootDir>/src/__tests__/__setup__/"],
+  testPathIgnorePatterns: ["<rootDir>/src/__tests__/__setup__/"],
   collectCoverage: true,
   collectCoverageFrom: ["src/**/*.{js,jsx}"],
 };

--- a/src/__tests__/data/reformDefinitionCode.test.js
+++ b/src/__tests__/data/reformDefinitionCode.test.js
@@ -113,7 +113,7 @@ describe("Test getReformCode", () => {
     const output = getReformCode("policy", reformPolicyUS, "us");
     expect(output).toBeInstanceOf(Array);
     expect(output).toContain(
-      "    parameters.simulation.reported_state_income_tax.update(",
+      "        self.modify_parameters(use_reported_state_income_tax)",
     );
     const paramName = Object.keys(reformPolicyUS.reform.data)[0];
     const paramAccessor = `parameters.${paramName}`;
@@ -123,9 +123,6 @@ describe("Test getReformCode", () => {
   test("Ensure proper formatting for policies with numbers", () => {
     const output = getReformCode("policy", numberedPolicyUS, "us");
     expect(output).toBeInstanceOf(Array);
-    expect(output).toContain(
-      "    parameters.simulation.reported_state_income_tax.update(",
-    );
     const paramName = Object.keys(numberedPolicyUS.reform.data)[0];
     let nameParts = paramName.split(".");
     let numPart = nameParts[nameParts.length - 1];

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -90,20 +90,8 @@ export function getReformCode(type, policy, region) {
     return [];
   }
 
-  let lines = ["", "", "def modify_parameters(parameters):"];
+  let lines = ["", "", "def reform_parameters(parameters):"];
 
-  // For US reforms, when calculated society-wide, add reported state income tax
-  if (type === "policy" && US_REGIONS.includes(region)) {
-    // Calculate the earliest start date and latest end date for
-    // the policies included in the simulation
-    const { earliestStart, latestEnd } = getStartEndDates(policy);
-
-    lines.push(
-      "    parameters.simulation.reported_state_income_tax.update(",
-      `        start=instant("${earliestStart}"), stop=instant("${latestEnd}"),`,
-      "        value=True)",
-    );
-  }
 
   for (let [parameterName, parameter] of Object.entries(policy.reform.data)) {
     for (let [instant, value] of Object.entries(parameter)) {
@@ -131,8 +119,20 @@ export function getReformCode(type, policy, region) {
     "",
     "class reform(Reform):",
     "    def apply(self):",
-    "        self.modify_parameters(modify_parameters)",
+    "        self.modify_parameters(reform_parameters)",
   ]);
+
+  // For US reforms, when calculated society-wide, add reported state income tax
+  if (type === "policy" && US_REGIONS.includes(region)) {
+    // Calculate the earliest start date and latest end date for
+    // the policies included in the simulation
+    const { earliestStart, latestEnd } = getStartEndDates(policy);
+
+    lines.push(
+    "        self.modify_parameters(use_reported_state_income_tax)",
+    );
+  }
+
   return lines;
 }
 

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -70,7 +70,7 @@ export function getBaselineCode(type, policy, region) {
     "In US nationwide simulations,",
     "use reported state income tax liabilities",
     `"""`,
-    "def modify_baseline(parameters):",
+    "def use_reported_state_income_tax(parameters):",
     "    parameters.simulation.reported_state_income_tax.update(",
     `        start=instant("${earliestStart}"), stop=instant("${latestEnd}"),`,
     "        value=True)",
@@ -79,7 +79,7 @@ export function getBaselineCode(type, policy, region) {
     "",
     "class baseline_reform(Reform):",
     "    def apply(self):",
-    "        self.modify_parameters(modify_baseline)",
+    "        self.modify_parameters(use_reported_state_income_tax)",
   ];
 }
 

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -123,10 +123,6 @@ export function getReformCode(type, policy, region) {
 
   // For US reforms, when calculated society-wide, add reported state income tax
   if (type === "policy" && US_REGIONS.includes(region)) {
-    // Calculate the earliest start date and latest end date for
-    // the policies included in the simulation
-    const { earliestStart, latestEnd } = getStartEndDates(policy);
-
     lines.push("        self.modify_parameters(use_reported_state_income_tax)");
   }
 
@@ -212,6 +208,8 @@ export function getImplementationCode(type, region, timePeriod) {
   const isCountryUS = US_REGIONS.includes(region);
 
   return [
+    "",
+    "",
     `baseline = Microsimulation(${
       isCountryUS ? "reform=baseline_reform" : ""
     })`,

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -92,7 +92,6 @@ export function getReformCode(type, policy, region) {
 
   let lines = ["", "", "def reform_parameters(parameters):"];
 
-
   for (let [parameterName, parameter] of Object.entries(policy.reform.data)) {
     for (let [instant, value] of Object.entries(parameter)) {
       const [start, end] = instant.split(".");
@@ -128,9 +127,7 @@ export function getReformCode(type, policy, region) {
     // the policies included in the simulation
     const { earliestStart, latestEnd } = getStartEndDates(policy);
 
-    lines.push(
-    "        self.modify_parameters(use_reported_state_income_tax)",
-    );
+    lines.push("        self.modify_parameters(use_reported_state_income_tax)");
   }
 
   return lines;


### PR DESCRIPTION
## Description

Fixes #1421.
Fixes #1487.

This PR changes the default names for the `Reproduce in Python` page's main reform and use_reported_income_tax baseline reform variables. It also applies the `use_reported_income_tax` reform directly to the baseline, as opposed to redefining it within the baseline, as shown within the discussion feed on #1421. 

At the same time, it removes the Jest setup files from code coverage.

## Screenshots

A video of the changes in action with two US policies, as well as one UK policy (where these changes shouldn't apply), is available below.

https://github.com/PolicyEngine/policyengine-app/assets/14987227/83351626-4007-4b28-a02e-b3c3eed65795

## Tests

Tests have been updated to accommodate the changes.
