### PR TITLE
Remove (enhanced cps) from titles

### DIFF
--- a/src/layout/BottomCarousel.jsx
+++ b/src/layout/BottomCarousel.jsx
@@ -25,11 +25,19 @@ export default function BottomCarousel(props) {
         justifyContent: mobile ? "center" : "right",
         borderTop: "1px solid black",
         padding: "10px 20px",
-        gap: "10px"
+        gap: "10px",
       }}
     >
       {!mobile && (
-        <div style={{ display: "flex", justifyContent: "flex-end", alignItems: "flex-start" }}>{bottomElements}</div>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            alignItems: "flex-start",
+          }}
+        >
+          {bottomElements}
+        </div>
       )}
       <div
         style={{

--- a/src/layout/BottomCarousel.jsx
+++ b/src/layout/BottomCarousel.jsx
@@ -17,25 +17,26 @@ export default function BottomCarousel(props) {
         position: "absolute",
         bottom: mobile ? "25vh" : 0,
         display: "flex",
-        height: 81,
+        height: "min-content",
         left: mobile ? 0 : "25%",
         width: mobile ? "100%" : "50%",
         alignItems: "center",
         backgroundColor: style.colors.WHITE,
-        padding: 5,
         justifyContent: mobile ? "center" : "right",
         borderTop: "1px solid black",
+        padding: "10px 20px",
+        gap: "10px"
       }}
     >
       {!mobile && (
-        <div style={{ paddingLeft: 50, paddingTop: 20 }}>{bottomElements}</div>
+        <div style={{ display: "flex", justifyContent: "flex-end", alignItems: "flex-start" }}>{bottomElements}</div>
       )}
       <div
         style={{
           flex: 1,
           display: "flex",
           justifyContent: mobile ? "center" : "right",
-          padding: "10px 20px",
+          alignItems: "flex-start",
           gap: 20,
         }}
       >

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -290,7 +290,7 @@ export function LowLevelDisplay(props) {
       );
     }
   } else if (metadata.countryId === "uk") {
-    bottomText = `PolicyEngine UK v{selectedVersion} estimates reform impacts using microsimulation. `;
+    bottomText = `PolicyEngine UK v${selectedVersion} estimates reform impacts using microsimulation. `;
     bottomLink =
       "/uk/research/how-machine-learning-tools-make-policyengine-more-accurate";
   }

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -259,6 +259,7 @@ export function LowLevelDisplay(props) {
   const urlParams = new URLSearchParams(window.location.search);
   const focus = urlParams.get("focus");
   const selectedVersion = urlParams.get("version") || metadata.version;
+  const region = urlParams.get("region");
   const policyOutputTree = getPolicyOutputTree(metadata.countryId);
   const url = encodeURIComponent(window.location.href);
   const encodedPolicyLabel = encodeURIComponent(getPolicyLabel(policy));
@@ -275,24 +276,35 @@ export function LowLevelDisplay(props) {
     content: () => componentRef.current,
   });
 
+  let bottomText = "";
+  let bottomLink = "";
+
+  if (metadata.countryId === "us") {
+    bottomText = `PolicyEngine US v${selectedVersion} estimates reform impacts using microsimulation. `;
+    bottomLink = "/us/research/enhancing-the-current-population-survey-for-policy-analysis";
+
+    if (region === "enhanced_us") {
+      bottomText = bottomText.concat("These calculations utilize enhanced CPS data, an experimental feature. ");
+    }
+  } else if (metadata.countryId === "uk") {
+    bottomText = `PolicyEngine UK v{selectedVersion} estimates reform impacts using microsimulation. `;
+    bottomLink = "/uk/research/how-machine-learning-tools-make-policyengine-more-accurate";
+  }
+
   const embed = new URLSearchParams(window.location.search).get("embed");
   const bottomElements =
