### PR TITLE
Add new posts to posts.json

### DIFF
--- a/src/posts/authors.json
+++ b/src/posts/authors.json
@@ -62,5 +62,11 @@
     "github": "Kim1277",
     "linkedin": "https://www.linkedin.com/in/lin-tao-384203207",
     "bio": "Lin is a data analyst at PolicyEngine."
+  },
+  "anthony-volk": {
+    "name": "Anthony Volk",
+    "email": "anthony@policyengine.org",
+    "bio": "is a full-stack engineer at PolicyEngine.",
+    "headshot": "anthony-volk.jpg"
   }
 }

--- a/src/posts/posts.json
+++ b/src/posts/posts.json
@@ -610,5 +610,50 @@
     "tags": ["uk", "impact", "featured"],
     "image": "citizens-economic-council.png",
     "authors": ["nikhil-woodruff"]
+  },
+  {
+    "title": "Autumn Statement 2023 tax-benefit reforms",
+    "description": "Chancellor Jeremy Hunt just announced National Insurance cuts and benefit uprating. We've evaluated these reforms.",
+    "date": "2023-11-22 17:25",
+    "filename": "autumn-statement-2023.md",
+    "tags": ["uk", "policy", "featured"],
+    "image": "jeremy-hunt.jpg",
+    "authors": ["nikhil-woodruff"]
+  },
+  {
+    "title": "Autumn 2023 model calibration update",
+    "description": "Evaluating PolicyEngine's model performance with the latest official statistics.",
+    "date": "2023-12-04 09:00:00",
+    "filename": "uk-calibration-2023-q4.ipynb",
+    "tags": ["uk", "technical"],
+    "image": "uk-calibration-dec-2023-update.png",
+    "authors": ["nikhil-woodruff"]
+  },
+  {
+    "title": "Wyden-Smith Child Tax Credit Expansion",
+    "description": "PolicyEngine estimates the impact of the reported compromise to expand the Child Tax Credit’s refundable component.",
+    "date": "2024-01-11 12:00:00",
+    "filename": "wyden-smith-ctc.md",
+    "tags": ["us", "impact", "featured", "child-tax-credit"],
+    "image": "wyden.jpeg",
+    "authors": ["max-ghenis"]
+  },
+  {
+    "title": "Spring Budget 2024 proposals",
+    "description": "PolicyEngine estimates reported likely tax-benefit reforms ahead of the UK Spring Budget.",
+    "date": "2024-03-04 09:00:00",
+    "filename": "spring-budget-2024.ipynb",
+    "tags": ["uk", "policy"],
+    "image": "jeremy_hunt.jpg",
+    "authors": ["anthony-volk", "nikhil-woodruff"]
+  },
+  {
+    "title": "Spring Budget 2024",
+    "description": "PolicyEngine estimates the impact of the UK Spring Budget.",
+    "date": "2024-03-06 09:00:00",
+    "filename": "uk-2024-spring-budget.ipynb",
+    "tags": ["uk", "policy", "featured"],
+    "image": "uk_budget_box_hunt.jpg",
+    "authors": ["nikhil-woodruff", "anthony-volk"]
   }
 ]


### PR DESCRIPTION
## Description

Fixes #1464.

At present, we maintain two separate lists of posts: `Posts.jsx`, which is utilized by the app for various purposes and which stores the posts data inside a private JS object inside the file; and `posts.json`, which is utilized by a few Python files to create social cards. Because social media providers crawl static page versions, instead of the pages' dynamic apps, the Python files run a temporary web server that injects the relevant social sharing properties, but must access a publicly available `posts.json` file to do so.

## Changes

This fix adds the most recent PolicyEngine articles to the `posts.json` file, such that they are now present in both `posts.json` and `Posts.jsx`. It also updates `authors.json`, another file which exists in tandem with the similar `Authors.jsx`. For the time being, all new articles must be added to both `Posts.jsx` and `posts.json`. 

In the longer-run, in a separate issue, we'll need to return to having one source of truth for posts and authors, likely by removing the data objects that `Authors.jsx` and `Posts.jsx` includes and replacing them with functions that fetch, load, and process their respective JSON equivalents. The need to centralize around one file is already referenced in #1156, but we'll likely have to pursue a different approach with that issue.

## Screenshots

N/A

## Tests

N/A
