### PR TITLE
Make default start date and end date reflect previously input value

### DIFF
--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -265,8 +265,17 @@ function PolicyNamer(props) {
 }
 
 function SinglePolicyChange(props) {
-  const { startDateStr, endDateStr, parameterMetadata, value, paramLabel, parameterName, reformId, region, timePeriodYear } =
-    props;
+  const {
+    startDateStr,
+    endDateStr,
+    parameterMetadata,
+    value,
+    paramLabel,
+    parameterName,
+    reformId,
+    region,
+    timePeriodYear,
+  } = props;
   const [searchParams, setSearchParams] = useSearchParams();
   const oldVal = getParameterAtInstant(parameterMetadata, startDateStr);
   const oldValStr = formatVariableValue(parameterMetadata, oldVal);
@@ -306,7 +315,6 @@ function SinglePolicyChange(props) {
                 color: style.colors.BLUE,
                 cursor: "pointer",
               }}
-
               onClick={() => {
                 const newSearchParams = copySearchParams(searchParams);
                 newSearchParams.set("focus", parameterName);
@@ -315,7 +323,7 @@ function SinglePolicyChange(props) {
                 newSearchParams.set("timePeriod", timePeriodYear);
                 newSearchParams.set("startDate", startDateStr);
                 newSearchParams.set("endDate", endDateStr);
-                setSearchParams(newSearchParams)
+                setSearchParams(newSearchParams);
               }}
             >
               {newValueStr}
@@ -331,7 +339,14 @@ function SinglePolicyChange(props) {
 }
 
 function PolicyItem(props) {
-  const { metadata, parameterName, reformData, reformId, region, timePeriodYear } = props;
+  const {
+    metadata,
+    parameterName,
+    reformData,
+    reformId,
+    region,
+    timePeriodYear,
+  } = props;
 
   const parameter = metadata.parameters[parameterName];
   let changes = [];

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -265,8 +265,9 @@ function PolicyNamer(props) {
 }
 
 function SinglePolicyChange(props) {
-  const { startDateStr, endDateStr, parameterMetadata, value, paramLabel } =
+  const { startDateStr, endDateStr, parameterMetadata, value, paramLabel, parameterName, reformId, region, timePeriodYear } =
     props;
+  const [searchParams, setSearchParams] = useSearchParams();
   const oldVal = getParameterAtInstant(parameterMetadata, startDateStr);
   const oldValStr = formatVariableValue(parameterMetadata, oldVal);
   const newValueStr = formatVariableValue(parameterMetadata, value);
@@ -305,6 +306,17 @@ function SinglePolicyChange(props) {
                 color: style.colors.BLUE,
                 cursor: "pointer",
               }}
+
+              onClick={() => {
+                const newSearchParams = copySearchParams(searchParams);
+                newSearchParams.set("focus", parameterName);
+                newSearchParams.set("reform", reformId);
+                newSearchParams.set("region", region);
+                newSearchParams.set("timePeriod", timePeriodYear);
+                newSearchParams.set("startDate", startDateStr);
+                newSearchParams.set("endDate", endDateStr);
+                setSearchParams(newSearchParams)
+              }}
             >
               {newValueStr}
             </span>
@@ -319,7 +331,8 @@ function SinglePolicyChange(props) {
 }
 
 function PolicyItem(props) {
-  const { metadata, parameterName, reformData } = props;
+  const { metadata, parameterName, reformData, reformId, region, timePeriodYear } = props;
+
   const parameter = metadata.parameters[parameterName];
   let changes = [];
   for (const [timePeriod, value] of Object.entries(reformData[parameterName])) {
@@ -332,6 +345,10 @@ function PolicyItem(props) {
         endDateStr={endDateStr}
         parameterMetadata={parameter}
         value={value}
+        parameterName={parameterName}
+        reformId={reformId}
+        region={region}
+        timePeriodYear={timePeriodYear}
       />,
     );
   }
@@ -352,7 +369,7 @@ function PolicyDisplay(props) {
     ),
   );
   const reformLength = Object.keys(policy.reform.data).length;
-  const [searchParams, setSearchParams] = useSearchParams();
+
   return (
     <div
       style={{
@@ -373,12 +390,6 @@ function PolicyDisplay(props) {
           <Carousel.Item
             key={parameterName}
             onClick={() => {
-              const newSearchParams = copySearchParams(searchParams);
-              newSearchParams.set("focus", parameterName);
-              newSearchParams.set("reform", policy.reform.id);
-              newSearchParams.set("region", region);
-              newSearchParams.set("timePeriod", timePeriod);
-              setSearchParams(newSearchParams);
               hideButtons && closeDrawer();
             }}
           >
@@ -387,6 +398,9 @@ function PolicyDisplay(props) {
               metadata={metadata}
               parameterName={parameterName}
               reformData={policy.reform.data}
+              reformId={policy.reform.id}
+              region={region}
+              timePeriodYear={timePeriod}
             />
           </Carousel.Item>
         ))}

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -22,8 +22,12 @@ export default function ParameterEditor(props) {
   const reformData = policy?.reform?.data?.[parameterName];
   const parameterValues = Object.entries(parameter.values);
   const [searchParams, setSearchParams] = useSearchParams();
-  const [startDate, setStartDate] = useState(searchParams.get("startDate") || defaultStartDate);
-  const [endDate, setEndDate] = useState(searchParams.get("endDate") || defaultEndDate);
+  const [startDate, setStartDate] = useState(
+    searchParams.get("startDate") || defaultStartDate,
+  );
+  const [endDate, setEndDate] = useState(
+    searchParams.get("endDate") || defaultEndDate,
+  );
   const baseMap = new IntervalMap(parameterValues, cmpDates, (x, y) => x === y);
   const reformMap = baseMap.copy();
   if (reformData) {
@@ -40,7 +44,7 @@ export default function ParameterEditor(props) {
 
     setStartDate(newStartDate);
     setEndDate(newEndDate);
-  }, [searchParams])
+  }, [searchParams]);
 
   function onChange(value) {
     reformMap.set(startDate, nextDay(endDate), value);

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -2,7 +2,7 @@ import CenteredMiddleColumn from "../../../layout/CenteredMiddleColumn";
 import ParameterOverTime from "./ParameterOverTime";
 import { Alert, DatePicker, Switch } from "antd";
 import { getNewPolicyId } from "../../../api/parameters";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import { copySearchParams } from "../../../api/call";
 import useMobile from "../../../layout/Responsive";
@@ -22,8 +22,8 @@ export default function ParameterEditor(props) {
   const reformData = policy?.reform?.data?.[parameterName];
   const parameterValues = Object.entries(parameter.values);
   const [searchParams, setSearchParams] = useSearchParams();
-  const [startDate, setStartDate] = useState(defaultStartDate);
-  const [endDate, setEndDate] = useState(defaultEndDate);
+  const [startDate, setStartDate] = useState(searchParams.get("startDate") || defaultStartDate);
+  const [endDate, setEndDate] = useState(searchParams.get("endDate") || defaultEndDate);
   const baseMap = new IntervalMap(parameterValues, cmpDates, (x, y) => x === y);
   const reformMap = baseMap.copy();
   if (reformData) {
@@ -33,6 +33,14 @@ export default function ParameterEditor(props) {
     }
   }
   const startValue = reformMap.get(startDate);
+
+  useEffect(() => {
+    const newStartDate = searchParams.get("startDate") || defaultStartDate;
+    const newEndDate = searchParams.get("endDate") || defaultEndDate;
+
+    setStartDate(newStartDate);
+    setEndDate(newEndDate);
+  }, [searchParams])
 
   function onChange(value) {
     reformMap.set(startDate, nextDay(endDate), value);
@@ -60,6 +68,8 @@ export default function ParameterEditor(props) {
         } else {
           let newSearch = copySearchParams(searchParams);
           newSearch.set("reform", result.policy_id);
+          newSearch.set("startDate", startDate);
+          newSearch.set("endDate", endDate);
           setSearchParams(newSearch);
         }
       });
@@ -124,7 +134,7 @@ export default function ParameterEditor(props) {
       }}
     >
       <RangePicker
-        defaultValue={[moment(startDate), moment(endDate)]}
+        value={[moment(startDate), moment(endDate)]}
         onChange={(_, dateStrings) => {
           setStartDate(dateStrings[0]);
           setEndDate(dateStrings[1]);


### PR DESCRIPTION
## Description

Closes #1520. This is not a complete solution yet. This is for reference in #1520 to discuss the complete solution. As of the initial PR, this correctly makes the start date and end date reflect the previously input value. However, it does not update the input number correctly when clicking a preexisting parameter and then another preexisting parameter, since the way the app passes in the input number is through StableInputNumber defaultValue prop, instead of the value prop, which causes the value state variable to be unchanged even when what's passed into defaultValue prop changed. The issue described can be seen more clearly in the video below.

## Changes

I create two new search parameters, startDate and endDate of a single policy to allow ParameterEditor access to the previous input value or single policy start and end date. I moved setting searchParams in Carousel.Item to setting searchParams in SinglePolicyChange (SinglePolicyChange is a grandchild component of Carousel.Item) to accommodate setting two new parameters, startDate and endDate. I, then, update ParameterEditor accordingly so that when a user clicks on a preexisting parameter, it uses startDate and endDate search params so startDate and endDate reflect previously input values.

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/59489624/7d991972-6a41-44df-8f33-455126e44a6f

## Tests

Manual testing and with make test (all tests passed).

