### PR TITLE
Display label metadata rather than filename for scale parameters

### DIFF
--- a/src/api/parameters.js
+++ b/src/api/parameters.js
@@ -29,7 +29,9 @@ export function buildParameterTree(parameters) {
     for (const key of pathComponents.slice(0, -1)) {
       cumulativePath += key;
       const fixedCumulativePath = cumulativePath;
-      let label = key;
+      let label =
+        (cumulativePath in parameters && parameters[cumulativePath].label) ||
+        key;
       // Transform e.g. "0]" -> 1
       if (key.endsWith("]")) {
         label = `Bracket ${parseInt(key.slice(0, -1)) + 1}`;


### PR DESCRIPTION
## Description

We fix #1475 by using the correct label for scale parameters when constructing the parameter tree.

## Screenshots

<img width="783" alt="Screenshot 2024-04-01 at 1 10 00 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/64f0cfae-438f-4f2c-a098-1207925f8dcf">