-    mobile & !embed ? null : metadata.countryId === "us" ? (
-      <p>
-        PolicyEngine US v{selectedVersion} estimates reform impacts using
-        microsimulation.{" "}
+    mobile & !embed ? null : (
+      <p
+        style={{
+          marginBottom: 0,
+          fontSize: region === "enhanced_us" && "12px"
+        }}
+      >
+        {bottomText}
         <a
-          href="/us/research/enhancing-the-current-population-survey-for-policy-analysis"
+          href={bottomLink}
           target="_blank"
         >
-          Learn more
-        </a>
-      </p>
-    ) : (
-      <p>
-        PolicyEngine UK v{selectedVersion} estimates reform impacts using
-        microsimulation.{" "}
-        <a href="/uk/research/how-machine-learning-tools-make-policyengine-more-accurate">
           Learn more
         </a>
       </p>

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -281,14 +281,18 @@ export function LowLevelDisplay(props) {
 
   if (metadata.countryId === "us") {
     bottomText = `PolicyEngine US v${selectedVersion} estimates reform impacts using microsimulation. `;
-    bottomLink = "/us/research/enhancing-the-current-population-survey-for-policy-analysis";
+    bottomLink =
+      "/us/research/enhancing-the-current-population-survey-for-policy-analysis";
 
     if (region === "enhanced_us") {
-      bottomText = bottomText.concat("These calculations utilize enhanced CPS data, an experimental feature. ");
+      bottomText = bottomText.concat(
+        "These calculations utilize enhanced CPS data, an experimental feature. ",
+      );
     }
   } else if (metadata.countryId === "uk") {
     bottomText = `PolicyEngine UK v{selectedVersion} estimates reform impacts using microsimulation. `;
-    bottomLink = "/uk/research/how-machine-learning-tools-make-policyengine-more-accurate";
+    bottomLink =
+      "/uk/research/how-machine-learning-tools-make-policyengine-more-accurate";
   }
 
   const embed = new URLSearchParams(window.location.search).get("embed");
@@ -297,14 +301,11 @@ export function LowLevelDisplay(props) {
       <p
         style={{
           marginBottom: 0,
-          fontSize: region === "enhanced_us" && "12px"
+          fontSize: region === "enhanced_us" && "12px",
         }}
       >
         {bottomText}
-        <a
-          href={bottomLink}
-          target="_blank"
-        >
+        <a href={bottomLink} target="_blank" rel="noreferrer">
           Learn more
         </a>
       </p>

--- a/src/pages/policy/output/ImpactChart.jsx
+++ b/src/pages/policy/output/ImpactChart.jsx
@@ -118,11 +118,7 @@ export function absoluteChangeMessage(
  * and it is not us or uk
  */
 export function regionName(metadata) {
-  const ignoreList = [
-    "us",
-    "uk",
-    "enhanced_us"
-  ];
+  const ignoreList = ["us", "uk", "enhanced_us"];
 
   const urlParams = new URLSearchParams(window.location.search);
   const region = urlParams.get("region");

--- a/src/pages/policy/output/ImpactChart.jsx
+++ b/src/pages/policy/output/ImpactChart.jsx
@@ -118,9 +118,15 @@ export function absoluteChangeMessage(
  * and it is not us or uk
  */
 export function regionName(metadata) {
+  const ignoreList = [
+    "us",
+    "uk",
+    "enhanced_us"
+  ];
+
   const urlParams = new URLSearchParams(window.location.search);
   const region = urlParams.get("region");
-  if (region === "us" || region === "uk") return;
+  if (ignoreList.includes(region)) return;
   const options = metadata.economy_options.region.map((region) => {
     return { value: region.name, label: region.label };
   });

--- a/src/pages/policy/output/PolicyBreakdown.jsx
+++ b/src/pages/policy/output/PolicyBreakdown.jsx
@@ -6,9 +6,19 @@ export default function PolicyBreakdown(props) {
   const regionObj = metadata.economy_options.region.find(
     (elem) => elem.name === region,
   );
-  const regionName = regionObj ? regionObj.label : "undefined region";
+  let regionLabel;
+  // This is a workaround for enhanced_us that should be changed
+  // if and when it is treated as something other than a "region"
+  // by the back end
+  if (regionObj?.name === "enhanced_us") {
+    regionLabel = "the US";
+  } else if (regionObj) {
+    regionLabel = regionObj.label;
+  } else {
+    regionLabel = "undefined region";
+  }
 
-  const title = `${policyLabel} in ${regionName}, ${timePeriod}`;
+  const title = `${policyLabel} in ${regionLabel}, ${timePeriod}`;
   const bottomText =
     "Click on an option on the left panel to view more details.";
 


### PR DESCRIPTION
## Description

Fixes #1474 
Fixes #1522 

## Changes

This PR alters the `regionName` function (in `ImpactChart.jsx`) to ignore the "enhanced_us" region's name when creating a chart title. It also removes the "(enhanced US)" from the title within the `PolicyBreakdown.jsx` component and adds a warning message to the `BottomCarousel` component to notify users when viewing enhanced CPS-based estimates. 

This PR also restyles the `BottomCarousel` component using flexbox to prevent the component's text from overflowing on narrower breakpoints.

## Screenshots

A video of the component in action is available below.

https://github.com/PolicyEngine/policyengine-app/assets/14987227/b1ce142d-5c24-438f-bae6-5bc765b4ee8c

## Tests

None have been added.
