### PR TITLE
Fixes #1440 articles on mobile don't place padding around their text

### DIFF
--- a/src/redesign/components/BlogPage.jsx
+++ b/src/redesign/components/BlogPage.jsx
@@ -338,7 +338,7 @@ function PostBodySection({ post, markdown, notebook }) {
     );
   }
 }
-// how to add margin in bodycontent when iti is tablet or not destop
+
 function PostHeadingSection({ post, markdown, notebook, postDate, imageUrl }) {
   const displayCategory = useDisplayCategory();
   if (!notebook && !markdown) {

--- a/src/redesign/components/BlogPage.jsx
+++ b/src/redesign/components/BlogPage.jsx
@@ -302,12 +302,16 @@ function PostBodySection({ post, markdown, notebook }) {
         <div style={{ flex: 1, marginRight: 50 }}>
           <div style={{ position: "sticky", top: 150 }}>
             <p className="spaced-sans-serif">Contents</p>
-            <LeftContents markdown={markdown} notebook={notebook} />
+            <div style={{ flex: 3, marginRight: 50, marginLeft: 50 }}>
+              <LeftContents markdown={markdown} notebook={notebook} />
+            </div>
             <div style={{ marginTop: 20 }} />
-            <MoreOn post={post} />
+            <div style={{ marginRight: 50, marginLeft: 50 }}>
+              <MoreOn post={post} />
+            </div>
           </div>
         </div>
-        <div style={{ flex: 3 }}>
+        <div style={{ flex: 3, marginRight: 50, marginLeft: 50 }}>
           {bodyContent}
           <AuthorSection post={post} />
         </div>
@@ -317,15 +321,15 @@ function PostBodySection({ post, markdown, notebook }) {
     return (
       <div style={{ display: "flex", flexDirection: "column" }}>
         <div style={{ flex: 1 }}>
-          <div style={{ marginBottom: 30 }}>
+          <div style={{ marginBottom: 30, marginRight: 50, marginLeft: 50 }}>
             <p className="spaced-sans-serif">Contents</p>
             <LeftContents markdown={markdown} notebook={notebook} />
           </div>
-          <div style={{ flex: 1 }}>
+          <div style={{ flex: 1, marginRight: 50, marginLeft: 50 }}>
             {bodyContent}
             <AuthorSection post={post} />
           </div>
-          <div style={{ flex: 1 }}>
+          <div style={{ flex: 1, marginRight: 50, marginLeft: 50 }}>
             <div style={{ marginTop: 20 }} />
             <MoreOn post={post} />
           </div>
@@ -334,7 +338,7 @@ function PostBodySection({ post, markdown, notebook }) {
     );
   }
 }
-
+// how to add margin in bodycontent when iti is tablet or not destop
 function PostHeadingSection({ post, markdown, notebook, postDate, imageUrl }) {
   const displayCategory = useDisplayCategory();
   if (!notebook && !markdown) {


### PR DESCRIPTION
## Description

This update fixes #1440 the articles on mobile don't place padding around their text.

## Changes

Update the style padding in PostBodySection function at BlogPage.jsx under components folder

## Screenshots

Screenshots on mobile version
![image](https://github.com/PolicyEngine/policyengine-app/assets/53825339/8f719ff8-89f3-4d9c-a574-238c119fa6fe)
![image](https://github.com/PolicyEngine/policyengine-app/assets/53825339/b6195b8e-547c-45fd-8de9-7cc6c0783c03)



## Tests

Passed all tests for 'make test'
