### PR TITLE
Improve ParameterEditor date selection

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -2,8 +2,8 @@
 // if a reform is applied into perpetuity; this should be replaced
 // with more substantive changes to how parameter changes work to 
 // allow for application into perpetuity, if that is desired behavior
-export const defaultForever = "2100"
+export const defaultForeverYear = "2100"
 
 export const defaultYear = new Date().getFullYear();
 export const defaultStartDate = defaultYear.toString().concat("-01-01");
-export const defaultEndDate = defaultForever.toString().concat("-12-31");
+export const defaultEndDate = defaultForeverYear.toString().concat("-12-31");

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,8 +1,8 @@
 // The below is used to make parameter editor components appear as
 // if a reform is applied into perpetuity; this should be replaced
-// with more substantive changes to how parameter changes work to 
+// with more substantive changes to how parameter changes work to
 // allow for application into perpetuity, if that is desired behavior
-export const defaultForeverYear = "2100"
+export const defaultForeverYear = "2100";
 
 export const defaultYear = new Date().getFullYear();
 export const defaultStartDate = defaultYear.toString().concat("-01-01");

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -7,3 +7,8 @@ export const defaultForeverYear = "2100"
 export const defaultYear = new Date().getFullYear();
 export const defaultStartDate = defaultYear.toString().concat("-01-01");
 export const defaultEndDate = defaultForeverYear.toString().concat("-12-31");
+
+// Charts in ParameterOverTime are meant to extend to 10 years beyond
+// the current year, as specified in app GitHub issue #1261; getPlotlyAxisFormat
+// already adds five, so this function only adds an additional 5
+export const defaultPOTEndDate = (defaultYear + 5).toString().concat("-12-31");

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,3 +1,9 @@
+// The below is used to make parameter editor components appear as
+// if a reform is applied into perpetuity; this should be replaced
+// with more substantive changes to how parameter changes work to 
+// allow for application into perpetuity, if that is desired behavior
+export const defaultForever = "2100"
+
 export const defaultYear = new Date().getFullYear();
 export const defaultStartDate = defaultYear.toString().concat("-01-01");
-export const defaultEndDate = defaultYear.toString().concat("-12-31");
+export const defaultEndDate = defaultForever.toString().concat("-12-31");

--- a/src/lang/format.js
+++ b/src/lang/format.js
@@ -85,7 +85,7 @@ export function formatPercent(number, countryId, options) {
 export function formatFullDate(date, countryId, options) {
   return new Intl.DateTimeFormat(localeCode(countryId), {
     dateStyle: "long",
-    ...options
+    ...options,
   }).format(new Date(date));
 }
 

--- a/src/lang/format.js
+++ b/src/lang/format.js
@@ -82,6 +82,13 @@ export function formatPercent(number, countryId, options) {
   });
 }
 
+export function formatFullDate(date, countryId, options) {
+  return new Intl.DateTimeFormat(localeCode(countryId), {
+    dateStyle: "long",
+    ...options
+  }).format(new Date(date));
+}
+
 /**
  *
  * @param {number} number a number

--- a/src/layout/CenteredMiddleColumn.jsx
+++ b/src/layout/CenteredMiddleColumn.jsx
@@ -15,7 +15,7 @@ export default function CenteredMiddleColumn(props) {
       style={{
         display: "flex",
         flexDirection: "column",
-        marginTop: mobile ? "20%" : marginTop ? marginTop : "10%",
+        marginTop: marginTop ? marginTop : "10%",
         paddingLeft: 50,
         paddingRight: 50,
         ...style

--- a/src/layout/CenteredMiddleColumn.jsx
+++ b/src/layout/CenteredMiddleColumn.jsx
@@ -7,9 +7,8 @@ export default function CenteredMiddleColumn(props) {
     children,
     marginTop,
     descriptionLabel = true,
-    style
+    style,
   } = props;
-  const mobile = useMobile();
   return (
     <div
       style={{
@@ -18,30 +17,30 @@ export default function CenteredMiddleColumn(props) {
         marginTop: marginTop ? marginTop : "10%",
         paddingLeft: 50,
         paddingRight: 50,
-        ...style
+        ...style,
       }}
     >
-        <h3 style={{ fontFamily: "Roboto Serif", fontWeight: 400 }}>{title}</h3>
+      <h3 style={{ fontFamily: "Roboto Serif", fontWeight: 400 }}>{title}</h3>
 
-        {description && (
-          <>
-            {descriptionLabel && (
-              <p
-                style={{
-                  marginTop: 10,
-                  marginBottom: 10,
-                  color: "grey",
-                  fontFamily: "Roboto",
-                  display: "inline-block",
-                }}
-              >
-                Description
-              </p>
-            )}
-            <p style={{ fontFamily: "Roboto Serif" }}>{description}</p>
-          </>
-        )}
-        {children}
-      </div>
+      {description && (
+        <>
+          {descriptionLabel && (
+            <p
+              style={{
+                marginTop: 10,
+                marginBottom: 10,
+                color: "grey",
+                fontFamily: "Roboto",
+                display: "inline-block",
+              }}
+            >
+              Description
+            </p>
+          )}
+          <p style={{ fontFamily: "Roboto Serif" }}>{description}</p>
+        </>
+      )}
+      {children}
+    </div>
   );
 }

--- a/src/layout/CenteredMiddleColumn.jsx
+++ b/src/layout/CenteredMiddleColumn.jsx
@@ -1,5 +1,3 @@
-import useMobile from "../layout/Responsive";
-
 export default function CenteredMiddleColumn(props) {
   const {
     title,

--- a/src/layout/CenteredMiddleColumn.jsx
+++ b/src/layout/CenteredMiddleColumn.jsx
@@ -7,6 +7,7 @@ export default function CenteredMiddleColumn(props) {
     children,
     marginTop,
     descriptionLabel = true,
+    style
   } = props;
   const mobile = useMobile();
   return (
@@ -15,14 +16,11 @@ export default function CenteredMiddleColumn(props) {
         display: "flex",
         flexDirection: "column",
         marginTop: mobile ? "20%" : marginTop ? marginTop : "10%",
+        paddingLeft: 50,
+        paddingRight: 50,
+        ...style
       }}
     >
-      <div
-        style={{
-          paddingLeft: 50,
-          paddingRight: 50,
-        }}
-      >
         <h3 style={{ fontFamily: "Roboto Serif", fontWeight: 400 }}>{title}</h3>
 
         {description && (
@@ -43,9 +41,7 @@ export default function CenteredMiddleColumn(props) {
             <p style={{ fontFamily: "Roboto Serif" }}>{description}</p>
           </>
         )}
-        <div style={{ marginTop: 20 }} />
         {children}
       </div>
-    </div>
   );
 }

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -269,8 +269,14 @@ function PolicyNamer(props) {
 }
 
 function SinglePolicyChange(props) {
-  const { startDateStr, endDateStr, parameterMetadata, value, paramLabel, countryId } =
-    props;
+  const {
+    startDateStr,
+    endDateStr,
+    parameterMetadata,
+    value,
+    paramLabel,
+    countryId,
+  } = props;
   const oldVal = getParameterAtInstant(parameterMetadata, startDateStr);
   const oldValStr = formatVariableValue(parameterMetadata, oldVal);
   const newValueStr = formatVariableValue(parameterMetadata, value);

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -18,6 +18,7 @@ import { defaultYear } from "data/constants";
 import useDisplayCategory from "../../hooks/useDisplayCategory";
 import { defaultForeverYear } from "../../data/constants";
 import Collapsable from "../../redesign/components/Collapsable";
+import { formatFullDate } from "../../lang/format";
 
 function RegionSelector(props) {
   const { metadata } = props;
@@ -268,7 +269,7 @@ function PolicyNamer(props) {
 }
 
 function SinglePolicyChange(props) {
-  const { startDateStr, endDateStr, parameterMetadata, value, paramLabel } =
+  const { startDateStr, endDateStr, parameterMetadata, value, paramLabel, countryId } =
     props;
   const oldVal = getParameterAtInstant(parameterMetadata, startDateStr);
   const oldValStr = formatVariableValue(parameterMetadata, oldVal);
@@ -321,7 +322,7 @@ function SinglePolicyChange(props) {
         )}
       </div>
       <div style={{ fontStyle: "italic" }}>
-        {`${startDateStr} ${isEndForever ? "onward" : `to ${endDateStr}`}`}
+        {`from ${formatFullDate(startDateStr, countryId)} ${isEndForever ? "onward" : `to ${formatFullDate(endDateStr, countryId)}`}`}
       </div>
     </div>
   );
@@ -339,6 +340,7 @@ function PolicyItem(props) {
         paramLabel={parameter.label}
         startDateStr={startDateStr}
         endDateStr={endDateStr}
+        countryId={metadata.countryId}
         parameterMetadata={parameter}
         value={value}
       />,

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -16,6 +16,7 @@ import { Alert, Modal, Switch, Tooltip } from "antd";
 import { ExclamationCircleOutlined } from "@ant-design/icons";
 import { defaultYear } from "data/constants";
 import useDisplayCategory from "../../hooks/useDisplayCategory";
+import { defaultForeverYear } from "../../data/constants";
 import moment from "moment";
 import Collapsable from "../../redesign/components/Collapsable";
 
@@ -273,6 +274,10 @@ function SinglePolicyChange(props) {
   const oldVal = getParameterAtInstant(parameterMetadata, startDateStr);
   const oldValStr = formatVariableValue(parameterMetadata, oldVal);
   const newValueStr = formatVariableValue(parameterMetadata, value);
+
+  const FOREVER_DATE = String(defaultForeverYear).concat("-12-31");
+  const isEndForever = endDateStr === FOREVER_DATE;
+
   const isBool =
     parameterMetadata.unit === "bool" || parameterMetadata.unit === "abolition";
   const prefix = isBool
@@ -316,9 +321,8 @@ function SinglePolicyChange(props) {
           </>
         )}
       </div>
-      <div style={{ paddingTop: 10 }}>
-        from {moment(startDateStr).format("Do MMMM, YYYY")} until{" "}
-        {moment(endDateStr).format("Do MMMM, YYYY")}
+      <div style={{ fontStyle: "italic" }}>
+        {`${startDateStr} ${isEndForever ? "onward" : `to ${endDateStr}`}`}
       </div>
     </div>
   );

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -17,7 +17,6 @@ import { ExclamationCircleOutlined } from "@ant-design/icons";
 import { defaultYear } from "data/constants";
 import useDisplayCategory from "../../hooks/useDisplayCategory";
 import { defaultForeverYear } from "../../data/constants";
-import moment from "moment";
 import Collapsable from "../../redesign/components/Collapsable";
 
 function RegionSelector(props) {

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -8,7 +8,7 @@ import { copySearchParams } from "../../../api/call";
 import useMobile from "../../../layout/Responsive";
 import { capitalize, localeCode } from "../../../lang/format";
 import { currencyMap } from "../../../api/variables";
-import { defaultStartDate, defaultEndDate } from "data/constants";
+import { defaultStartDate, defaultEndDate, defaultForeverYear } from "data/constants";
 import { IntervalMap } from "algorithms/IntervalMap";
 import { cmpDates, nextDay, prevDay } from "lang/stringDates";
 import moment from "dayjs";
@@ -165,13 +165,17 @@ export default function ParameterEditor(props) {
   );
 
   let dateSelectButtonLabel = "";
-  if (
+  const isFullYearSet = (
     checkBoundaryDate(startDate, "start") &&
     checkBoundaryDate(endDate, "end")
-  ) {
-    dateSelectButtonLabel = `from ${moment(startDate).year()} to ${moment(endDate).year()}`;
-  } else {
+  );
+
+  if (!isFullYearSet) {
     dateSelectButtonLabel = `from ${moment(startDate).format("MMMM Do, YYYY")} to ${moment(endDate).format("MMMM Do, YYYY")}`;
+  } else if (moment(endDate).year() === Number(defaultForeverYear)) {
+    dateSelectButtonLabel = `from ${moment(startDate).year()} onward`;
+  } else {
+    dateSelectButtonLabel = `from ${moment(startDate).year()} to ${moment(endDate).year()}`;
   }
 
   const mobile = useMobile();

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -25,7 +25,6 @@ import { cmpDates, nextDay, prevDay } from "lang/stringDates";
 import moment from "dayjs";
 import StableInputNumber from "controls/StableInputNumber";
 import useDisplayCategory from "hooks/useDisplayCategory";
-import style from "../../../style";
 
 const { RangePicker } = DatePicker;
 
@@ -71,13 +70,6 @@ export default function ParameterEditor(props) {
     }
   }, [reformData]);
 
-  let gridTemplate = null;
-  if (displayCategory === "mobile" || displayCategory === "tablet") {
-    gridTemplate = "repeat(2, 1fr) / 1fr";
-  } else {
-    gridTemplate = "1fr / repeat(2, 1fr)";
-  }
-
   const timePeriodSentence = parameter.period
     ? ` This parameter is ${parameter.period}ly.`
     : "";
@@ -101,14 +93,14 @@ export default function ParameterEditor(props) {
           gap: "30px",
           // The below margin is because, for params with descriptions,
           // the description already contains bottom padding
-          marginTop: "14px"
+          marginTop: "14px",
         }}
       >
         <div
           style={{
             display: "flex",
             flexDirection: "column",
-            gap: "10px"
+            gap: "10px",
           }}
         >
           <p
@@ -117,7 +109,7 @@ export default function ParameterEditor(props) {
               color: "gray",
               display: "inline-block",
               fontFamily: "Roboto",
-              margin: 0
+              margin: 0,
             }}
           >
             Current value
@@ -129,7 +121,7 @@ export default function ParameterEditor(props) {
               flexDirection: "row",
               justifyContent: "flex-start",
               alignItems: "center",
-              gap: "10px"
+              gap: "10px",
             }}
           >
             <PeriodSetter
@@ -156,8 +148,7 @@ export default function ParameterEditor(props) {
             type="warning"
           />
         )}
-        <div
-        >
+        <div>
           <p
             style={{
               margin: 0,
@@ -165,12 +156,19 @@ export default function ParameterEditor(props) {
               display: "inline-block",
               fontFamily: "Roboto",
               position: "relative",
-              zIndex: 5
+              zIndex: 5,
             }}
           >
             Historical values
           </p>
-          <div style={{marginLeft: "-25px", marginTop: "-20px", position: "relative", zIndex: 1}}>
+          <div
+            style={{
+              marginLeft: "-25px",
+              marginTop: "-20px",
+              position: "relative",
+              zIndex: 1,
+            }}
+          >
             <ParameterOverTime
               baseMap={baseMap}
               {...(reformData &&
@@ -308,7 +306,6 @@ function ValueSetter(props) {
   } = props;
 
   const [searchParams, setSearchParams] = useSearchParams();
-  const displayCategory = useDisplayCategory();
   const startValue = reformMap.get(startDate);
   const parameter = metadata.parameters[parameterName];
 
@@ -363,7 +360,7 @@ function ValueSetter(props) {
       <StableInputNumber
         style={{
           width: "100%",
-          minWidth: "100px"
+          minWidth: "100px",
         }}
         key={"input for" + parameter.parameter}
         {...(isCurrency

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -24,7 +24,7 @@ import { IntervalMap } from "algorithms/IntervalMap";
 import { cmpDates, nextDay, prevDay } from "lang/stringDates";
 import moment from "dayjs";
 import StableInputNumber from "controls/StableInputNumber";
-import useDisplayCategory from "redesign/components/useDisplayCategory";
+import useDisplayCategory from "hooks/useDisplayCategory";
 
 const { RangePicker } = DatePicker;
 
@@ -95,14 +95,23 @@ export default function ParameterEditor(props) {
     >
       <div
         style={{
+          width: "100%",
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "flex-start",
+          alignItems: "center",
+          gap: "10px"
+
+          /*
           display: "grid",
           justifyItems: "center",
           gridTemplate: gridTemplate,
           alignItems: "center",
-          padding: displayCategory !== "mobile" && "20px 80px 0 80px",
+          padding: displayCategory !== "mobile" && "20px 0px 0 0px",
           paddingTop: 20,
           gap: 10,
           width: "100%",
+          */
         }}
       >
         <PeriodSetter
@@ -240,7 +249,7 @@ function PeriodSetter(props) {
         <Button
           type="text"
           style={{
-            width: "100%",
+            width: "max-content",
           }}
         >
           {dateSelectButtonLabel}

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -59,11 +59,6 @@ export default function ParameterEditor(props) {
     }
   }, [reformData]);
 
-  useEffect(() => {
-    console.log(startDate);
-    console.log(endDate + "\n");
-  }, [startDate, endDate])
-
   let gridTemplate = null;
   if (displayCategory === "mobile" || displayCategory === "tablet") {
     gridTemplate = "repeat(2, 1fr) / 1fr";
@@ -151,11 +146,13 @@ function PeriodSetter(props) {
     setVisibleDateSelector(value);
   }
 
+  const FOREVER_DATE = String(defaultForeverYear).concat("-12-31");
+
   // Array of selectable years, sorted in ascending order
   const possibleYears = metadata.economy_options.time_period.map((period) => period.name).sort();
   const minPossibleDate = String(possibleYears[0]).concat("-01-01");
   const maxPossibleDate = String(possibleYears[possibleYears.length - 1] + 10).concat("-12-31");
-  const defaultEnd = endDate === String(defaultForeverYear).concat("-12-31") ? null : moment(endDate);
+  const isEndForever = endDate === FOREVER_DATE;
 
   let dateSelectButtonLabel = "";
   const isFullYearSet = (
@@ -165,7 +162,7 @@ function PeriodSetter(props) {
 
   if (!isFullYearSet) {
     dateSelectButtonLabel = `from ${moment(startDate).format("MMMM Do, YYYY")} to ${moment(endDate).format("MMMM Do, YYYY")}:`;
-  } else if (moment(endDate).year() === Number(defaultForeverYear)) {
+  } else if (isEndForever) {
     dateSelectButtonLabel = `from ${moment(startDate).year()} onward:`;
   } else {
     dateSelectButtonLabel = `from ${moment(startDate).year()} to ${moment(endDate).year()}:`;
@@ -174,8 +171,8 @@ function PeriodSetter(props) {
   const yearSelector = (
     <RangePicker
       picker="year"
-      defaultValue={[moment(startDate), defaultEnd]}
-      value={[moment(startDate), endDate === "2100-12-31" ? null : moment(endDate)]}
+      defaultValue={[moment(startDate), null]}
+      value={[moment(startDate), isEndForever ? null : moment(endDate)]}
       onChange={(_, yearStrings) => {
         setStartDate(yearStrings[0].concat("-01-01"));
         setEndDate(yearStrings[1].concat("-12-31"));
@@ -187,8 +184,8 @@ function PeriodSetter(props) {
 
   const dateSelector = (
     <RangePicker
-      defaultValue={[moment(startDate), defaultEnd]}
-      value={[moment(startDate), endDate === "2100-12-31" ? null : moment(endDate)]}
+      defaultValue={[moment(startDate), null]}
+      value={[moment(startDate), isEndForever ? null : moment(endDate)]}
       onChange={(_, dateStrings) => {
         setStartDate(dateStrings[0]);
         setEndDate(dateStrings[1]);

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -1,6 +1,6 @@
 import CenteredMiddleColumn from "../../../layout/CenteredMiddleColumn";
 import ParameterOverTime from "./ParameterOverTime";
-import { Alert, DatePicker, Switch } from "antd";
+import { Alert, Button, DatePicker, Popover, Switch, Tabs } from "antd";
 import { getNewPolicyId } from "../../../api/parameters";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -13,6 +13,8 @@ import { IntervalMap } from "algorithms/IntervalMap";
 import { cmpDates, nextDay, prevDay } from "lang/stringDates";
 import moment from "dayjs";
 import StableInputNumber from "controls/StableInputNumber";
+import { CaretDownFilled } from "@ant-design/icons";
+import useDisplayCategory from "redesign/components/useDisplayCategory";
 
 const { RangePicker } = DatePicker;
 
@@ -32,6 +34,8 @@ export default function ParameterEditor(props) {
       reformMap.set(startDate, nextDay(endDate), value);
     }
   }
+
+  const displayCategory = useDisplayCategory();
   const startValue = reformMap.get(startDate);
 
   function onChange(value) {
@@ -85,6 +89,9 @@ export default function ParameterEditor(props) {
     const maximumFractionDigits = 2;
     control = (
       <StableInputNumber
+        style={{
+          width: "50%"
+        }}
         key={"input for" + parameter.parameter}
         {...(isCurrency
           ? {
@@ -111,6 +118,52 @@ export default function ParameterEditor(props) {
       />
     );
   }
+
+  const yearSelector = (
+    <RangePicker
+      picker="year"
+      defaultValue={[moment(startDate), moment(endDate)]}
+      onChange={(_, dateStrings) => {
+        setStartDate(dateStrings[0]);
+        setEndDate(dateStrings[1]);
+      }}
+      disabledDate={(date) => date.isBefore("2021-01-01")}
+      separator="→"
+    />
+  );
+
+  const dateSelector = (
+    <RangePicker
+      defaultValue={[moment(startDate), moment(endDate)]}
+      onChange={(_, dateStrings) => {
+        setStartDate(dateStrings[0]);
+        setEndDate(dateStrings[1]);
+      }}
+      disabledDate={(date) => date.isBefore("2021-01-01")}
+      separator="→"
+    />
+  )
+
+  const popoverContent = (
+    <Tabs
+      items={[
+        {
+          label: "Yearly",
+          key: "yearly",
+          children: yearSelector
+        },
+        {
+          label: "Advanced",
+          key: "advanced",
+          children: dateSelector
+        }
+      ]}
+      defaultActiveKey="yearly"
+      type="card"
+      size="small"
+    />
+  )
+
   const mobile = useMobile();
   const editControl = (
     <div
@@ -121,20 +174,28 @@ export default function ParameterEditor(props) {
         paddingTop: 10,
         paddingLeft: 0,
         gap: 10,
+        width: "100%"
         fontFamily: "Roboto Serif",
       }}
     >
-      <RangePicker
-        defaultValue={[moment(startDate), moment(endDate)]}
-        onChange={(_, dateStrings) => {
-          setStartDate(dateStrings[0]);
-          setEndDate(dateStrings[1]);
-        }}
-        disabledDate={(date) => date.isBefore("2021-01-01")}
-        separator="→"
-        style={{ fontFamily: "Roboto Serif" }}
-      />
       {control}
+      <Popover
+        trigger="click"
+        content={popoverContent}
+        placement={displayCategory === "mobile" ? "bottom" : "bottomRight"}
+      >
+        <Button
+          type="text"
+        >
+          from 2024 onward
+          <CaretDownFilled
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+            }}
+          />
+        </Button>
+      </Popover>
     </div>
   );
 

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -92,44 +92,55 @@ export default function ParameterEditor(props) {
       marginBottom={0}
       title={capitalize(parameter.label)}
       description={description + timePeriodSentence}
+      style={{
+        gap: "30px"
+      }}
     >
       <div
         style={{
-          width: "100%",
           display: "flex",
-          flexDirection: "row",
-          justifyContent: "flex-start",
-          alignItems: "center",
+          flexDirection: "column",
           gap: "10px"
-
-          /*
-          display: "grid",
-          justifyItems: "center",
-          gridTemplate: gridTemplate,
-          alignItems: "center",
-          padding: displayCategory !== "mobile" && "20px 0px 0 0px",
-          paddingTop: 20,
-          gap: 10,
-          width: "100%",
-          */
         }}
       >
-        <PeriodSetter
-          metadata={metadata}
-          startDate={startDate}
-          endDate={endDate}
-          setStartDate={setStartDate}
-          setEndDate={setEndDate}
-        />
-        <ValueSetter
-          startDate={startDate}
-          endDate={endDate}
-          parameterName={parameterName}
-          policy={policy}
-          metadata={metadata}
-          reformMap={reformMap}
-          baseMap={baseMap}
-        />
+        <p
+          style={{
+            paddingRight: 30,
+            color: "gray",
+            display: "inline-block",
+            fontFamily: "Roboto",
+            margin: 0
+          }}
+        >
+          Current value
+        </p>
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "flex-start",
+            alignItems: "center",
+            gap: "10px"
+          }}
+        >
+          <PeriodSetter
+            metadata={metadata}
+            startDate={startDate}
+            endDate={endDate}
+            setStartDate={setStartDate}
+            setEndDate={setEndDate}
+          />
+          <ValueSetter
+            startDate={startDate}
+            endDate={endDate}
+            parameterName={parameterName}
+            policy={policy}
+            metadata={metadata}
+            reformMap={reformMap}
+            baseMap={baseMap}
+          />
+        </div>
       </div>
       {!parameter.economy && (
         <Alert
@@ -137,16 +148,33 @@ export default function ParameterEditor(props) {
           type="warning"
         />
       )}
-      <ParameterOverTime
-        baseMap={baseMap}
-        {...(reformData &&
-          Object.keys(reformData).length > 0 && {
-            reformMap: reformMap,
-          })}
-        parameter={parameter}
-        policy={policy}
-        metadata={metadata}
-      />
+      <div
+      >
+        <p
+          style={{
+            margin: 0,
+            color: "gray",
+            display: "inline-block",
+            fontFamily: "Roboto",
+            position: "relative",
+            zIndex: 5
+          }}
+        >
+          Historical values
+        </p>
+        <div style={{marginLeft: "-25px", marginTop: "-15px", position: "relative", zIndex: 1}}>
+          <ParameterOverTime
+            baseMap={baseMap}
+            {...(reformData &&
+              Object.keys(reformData).length > 0 && {
+                reformMap: reformMap,
+              })}
+            parameter={parameter}
+            policy={policy}
+            metadata={metadata}
+          />
+        </div>
+      </div>
     </CenteredMiddleColumn>
   );
 }

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -163,7 +163,7 @@ export default function ParameterEditor(props) {
         >
           Historical values
         </p>
-        <div style={{marginLeft: "-25px", marginTop: "-15px", position: "relative", zIndex: 1}}>
+        <div style={{marginLeft: "-25px", marginTop: "-20px", position: "relative", zIndex: 1}}>
           <ParameterOverTime
             baseMap={baseMap}
             {...(reformData &&

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -40,7 +40,7 @@ export default function ParameterEditor(props) {
 
   useEffect(() => {
 
-    if (reformData) {
+    if (reformData && Object.keys(reformData).length > 0) {
       // Assign the dates of the first item from the reform data
       // as the default start and end dates and value; this should
       // be written against a stronger structure in the future, as 

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -93,87 +93,95 @@ export default function ParameterEditor(props) {
       marginBottom={0}
       title={capitalize(parameter.label)}
       description={description + timePeriodSentence}
-      style={{
-        gap: "30px"
-      }}
     >
       <div
         style={{
           display: "flex",
           flexDirection: "column",
-          gap: "10px"
+          gap: "30px",
+          // The below margin is because, for params with descriptions,
+          // the description already contains bottom padding
+          marginTop: "14px"
         }}
       >
-        <p
-          style={{
-            paddingRight: 30,
-            color: "gray",
-            display: "inline-block",
-            fontFamily: "Roboto",
-            margin: 0
-          }}
-        >
-          Current value
-        </p>
         <div
           style={{
-            width: "100%",
             display: "flex",
-            flexDirection: "row",
-            justifyContent: "flex-start",
-            alignItems: "center",
+            flexDirection: "column",
             gap: "10px"
           }}
         >
-          <PeriodSetter
-            metadata={metadata}
-            startDate={startDate}
-            endDate={endDate}
-            setStartDate={setStartDate}
-            setEndDate={setEndDate}
-          />
-          <ValueSetter
-            startDate={startDate}
-            endDate={endDate}
-            parameterName={parameterName}
-            policy={policy}
-            metadata={metadata}
-            reformMap={reformMap}
-            baseMap={baseMap}
-          />
+          <p
+            style={{
+              paddingRight: 30,
+              color: "gray",
+              display: "inline-block",
+              fontFamily: "Roboto",
+              margin: 0
+            }}
+          >
+            Current value
+          </p>
+          <div
+            style={{
+              width: "100%",
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "flex-start",
+              alignItems: "center",
+              gap: "10px"
+            }}
+          >
+            <PeriodSetter
+              metadata={metadata}
+              startDate={startDate}
+              endDate={endDate}
+              setStartDate={setStartDate}
+              setEndDate={setEndDate}
+            />
+            <ValueSetter
+              startDate={startDate}
+              endDate={endDate}
+              parameterName={parameterName}
+              policy={policy}
+              metadata={metadata}
+              reformMap={reformMap}
+              baseMap={baseMap}
+            />
+          </div>
         </div>
-      </div>
-      {!parameter.economy && (
-        <Alert
-          message="PolicyEngine does not currently model this parameter in society-wide economic simulations."
-          type="warning"
-        />
-      )}
-      <div
-      >
-        <p
-          style={{
-            margin: 0,
-            color: "gray",
-            display: "inline-block",
-            fontFamily: "Roboto",
-            position: "relative",
-            zIndex: 5
-          }}
-        >
-          Historical values
-        </p>
-        <div style={{marginLeft: "-25px", marginTop: "-20px", position: "relative", zIndex: 1}}>
-          <ParameterOverTime
-            baseMap={baseMap}
-            {...(reformData &&
-              Object.keys(reformData).length > 0 && {
-                reformMap: reformMap,
-              })}
-            parameter={parameter}
-            policy={policy}
-            metadata={metadata}
+        {!parameter.economy && (
+          <Alert
+            message="PolicyEngine does not currently model this parameter in society-wide economic simulations."
+            type="warning"
           />
+        )}
+        <div
+        >
+          <p
+            style={{
+              margin: 0,
+              color: "gray",
+              display: "inline-block",
+              fontFamily: "Roboto",
+              position: "relative",
+              zIndex: 5
+            }}
+          >
+            Historical values
+          </p>
+          <div style={{marginLeft: "-25px", marginTop: "-20px", position: "relative", zIndex: 1}}>
+            <ParameterOverTime
+              baseMap={baseMap}
+              {...(reformData &&
+                Object.keys(reformData).length > 0 && {
+                  reformMap: reformMap,
+                })}
+              parameter={parameter}
+              policy={policy}
+              metadata={metadata}
+            />
+          </div>
         </div>
       </div>
     </CenteredMiddleColumn>

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -90,7 +90,7 @@ export default function ParameterEditor(props) {
     control = (
       <StableInputNumber
         style={{
-          width: "50%"
+          width: "50%",
         }}
         key={"input for" + parameter.parameter}
         {...(isCurrency
@@ -142,7 +142,7 @@ export default function ParameterEditor(props) {
       disabledDate={(date) => date.isBefore("2021-01-01")}
       separator="→"
     />
-  )
+  );
 
   const popoverContent = (
     <Tabs
@@ -150,25 +150,28 @@ export default function ParameterEditor(props) {
         {
           label: "Yearly",
           key: "yearly",
-          children: yearSelector
+          children: yearSelector,
         },
         {
           label: "Advanced",
           key: "advanced",
-          children: dateSelector
-        }
+          children: dateSelector,
+        },
       ]}
       defaultActiveKey="yearly"
       type="card"
       size="small"
     />
-  )
+  );
 
   let dateSelectButtonLabel = "";
-  if (checkBoundaryDate(startDate, "start") && checkBoundaryDate(endDate, "end")) {
+  if (
+    checkBoundaryDate(startDate, "start") &&
+    checkBoundaryDate(endDate, "end")
+  ) {
     dateSelectButtonLabel = `from ${moment(startDate).year()} to ${moment(endDate).year()}`;
   } else {
-    dateSelectButtonLabel = `from ${moment(startDate).format("MMMM Do, YYYY")} to ${moment(endDate).format("MMMM Do, YYYY")}`
+    dateSelectButtonLabel = `from ${moment(startDate).format("MMMM Do, YYYY")} to ${moment(endDate).format("MMMM Do, YYYY")}`;
   }
 
   const mobile = useMobile();
@@ -181,7 +184,7 @@ export default function ParameterEditor(props) {
         paddingTop: 10,
         paddingLeft: 0,
         gap: 10,
-        width: "100%"
+        width: "100%",
         fontFamily: "Roboto Serif",
       }}
     >
@@ -191,9 +194,7 @@ export default function ParameterEditor(props) {
         content={popoverContent}
         placement={displayCategory === "mobile" ? "bottom" : "bottomRight"}
       >
-        <Button
-          type="text"
-        >
+        <Button type="text">
           {dateSelectButtonLabel}
           <CaretDownFilled
             style={{
@@ -269,29 +270,28 @@ export default function ParameterEditor(props) {
 }
 
 /**
- * Checks whether or not an input date is a boundary date - 
- * the first or last day of a fixed period (e.g., Jan. 1 or 
+ * Checks whether or not an input date is a boundary date -
+ * the first or last day of a fixed period (e.g., Jan. 1 or
  * Dec. 31)
- * @param {String} date 
+ * @param {String} date
  * @param {("start"|"end")} variant The date type - either a
  * period's start or its end date
  * @returns {Boolean} Whether or not the date is a boundary date
  */
 function checkBoundaryDate(date, variant) {
-
   // Define boundary dates and types
   // Note that month is 0-indexed in moment
   const boundaries = [
     {
       type: "start",
       month: 0,
-      date: 1
+      date: 1,
     },
     {
       type: "end",
       month: 11,
-      date: 31
-    }
+      date: 31,
+    },
   ];
 
   // Take the date and define it in terms of moment package
@@ -304,16 +304,15 @@ function checkBoundaryDate(date, variant) {
   for (const boundary of boundaries) {
     // Set up a test date using the test year and the boundary's defined
     // month and date
-    const testDate = moment().year(testYear).month(boundary.month).date(boundary.date);
+    const testDate = moment()
+      .year(testYear)
+      .month(boundary.month)
+      .date(boundary.date);
     // If the date is a boundary date, return true
-    if (
-      boundary.type === variant &&
-      testDate.isSame(momentDate, "date")
-    ) {
+    if (boundary.type === variant && testDate.isSame(momentDate, "date")) {
       return true;
     }
   }
   // If we've found no boundary dates, return false
   return false;
-
 }

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -123,9 +123,9 @@ export default function ParameterEditor(props) {
     <RangePicker
       picker="year"
       defaultValue={[moment(startDate), moment(endDate)]}
-      onChange={(_, dateStrings) => {
-        setStartDate(dateStrings[0]);
-        setEndDate(dateStrings[1]);
+      onChange={(_, yearStrings) => {
+        setStartDate(yearStrings[0].concat("-01-01"));
+        setEndDate(yearStrings[1].concat("-12-31"));
       }}
       disabledDate={(date) => date.isBefore("2021-01-01")}
       separator="→"

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -25,6 +25,7 @@ import { cmpDates, nextDay, prevDay } from "lang/stringDates";
 import moment from "dayjs";
 import StableInputNumber from "controls/StableInputNumber";
 import useDisplayCategory from "hooks/useDisplayCategory";
+import style from "../../../style";
 
 const { RangePicker } = DatePicker;
 
@@ -275,7 +276,7 @@ function PeriodSetter(props) {
     <Popover trigger="click" content={popoverContent} placement="bottom">
       <Tooltip title="Click to edit parameter timespan">
         <Button
-          type="text"
+          type="default"
           style={{
             width: "max-content",
           }}

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -51,7 +51,6 @@ export default function ParameterEditor(props) {
 
       setStartDate(reformStartDate);
       setEndDate(reformEndDate);
-
     }
   }, [reformData]);
 
@@ -140,6 +139,11 @@ export default function ParameterEditor(props) {
     );
   }
 
+  useEffect(() => {
+    console.log(startDate);
+    console.log(endDate + "\n");
+  }, [startDate, endDate])
+
   // Array of selectable years, sorted in ascending order
   const possibleYears = metadata.economy_options.time_period.map((period) => period.name).sort();
   const minPossibleDate = String(possibleYears[0]).concat("-01-01");
@@ -150,6 +154,7 @@ export default function ParameterEditor(props) {
     <RangePicker
       picker="year"
       defaultValue={[moment(startDate), defaultEnd]}
+      value={[moment(startDate), endDate === "2100-12-31" ? null : moment(endDate)]}
       onChange={(_, yearStrings) => {
         setStartDate(yearStrings[0].concat("-01-01"));
         setEndDate(yearStrings[1].concat("-12-31"));
@@ -162,6 +167,7 @@ export default function ParameterEditor(props) {
   const dateSelector = (
     <RangePicker
       defaultValue={[moment(startDate), defaultEnd]}
+      value={[moment(startDate), endDate === "2100-12-31" ? null : moment(endDate)]}
       onChange={(_, dateStrings) => {
         setStartDate(dateStrings[0]);
         setEndDate(dateStrings[1]);
@@ -218,7 +224,6 @@ export default function ParameterEditor(props) {
     dateSelectButtonLabel = `from ${moment(startDate).year()} to ${moment(endDate).year()}:`;
   }
 
-  const mobile = useMobile();
   let gridTemplate = null;
   if (displayCategory === "mobile" || displayCategory === "tablet") {
     gridTemplate = "repeat(2, 1fr) / 1fr";

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -204,11 +204,13 @@ export default function ParameterEditor(props) {
         trigger="click"
         content={popoverContent}
         placement={displayCategory === "mobile" ? "bottom" : "bottomRight"}
-        style={{
-          justifySelf: "end"
-        }}
       >
-        <Button type="text">
+        <Button 
+          type="text"
+          style={{
+            width: "100%"
+          }}
+        >
           {dateSelectButtonLabel}
           <CaretDownFilled
             style={{

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -1,6 +1,6 @@
 import CenteredMiddleColumn from "../../../layout/CenteredMiddleColumn";
 import ParameterOverTime from "./ParameterOverTime";
-import { Alert, Button, DatePicker, Popover, Switch, Tabs, Tooltip } from "antd";
+import { Alert, Button, DatePicker, Popover, Segmented, Switch, Tabs, Tooltip } from "antd";
 import { getNewPolicyId } from "../../../api/parameters";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -34,6 +34,7 @@ export default function ParameterEditor(props) {
   const [searchParams, setSearchParams] = useSearchParams();
   const [startDate, setStartDate] = useState(defaultStartDate);
   const [endDate, setEndDate] = useState(defaultEndDate);
+  const [visibleDateSelector, setVisibleDateSelector] = useState(null);
 
   const displayCategory = useDisplayCategory();
   const startValue = reformMap.get(startDate);
@@ -53,6 +54,14 @@ export default function ParameterEditor(props) {
 
     }
   }, [reformData]);
+
+  useEffect(() => {
+    setVisibleDateSelector(yearSelector);
+  }, []);
+
+  function handleSegmentedChange(value) {
+    setVisibleDateSelector(value);
+  }
 
   function onChange(value) {
     reformMap.set(startDate, nextDay(endDate), value);
@@ -167,23 +176,30 @@ export default function ParameterEditor(props) {
   );
 
   const popoverContent = (
-    <Tabs
-      items={[
-        {
-          label: "Yearly",
-          key: "yearly",
-          children: yearSelector,
-        },
-        {
-          label: "Advanced",
-          key: "advanced",
-          children: dateSelector,
-        },
-      ]}
-      defaultActiveKey="yearly"
-      type="card"
-      size="small"
-    />
+    <div
+      style={{
+        width: "100%",
+      }}
+    >
+      <Segmented
+        block
+        options={[
+          "Yearly",
+          "Advanced"
+        ]}
+        width="100%"
+        onChange={handleSegmentedChange}
+        style={{
+          marginBottom: "10px",
+        }}
+      />
+      {visibleDateSelector === "Yearly" ? (
+        yearSelector
+      ) : (
+        dateSelector
+      )
+      }
+    </div>
   );
 
   let dateSelectButtonLabel = "";

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -13,9 +13,7 @@ import { IntervalMap } from "algorithms/IntervalMap";
 import { cmpDates, nextDay, prevDay } from "lang/stringDates";
 import moment from "dayjs";
 import StableInputNumber from "controls/StableInputNumber";
-import { CaretDownFilled, SettingOutlined } from "@ant-design/icons";
 import useDisplayCategory from "redesign/components/useDisplayCategory";
-import style from "../../../style";
 
 const { RangePicker } = DatePicker;
 

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -34,7 +34,7 @@ export default function ParameterEditor(props) {
   const [searchParams, setSearchParams] = useSearchParams();
   const [startDate, setStartDate] = useState(defaultStartDate);
   const [endDate, setEndDate] = useState(defaultEndDate);
-  const [visibleDateSelector, setVisibleDateSelector] = useState(null);
+  const [visibleDateSelector, setVisibleDateSelector] = useState("yearly");
 
   const displayCategory = useDisplayCategory();
   const startValue = reformMap.get(startDate);
@@ -54,10 +54,6 @@ export default function ParameterEditor(props) {
 
     }
   }, [reformData]);
-
-  useEffect(() => {
-    setVisibleDateSelector(yearSelector);
-  }, []);
 
   function handleSegmentedChange(value) {
     setVisibleDateSelector(value);
@@ -184,8 +180,14 @@ export default function ParameterEditor(props) {
       <Segmented
         block
         options={[
-          "Yearly",
-          "Advanced"
+          {
+            label: "Yearly",
+            value: "yearly"
+          },
+          {
+            label: "Advanced",
+            value: "date"
+          }
         ]}
         width="100%"
         onChange={handleSegmentedChange}
@@ -193,7 +195,7 @@ export default function ParameterEditor(props) {
           marginBottom: "10px",
         }}
       />
-      {visibleDateSelector === "Yearly" ? (
+      {visibleDateSelector === "yearly" ? (
         yearSelector
       ) : (
         dateSelector

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -362,7 +362,8 @@ function ValueSetter(props) {
     return (
       <StableInputNumber
         style={{
-          width: displayCategory === "mobile" ? "50%" : "100%",
+          width: "100%",
+          minWidth: "100px"
         }}
         key={"input for" + parameter.parameter}
         {...(isCurrency

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -164,6 +164,13 @@ export default function ParameterEditor(props) {
     />
   )
 
+  let dateSelectButtonLabel = "";
+  if (checkBoundaryDate(startDate, "start") && checkBoundaryDate(endDate, "end")) {
+    dateSelectButtonLabel = `from ${moment(startDate).year()} to ${moment(endDate).year()}`;
+  } else {
+    dateSelectButtonLabel = `from ${moment(startDate).format("MMMM Do, YYYY")} to ${moment(endDate).format("MMMM Do, YYYY")}`
+  }
+
   const mobile = useMobile();
   const editControl = (
     <div
@@ -187,7 +194,7 @@ export default function ParameterEditor(props) {
         <Button
           type="text"
         >
-          from 2024 onward
+          {dateSelectButtonLabel}
           <CaretDownFilled
             style={{
               display: "inline-flex",
@@ -259,4 +266,54 @@ export default function ParameterEditor(props) {
       </div>
     </CenteredMiddleColumn>
   );
+}
+
+/**
+ * Checks whether or not an input date is a boundary date - 
+ * the first or last day of a fixed period (e.g., Jan. 1 or 
+ * Dec. 31)
+ * @param {String} date 
+ * @param {("start"|"end")} variant The date type - either a
+ * period's start or its end date
+ * @returns {Boolean} Whether or not the date is a boundary date
+ */
+function checkBoundaryDate(date, variant) {
+
+  // Define boundary dates and types
+  // Note that month is 0-indexed in moment
+  const boundaries = [
+    {
+      type: "start",
+      month: 0,
+      date: 1
+    },
+    {
+      type: "end",
+      month: 11,
+      date: 31
+    }
+  ];
+
+  // Take the date and define it in terms of moment package
+  const momentDate = moment(date);
+
+  // Duplicate its year for testing purposes
+  const testYear = momentDate.year();
+
+  // For each boundary defined above
+  for (const boundary of boundaries) {
+    // Set up a test date using the test year and the boundary's defined
+    // month and date
+    const testDate = moment().year(testYear).month(boundary.month).date(boundary.date);
+    // If the date is a boundary date, return true
+    if (
+      boundary.type === variant &&
+      testDate.isSame(momentDate, "date")
+    ) {
+      return true;
+    }
+  }
+  // If we've found no boundary dates, return false
+  return false;
+
 }

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -1,13 +1,25 @@
 import CenteredMiddleColumn from "../../../layout/CenteredMiddleColumn";
 import ParameterOverTime from "./ParameterOverTime";
-import { Alert, Button, DatePicker, Popover, Segmented, Switch, Tooltip } from "antd";
+import {
+  Alert,
+  Button,
+  DatePicker,
+  Popover,
+  Segmented,
+  Switch,
+  Tooltip,
+} from "antd";
 import { getNewPolicyId } from "../../../api/parameters";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { copySearchParams } from "../../../api/call";
 import { capitalize, localeCode } from "../../../lang/format";
 import { currencyMap } from "../../../api/variables";
-import { defaultStartDate, defaultEndDate, defaultForeverYear } from "data/constants";
+import {
+  defaultStartDate,
+  defaultEndDate,
+  defaultForeverYear,
+} from "data/constants";
 import { IntervalMap } from "algorithms/IntervalMap";
 import { cmpDates, nextDay, prevDay } from "lang/stringDates";
 import moment from "dayjs";
@@ -19,7 +31,7 @@ const { RangePicker } = DatePicker;
 /**
  * Component used to edit the values for a parameter; this is itself
  * composed of two sub-components: PeriodSetter and ValueSetter
- * @param {Object} props 
+ * @param {Object} props
  * @param {Object} props.metadata
  * @param {Object} props.policy
  * @param {String} props.parameterName
@@ -45,11 +57,10 @@ export default function ParameterEditor(props) {
   const displayCategory = useDisplayCategory();
 
   useEffect(() => {
-
     if (reformData && Object.keys(reformData).length > 0) {
       // Assign the dates of the first item from the reform data
       // as the default start and end dates and value; this should
-      // be written against a stronger structure in the future, as 
+      // be written against a stronger structure in the future, as
       // JS Objects have no guaranteed order
       const reformDates = Object.keys(reformData)[0];
       const [reformStartDate, reformEndDate] = reformDates.split(".");
@@ -94,14 +105,14 @@ export default function ParameterEditor(props) {
           width: "100%",
         }}
       >
-        <PeriodSetter 
+        <PeriodSetter
           metadata={metadata}
           startDate={startDate}
           endDate={endDate}
           setStartDate={setStartDate}
           setEndDate={setEndDate}
         />
-        <ValueSetter 
+        <ValueSetter
           startDate={startDate}
           endDate={endDate}
           parameterName={parameterName}
@@ -132,13 +143,7 @@ export default function ParameterEditor(props) {
 }
 
 function PeriodSetter(props) {
-  const {
-    metadata,
-    startDate,
-    endDate,
-    setStartDate,
-    setEndDate
-  } = props;
+  const { metadata, startDate, endDate, setStartDate, setEndDate } = props;
 
   const [visibleDateSelector, setVisibleDateSelector] = useState("yearly");
 
@@ -149,16 +154,18 @@ function PeriodSetter(props) {
   const FOREVER_DATE = String(defaultForeverYear).concat("-12-31");
 
   // Array of selectable years, sorted in ascending order
-  const possibleYears = metadata.economy_options.time_period.map((period) => period.name).sort();
+  const possibleYears = metadata.economy_options.time_period
+    .map((period) => period.name)
+    .sort();
   const minPossibleDate = String(possibleYears[0]).concat("-01-01");
-  const maxPossibleDate = String(possibleYears[possibleYears.length - 1] + 10).concat("-12-31");
+  const maxPossibleDate = String(
+    possibleYears[possibleYears.length - 1] + 10,
+  ).concat("-12-31");
   const isEndForever = endDate === FOREVER_DATE;
 
   let dateSelectButtonLabel = "";
-  const isFullYearSet = (
-    checkBoundaryDate(startDate, "start") &&
-    checkBoundaryDate(endDate, "end")
-  );
+  const isFullYearSet =
+    checkBoundaryDate(startDate, "start") && checkBoundaryDate(endDate, "end");
 
   if (!isFullYearSet) {
     dateSelectButtonLabel = `from ${moment(startDate).format("MMMM Do, YYYY")} to ${moment(endDate).format("MMMM Do, YYYY")}:`;
@@ -177,7 +184,9 @@ function PeriodSetter(props) {
         setStartDate(yearStrings[0].concat("-01-01"));
         setEndDate(yearStrings[1].concat("-12-31"));
       }}
-      disabledDate={(date) => date.isBefore(minPossibleDate) || date.isAfter(maxPossibleDate)}
+      disabledDate={(date) =>
+        date.isBefore(minPossibleDate) || date.isAfter(maxPossibleDate)
+      }
       separator="→"
     />
   );
@@ -190,7 +199,9 @@ function PeriodSetter(props) {
         setStartDate(dateStrings[0]);
         setEndDate(dateStrings[1]);
       }}
-      disabledDate={(date) => date.isBefore(minPossibleDate) || date.isAfter(maxPossibleDate)}
+      disabledDate={(date) =>
+        date.isBefore(minPossibleDate) || date.isAfter(maxPossibleDate)
+      }
       separator="→"
     />
   );
@@ -206,12 +217,12 @@ function PeriodSetter(props) {
         options={[
           {
             label: "Yearly",
-            value: "yearly"
+            value: "yearly",
           },
           {
             label: "Advanced",
-            value: "date"
-          }
+            value: "date",
+          },
         ]}
         width="100%"
         onChange={handleSegmentedChange}
@@ -219,26 +230,17 @@ function PeriodSetter(props) {
           marginBottom: "10px",
         }}
       />
-      {visibleDateSelector === "yearly" ? (
-        yearSelector
-      ) : (
-        dateSelector
-      )
-      }
+      {visibleDateSelector === "yearly" ? yearSelector : dateSelector}
     </div>
   );
 
   return (
-    <Popover
-      trigger="click"
-      content={popoverContent}
-      placement="bottom"
-    >
+    <Popover trigger="click" content={popoverContent} placement="bottom">
       <Tooltip title="Click to edit parameter timespan">
-        <Button 
+        <Button
           type="text"
           style={{
-            width: "100%"
+            width: "100%",
           }}
         >
           {dateSelectButtonLabel}
@@ -256,7 +258,7 @@ function ValueSetter(props) {
     metadata,
     reformMap,
     baseMap,
-    policy
+    policy,
   } = props;
 
   const [searchParams, setSearchParams] = useSearchParams();

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -2,7 +2,7 @@ import CenteredMiddleColumn from "../../../layout/CenteredMiddleColumn";
 import ParameterOverTime from "./ParameterOverTime";
 import { Alert, Button, DatePicker, Popover, Switch, Tabs } from "antd";
 import { getNewPolicyId } from "../../../api/parameters";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { copySearchParams } from "../../../api/call";
 import useMobile from "../../../layout/Responsive";
@@ -123,11 +123,12 @@ export default function ParameterEditor(props) {
   const possibleYears = metadata.economy_options.time_period.map((period) => period.name).sort();
   const minPossibleDate = String(possibleYears[0]).concat("-01-01");
   const maxPossibleDate = String(possibleYears[possibleYears.length - 1] + 10).concat("-12-31");
+  const defaultEnd = endDate === String(defaultForeverYear).concat("-12-31") ? null : moment(endDate);
 
   const yearSelector = (
     <RangePicker
       picker="year"
-      defaultValue={[moment(startDate), moment(endDate)]}
+      defaultValue={[moment(startDate), defaultEnd]}
       onChange={(_, yearStrings) => {
         setStartDate(yearStrings[0].concat("-01-01"));
         setEndDate(yearStrings[1].concat("-12-31"));
@@ -139,7 +140,7 @@ export default function ParameterEditor(props) {
 
   const dateSelector = (
     <RangePicker
-      defaultValue={[moment(startDate), moment(endDate)]}
+      defaultValue={[moment(startDate), defaultEnd]}
       onChange={(_, dateStrings) => {
         setStartDate(dateStrings[0]);
         setEndDate(dateStrings[1]);

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -13,8 +13,9 @@ import { IntervalMap } from "algorithms/IntervalMap";
 import { cmpDates, nextDay, prevDay } from "lang/stringDates";
 import moment from "dayjs";
 import StableInputNumber from "controls/StableInputNumber";
-import { CaretDownFilled } from "@ant-design/icons";
+import { CaretDownFilled, SettingOutlined } from "@ant-design/icons";
 import useDisplayCategory from "redesign/components/useDisplayCategory";
+import style from "../../../style";
 
 const { RangePicker } = DatePicker;
 
@@ -194,11 +195,11 @@ export default function ParameterEditor(props) {
   );
 
   if (!isFullYearSet) {
-    dateSelectButtonLabel = `from ${moment(startDate).format("MMMM Do, YYYY")} to ${moment(endDate).format("MMMM Do, YYYY")}`;
+    dateSelectButtonLabel = `from ${moment(startDate).format("MMMM Do, YYYY")} to ${moment(endDate).format("MMMM Do, YYYY")}:`;
   } else if (moment(endDate).year() === Number(defaultForeverYear)) {
-    dateSelectButtonLabel = `from ${moment(startDate).year()} onward`;
+    dateSelectButtonLabel = `from ${moment(startDate).year()} onward:`;
   } else {
-    dateSelectButtonLabel = `from ${moment(startDate).year()} to ${moment(endDate).year()}`;
+    dateSelectButtonLabel = `from ${moment(startDate).year()} to ${moment(endDate).year()}:`;
   }
 
   const mobile = useMobile();
@@ -226,7 +227,7 @@ export default function ParameterEditor(props) {
       <Popover
         trigger="click"
         content={popoverContent}
-        placement={displayCategory === "mobile" ? "bottom" : "bottomRight"}
+        placement="bottom"
       >
         <Button 
           type="text"
@@ -235,12 +236,15 @@ export default function ParameterEditor(props) {
           }}
         >
           {dateSelectButtonLabel}
-          <CaretDownFilled
+          {/*
+          <SettingOutlined
             style={{
+              color: style.colors.DARK_GRAY,
               display: "inline-flex",
               alignItems: "center",
             }}
           />
+          */}
         </Button>
       </Popover>
       {control}

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -46,7 +46,7 @@ export default function ParameterEditor(props) {
       // as the default start and end dates and value; this should
       // be written against a stronger structure in the future, as 
       // JS Objects have no guaranteed order
-      const [reformDates, reformValue] = Object.entries(reformData)[0];
+      const reformDates = Object.keys(reformData)[0];
       const [reformStartDate, reformEndDate] = reformDates.split(".");
 
       setStartDate(reformStartDate);

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -21,11 +21,8 @@ const { RangePicker } = DatePicker;
 export default function ParameterEditor(props) {
   const { metadata, policy, parameterName } = props;
   const parameter = metadata.parameters[parameterName];
-  const reformData = policy?.reform?.data?.[parameterName];
   const parameterValues = Object.entries(parameter.values);
-  const [searchParams, setSearchParams] = useSearchParams();
-  const [startDate, setStartDate] = useState(defaultStartDate);
-  const [endDate, setEndDate] = useState(defaultEndDate);
+  const reformData = policy?.reform?.data?.[parameterName];
   const baseMap = new IntervalMap(parameterValues, cmpDates, (x, y) => x === y);
   const reformMap = baseMap.copy();
   if (reformData) {
@@ -35,8 +32,28 @@ export default function ParameterEditor(props) {
     }
   }
 
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [startDate, setStartDate] = useState(defaultStartDate);
+  const [endDate, setEndDate] = useState(defaultEndDate);
+
   const displayCategory = useDisplayCategory();
   const startValue = reformMap.get(startDate);
+
+  useEffect(() => {
+
+    if (reformData) {
+      // Assign the dates of the first item from the reform data
+      // as the default start and end dates and value; this should
+      // be written against a stronger structure in the future, as 
+      // JS Objects have no guaranteed order
+      const [reformDates, reformValue] = Object.entries(reformData)[0];
+      const [reformStartDate, reformEndDate] = reformDates.split(".");
+
+      setStartDate(reformStartDate);
+      setEndDate(reformEndDate);
+
+    }
+  }, [reformData]);
 
   function onChange(value) {
     reformMap.set(startDate, nextDay(endDate), value);

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -1,6 +1,6 @@
 import CenteredMiddleColumn from "../../../layout/CenteredMiddleColumn";
 import ParameterOverTime from "./ParameterOverTime";
-import { Alert, Button, DatePicker, Popover, Switch, Tabs } from "antd";
+import { Alert, Button, DatePicker, Popover, Switch, Tabs, Tooltip } from "antd";
 import { getNewPolicyId } from "../../../api/parameters";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -229,23 +229,16 @@ export default function ParameterEditor(props) {
         content={popoverContent}
         placement="bottom"
       >
-        <Button 
-          type="text"
-          style={{
-            width: "100%"
-          }}
-        >
-          {dateSelectButtonLabel}
-          {/*
-          <SettingOutlined
+        <Tooltip title="Click to edit parameter timespan">
+          <Button 
+            type="text"
             style={{
-              color: style.colors.DARK_GRAY,
-              display: "inline-flex",
-              alignItems: "center",
+              width: "100%"
             }}
-          />
-          */}
-        </Button>
+          >
+            {dateSelectButtonLabel}
+          </Button>
+        </Tooltip>
       </Popover>
       {control}
     </div>

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -119,6 +119,11 @@ export default function ParameterEditor(props) {
     );
   }
 
+  // Array of selectable years, sorted in ascending order
+  const possibleYears = metadata.economy_options.time_period.map((period) => period.name).sort();
+  const minPossibleDate = String(possibleYears[0]).concat("-01-01");
+  const maxPossibleDate = String(possibleYears[possibleYears.length - 1] + 10).concat("-12-31");
+
   const yearSelector = (
     <RangePicker
       picker="year"
@@ -127,7 +132,7 @@ export default function ParameterEditor(props) {
         setStartDate(yearStrings[0].concat("-01-01"));
         setEndDate(yearStrings[1].concat("-12-31"));
       }}
-      disabledDate={(date) => date.isBefore("2021-01-01")}
+      disabledDate={(date) => date.isBefore(minPossibleDate) || date.isAfter(maxPossibleDate)}
       separator="→"
     />
   );
@@ -139,7 +144,7 @@ export default function ParameterEditor(props) {
         setStartDate(dateStrings[0]);
         setEndDate(dateStrings[1]);
       }}
-      disabledDate={(date) => date.isBefore("2021-01-01")}
+      disabledDate={(date) => date.isBefore(minPossibleDate) || date.isAfter(maxPossibleDate)}
       separator="→"
     />
   );

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -90,7 +90,7 @@ export default function ParameterEditor(props) {
     control = (
       <StableInputNumber
         style={{
-          width: "50%",
+          width: displayCategory === "mobile" ? "50%" : "100%",
         }}
         key={"input for" + parameter.parameter}
         {...(isCurrency
@@ -179,24 +179,34 @@ export default function ParameterEditor(props) {
   }
 
   const mobile = useMobile();
+  let gridTemplate = null;
+  if (displayCategory === "mobile" || displayCategory === "tablet") {
+    gridTemplate = "repeat(2, 1fr) / 1fr";
+  } else {
+    gridTemplate = "1fr / repeat(2, 1fr)";
+  }
+
   const editControl = (
     <div
       style={{
-        display: "flex",
-        flexDirection: mobile ? "column" : "row",
+        display: "grid",
+        justifyItems: "center",
+        gridTemplate: gridTemplate,
         alignItems: "center",
-        paddingTop: 10,
-        paddingLeft: 0,
+        padding: displayCategory !== "mobile" && "20px 80px 0 80px",
+        paddingTop: 20,
         gap: 10,
         width: "100%",
         fontFamily: "Roboto Serif",
       }}
     >
-      {control}
       <Popover
         trigger="click"
         content={popoverContent}
         placement={displayCategory === "mobile" ? "bottom" : "bottomRight"}
+        style={{
+          justifySelf: "end"
+        }}
       >
         <Button type="text">
           {dateSelectButtonLabel}
@@ -208,6 +218,7 @@ export default function ParameterEditor(props) {
           />
         </Button>
       </Popover>
+      {control}
     </div>
   );
 

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -1,11 +1,10 @@
 import CenteredMiddleColumn from "../../../layout/CenteredMiddleColumn";
 import ParameterOverTime from "./ParameterOverTime";
-import { Alert, Button, DatePicker, Popover, Segmented, Switch, Tabs, Tooltip } from "antd";
+import { Alert, Button, DatePicker, Popover, Segmented, Switch, Tooltip } from "antd";
 import { getNewPolicyId } from "../../../api/parameters";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { copySearchParams } from "../../../api/call";
-import useMobile from "../../../layout/Responsive";
 import { capitalize, localeCode } from "../../../lang/format";
 import { currencyMap } from "../../../api/variables";
 import { defaultStartDate, defaultEndDate, defaultForeverYear } from "data/constants";
@@ -17,6 +16,15 @@ import useDisplayCategory from "redesign/components/useDisplayCategory";
 
 const { RangePicker } = DatePicker;
 
+/**
+ * Component used to edit the values for a parameter; this is itself
+ * composed of two sub-components: PeriodSetter and ValueSetter
+ * @param {Object} props 
+ * @param {Object} props.metadata
+ * @param {Object} props.policy
+ * @param {String} props.parameterName
+ * @returns {import("react-markdown/lib/react-markdown").ReactElement}
+ */
 export default function ParameterEditor(props) {
   const { metadata, policy, parameterName } = props;
   const parameter = metadata.parameters[parameterName];
@@ -31,13 +39,10 @@ export default function ParameterEditor(props) {
     }
   }
 
-  const [searchParams, setSearchParams] = useSearchParams();
   const [startDate, setStartDate] = useState(defaultStartDate);
   const [endDate, setEndDate] = useState(defaultEndDate);
-  const [visibleDateSelector, setVisibleDateSelector] = useState("yearly");
 
   const displayCategory = useDisplayCategory();
-  const startValue = reformMap.get(startDate);
 
   useEffect(() => {
 
@@ -54,101 +59,117 @@ export default function ParameterEditor(props) {
     }
   }, [reformData]);
 
-  function handleSegmentedChange(value) {
-    setVisibleDateSelector(value);
-  }
-
-  function onChange(value) {
-    reformMap.set(startDate, nextDay(endDate), value);
-    let data = {};
-    reformMap.minus(baseMap).forEach(([k1, k2, v]) => {
-      data[`${k1}.${prevDay(k2)}`] = v;
-    });
-    const newReforms = { ...policy.reform.data };
-    if (
-      Object.keys(data).length === 0 &&
-      Object.keys(newReforms).length === 1
-    ) {
-      let newSearch = copySearchParams(searchParams);
-      newSearch.delete("reform");
-      setSearchParams(newSearch);
-    } else {
-      newReforms[parameterName] = data;
-      getNewPolicyId(metadata.countryId, newReforms).then((result) => {
-        if (result.status !== "ok") {
-          console.error(
-            "ParameterEditor: In attempting to fetch new " +
-              "policy, the following error occurred: " +
-              result.message,
-          );
-        } else {
-          let newSearch = copySearchParams(searchParams);
-          newSearch.set("reform", result.policy_id);
-          setSearchParams(newSearch);
-        }
-      });
-    }
-  }
-
-  let control;
-
-  if (parameter.unit === "bool" || parameter.unit === "abolition") {
-    control = (
-      <div style={{ padding: 10 }}>
-        <Switch
-          key={"input for" + parameter.parameter}
-          defaultChecked={startValue}
-          onChange={(value) => onChange(!!value)}
-        />
-      </div>
-    );
-  } else {
-    const isPercent = parameter.unit === "/1";
-    const scale = isPercent ? 100 : 1;
-    const isCurrency = Object.keys(currencyMap).includes(parameter.unit);
-    const maximumFractionDigits = 2;
-    control = (
-      <StableInputNumber
-        style={{
-          width: displayCategory === "mobile" ? "50%" : "100%",
-        }}
-        key={"input for" + parameter.parameter}
-        {...(isCurrency
-          ? {
-              addonBefore: currencyMap[parameter.unit],
-            }
-          : {})}
-        {...(isPercent
-          ? {
-              addonAfter: "%",
-            }
-          : {})}
-        formatter={(value, { userTyping }) => {
-          const n = +value;
-          const isInteger = Number.isInteger(n);
-          return n.toLocaleString(localeCode(metadata.countryId), {
-            minimumFractionDigits: userTyping || isInteger ? 0 : 2,
-            maximumFractionDigits: userTyping ? 16 : maximumFractionDigits,
-          });
-        }}
-        defaultValue={Number(startValue) * scale}
-        onPressEnter={(_, value) =>
-          onChange(+value.toFixed(maximumFractionDigits) / scale)
-        }
-      />
-    );
-  }
-
   useEffect(() => {
     console.log(startDate);
     console.log(endDate + "\n");
   }, [startDate, endDate])
+
+  let gridTemplate = null;
+  if (displayCategory === "mobile" || displayCategory === "tablet") {
+    gridTemplate = "repeat(2, 1fr) / 1fr";
+  } else {
+    gridTemplate = "1fr / repeat(2, 1fr)";
+  }
+
+  const timePeriodSentence = parameter.period
+    ? ` This parameter is ${parameter.period}ly.`
+    : "";
+
+  let description = parameter.description;
+  if (!description) {
+    description = "";
+  }
+
+  return (
+    <CenteredMiddleColumn
+      marginTop="5%"
+      marginBottom={0}
+      title={capitalize(parameter.label)}
+      description={description + timePeriodSentence}
+    >
+      <div
+        style={{
+          display: "grid",
+          justifyItems: "center",
+          gridTemplate: gridTemplate,
+          alignItems: "center",
+          padding: displayCategory !== "mobile" && "20px 80px 0 80px",
+          paddingTop: 20,
+          gap: 10,
+          width: "100%",
+        }}
+      >
+        <PeriodSetter 
+          metadata={metadata}
+          startDate={startDate}
+          endDate={endDate}
+          setStartDate={setStartDate}
+          setEndDate={setEndDate}
+        />
+        <ValueSetter 
+          startDate={startDate}
+          endDate={endDate}
+          parameterName={parameterName}
+          policy={policy}
+          metadata={metadata}
+          reformMap={reformMap}
+          baseMap={baseMap}
+        />
+      </div>
+      {!parameter.economy && (
+        <Alert
+          message="PolicyEngine does not currently model this parameter in society-wide economic simulations."
+          type="warning"
+        />
+      )}
+      <ParameterOverTime
+        baseMap={baseMap}
+        {...(reformData &&
+          Object.keys(reformData).length > 0 && {
+            reformMap: reformMap,
+          })}
+        parameter={parameter}
+        policy={policy}
+        metadata={metadata}
+      />
+    </CenteredMiddleColumn>
+  );
+}
+
+function PeriodSetter(props) {
+  const {
+    metadata,
+    startDate,
+    endDate,
+    setStartDate,
+    setEndDate
+  } = props;
+
+  const [visibleDateSelector, setVisibleDateSelector] = useState("yearly");
+
+  function handleSegmentedChange(value) {
+    setVisibleDateSelector(value);
+  }
 
   // Array of selectable years, sorted in ascending order
   const possibleYears = metadata.economy_options.time_period.map((period) => period.name).sort();
   const minPossibleDate = String(possibleYears[0]).concat("-01-01");
   const maxPossibleDate = String(possibleYears[possibleYears.length - 1] + 10).concat("-12-31");
   const defaultEnd = endDate === String(defaultForeverYear).concat("-12-31") ? null : moment(endDate);
+
+  let dateSelectButtonLabel = "";
+  const isFullYearSet = (
+    checkBoundaryDate(startDate, "start") &&
+    checkBoundaryDate(endDate, "end")
+  );
+
+  if (!isFullYearSet) {
+    dateSelectButtonLabel = `from ${moment(startDate).format("MMMM Do, YYYY")} to ${moment(endDate).format("MMMM Do, YYYY")}:`;
+  } else if (moment(endDate).year() === Number(defaultForeverYear)) {
+    dateSelectButtonLabel = `from ${moment(startDate).year()} onward:`;
+  } else {
+    dateSelectButtonLabel = `from ${moment(startDate).year()} to ${moment(endDate).year()}:`;
+  }
 
   const yearSelector = (
     <RangePicker
@@ -210,121 +231,120 @@ export default function ParameterEditor(props) {
     </div>
   );
 
-  let dateSelectButtonLabel = "";
-  const isFullYearSet = (
-    checkBoundaryDate(startDate, "start") &&
-    checkBoundaryDate(endDate, "end")
-  );
-
-  if (!isFullYearSet) {
-    dateSelectButtonLabel = `from ${moment(startDate).format("MMMM Do, YYYY")} to ${moment(endDate).format("MMMM Do, YYYY")}:`;
-  } else if (moment(endDate).year() === Number(defaultForeverYear)) {
-    dateSelectButtonLabel = `from ${moment(startDate).year()} onward:`;
-  } else {
-    dateSelectButtonLabel = `from ${moment(startDate).year()} to ${moment(endDate).year()}:`;
-  }
-
-  let gridTemplate = null;
-  if (displayCategory === "mobile" || displayCategory === "tablet") {
-    gridTemplate = "repeat(2, 1fr) / 1fr";
-  } else {
-    gridTemplate = "1fr / repeat(2, 1fr)";
-  }
-
-  const editControl = (
-    <div
-      style={{
-        display: "grid",
-        justifyItems: "center",
-        gridTemplate: gridTemplate,
-        alignItems: "center",
-        padding: displayCategory !== "mobile" && "20px 80px 0 80px",
-        paddingTop: 20,
-        gap: 10,
-        width: "100%",
-        fontFamily: "Roboto Serif",
-      }}
-    >
-      <Popover
-        trigger="click"
-        content={popoverContent}
-        placement="bottom"
-      >
-        <Tooltip title="Click to edit parameter timespan">
-          <Button 
-            type="text"
-            style={{
-              width: "100%"
-            }}
-          >
-            {dateSelectButtonLabel}
-          </Button>
-        </Tooltip>
-      </Popover>
-      {control}
-    </div>
-  );
-
-  let description = parameter.description;
-  if (!description) {
-    description = "";
-  }
-
   return (
-    <CenteredMiddleColumn
-      marginTop="5%"
-      marginBottom={0}
-      title={capitalize(parameter.label)}
-      description={description}
+    <Popover
+      trigger="click"
+      content={popoverContent}
+      placement="bottom"
     >
-      <div>
-        <p
+      <Tooltip title="Click to edit parameter timespan">
+        <Button 
+          type="text"
           style={{
-            marginBottom: 2,
-            fontFamily: "Roboto",
-            marginTop: 10,
-            color: "grey",
-            display: "inline-block",
+            width: "100%"
           }}
         >
-          Current value
-        </p>
-      </div>
-      {editControl}
-      {!parameter.economy && (
-        <div style={{ paddingTop: 20 }}>
-          <Alert
-            message="PolicyEngine does not currently model this parameter in society-wide economic simulations."
-            type="warning"
-          />
-        </div>
-      )}
-      <div style={{ paddingRight: 30, marginTop: 30 }}>
-        <p
-          style={{
-            marginBottom: 0,
-            color: "grey",
-            display: "inline-block",
-            fontFamily: "Roboto",
-          }}
-        >
-          Historical values
-        </p>
-      </div>
-      <div style={{ marginLeft: -25 }}>
-        <ParameterOverTime
-          baseMap={baseMap}
-          {...(reformData &&
-            Object.keys(reformData).length > 0 && {
-              reformMap: reformMap,
-            })}
-          parameter={parameter}
-          policy={policy}
-          metadata={metadata}
+          {dateSelectButtonLabel}
+        </Button>
+      </Tooltip>
+    </Popover>
+  );
+}
+
+function ValueSetter(props) {
+  const {
+    startDate,
+    endDate,
+    parameterName,
+    metadata,
+    reformMap,
+    baseMap,
+    policy
+  } = props;
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const displayCategory = useDisplayCategory();
+  const startValue = reformMap.get(startDate);
+  const parameter = metadata.parameters[parameterName];
+
+  function changeHandler(value) {
+    reformMap.set(startDate, nextDay(endDate), value);
+    let data = {};
+    reformMap.minus(baseMap).forEach(([k1, k2, v]) => {
+      data[`${k1}.${prevDay(k2)}`] = v;
+    });
+    const newReforms = { ...policy.reform.data };
+    if (
+      Object.keys(data).length === 0 &&
+      Object.keys(newReforms).length === 1
+    ) {
+      let newSearch = copySearchParams(searchParams);
+      newSearch.delete("reform");
+      setSearchParams(newSearch);
+    } else {
+      newReforms[parameterName] = data;
+      getNewPolicyId(metadata.countryId, newReforms).then((result) => {
+        if (result.status !== "ok") {
+          console.error(
+            "ParameterEditor: In attempting to fetch new " +
+              "policy, the following error occurred: " +
+              result.message,
+          );
+        } else {
+          let newSearch = copySearchParams(searchParams);
+          newSearch.set("reform", result.policy_id);
+          setSearchParams(newSearch);
+        }
+      });
+    }
+  }
+
+  if (parameter.unit === "bool" || parameter.unit === "abolition") {
+    return (
+      <div style={{ padding: 10 }}>
+        <Switch
+          key={"input for" + parameter.parameter}
+          defaultChecked={startValue}
+          onChange={(value) => changeHandler(!!value)}
         />
       </div>
-    </CenteredMiddleColumn>
-  );
+    );
+  } else {
+    const isPercent = parameter.unit === "/1";
+    const scale = isPercent ? 100 : 1;
+    const isCurrency = Object.keys(currencyMap).includes(parameter.unit);
+    const maximumFractionDigits = isCurrency ? 2 : 16;
+    return (
+      <StableInputNumber
+        style={{
+          width: displayCategory === "mobile" ? "50%" : "100%",
+        }}
+        key={"input for" + parameter.parameter}
+        {...(isCurrency
+          ? {
+              addonBefore: currencyMap[parameter.unit],
+            }
+          : {})}
+        {...(isPercent
+          ? {
+              addonAfter: "%",
+            }
+          : {})}
+        formatter={(value, { userTyping }) => {
+          const n = +value;
+          const isInteger = Number.isInteger(n);
+          return n.toLocaleString(localeCode(metadata.countryId), {
+            minimumFractionDigits: userTyping || isInteger ? 0 : 2,
+            maximumFractionDigits: userTyping ? 16 : maximumFractionDigits,
+          });
+        }}
+        defaultValue={Number(startValue) * scale}
+        onPressEnter={(_, value) =>
+          changeHandler(+value.toFixed(maximumFractionDigits) / scale)
+        }
+      />
+    );
+  }
 }
 
 /**

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -24,7 +24,6 @@ import { IntervalMap } from "algorithms/IntervalMap";
 import { cmpDates, nextDay, prevDay } from "lang/stringDates";
 import moment from "dayjs";
 import StableInputNumber from "controls/StableInputNumber";
-import useDisplayCategory from "hooks/useDisplayCategory";
 
 const { RangePicker } = DatePicker;
 
@@ -53,8 +52,6 @@ export default function ParameterEditor(props) {
 
   const [startDate, setStartDate] = useState(defaultStartDate);
   const [endDate, setEndDate] = useState(defaultEndDate);
-
-  const displayCategory = useDisplayCategory();
 
   useEffect(() => {
     if (reformData && Object.keys(reformData).length > 0) {

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -8,7 +8,7 @@ import useMobile from "../../../layout/Responsive";
 import style from "../../../style";
 import { plotLayoutFont } from "pages/policy/output/utils";
 import { localeCode } from "lang/format";
-import { defaultEndDate, defaultStartDate } from "../../../data/constants";
+import { defaultPOTEndDate, defaultStartDate } from "../../../data/constants";
 import { useWindowHeight } from "../../../hooks/useWindow";
 
 /**
@@ -45,10 +45,14 @@ export default function ParameterOverTime(props) {
 
   let xaxisValues = reformedX ? x.concat(reformedX) : x;
   xaxisValues = xaxisValues.filter(
-    (e) => e !== "0000-01-01" && e !== "2099-12-31",
+    (e) => e !== "0000-01-01" && e < "2099-12-31",
   );
+
   xaxisValues.push(defaultStartDate);
-  xaxisValues.push(defaultEndDate);
+  // This value is used for preventing the chart from expanding
+  // beyond 10 years past the current date for policy changes
+  // defined until "forever" (i.e., 2100-12-31)
+  xaxisValues.push(defaultPOTEndDate);
   const yaxisValues = reformedY ? y.concat(reformedY) : y;
   const xaxisFormat = getPlotlyAxisFormat("date", xaxisValues);
   const yaxisFormat = getPlotlyAxisFormat(parameter.unit, yaxisValues);

--- a/src/style/colors.jsx
+++ b/src/style/colors.jsx
@@ -34,8 +34,6 @@ const colors = {
   DARK_BLUE_HOVER,
   BLUE_LIGHT,
   BLUE_PRESSED,
-  ANT_BORDER_GRAY,
-  ANT_HOVERED_LIGHT_GRAY
 };
 
 export default colors;

--- a/src/style/colors.jsx
+++ b/src/style/colors.jsx
@@ -34,6 +34,8 @@ const colors = {
   DARK_BLUE_HOVER,
   BLUE_LIGHT,
   BLUE_PRESSED,
+  ANT_BORDER_GRAY,
+  ANT_HOVERED_LIGHT_GRAY
 };
 
 export default colors;


### PR DESCRIPTION
## Description

Fixes #1261

## Changes

This PR re-engineers how users interact with the policy parameter editor component. 

As a workaround due to the limitations inherent within the API, specifically how it currently stores custom policies, this code chooses an arbitrary year (2100) to represent "forever," storing this as a constant. It operates from the assumption that any policy defined to end on Dec. 31, 2100, is meant to occur "forever," altering the UX to reflect this assumption. 

With this PR, when a user loads the parameter editor, the default period displayed to a user over which a parameter change will be made is the current year "onward," representing 2100-12-31 behind-the-scenes. When a user clicks on the displayed year, which is now shown to the left of the value, an editor component with two tabs is shown. The left tab, labeled "yearly," edits a parameter from Jan. 1 of the first year to Dec. 31 of the final, mirroring the behavior of many of the users looking to select custom dates. The years displayed are restricted to the first year present within the respective country's metadata to 10 years from the last year in the metadata (i.e., currently Dec. 31, 2035 for US and Dec. 31, 2037, I believe, for UK).

For the remaining small group of users looking to select specific dates, the "advanced" tab provides an editor akin to what the app currently has, allowing custom date selection. Both the "yearly" and "advanced" editors use an Ant Design `Popover` instead of a collapsible component to prevent forcing the display chart downward, as well as due to the fact that the default collapsible component is a block element, while this altered date setter is intended to sit inline with the existing value setting component.

This PR also changes the right-hand sidebar to properly display "forever" dates, showing "onward" in these cases, as well. Finally, it refactors the `ParameterEditor` component by breaking out its individual `ValueSetter` and `PeriodSetter` components in order to allow for easier editing of the logic of either of these sub-components in the future. 

At the moment, I'm hoping to gain feedback on the visuals of this component. In particular, should the date setter look more like a button? I have tried a few different permutations visually, each of which came out worse than the current setup:
* Manually setting a border on hover leads to visual bugs due to the (faster) CSS-based hover pseudo-class Ant Design uses
* Adding a ":" after the date makes it feel slightly less obvious that it's a button
* Right-aligning the date leaves a strange-looking gap to the left
* Adding a gear or pencil icon beside the date looks unbalanced and strange

## Screenshots


https://github.com/PolicyEngine/policyengine-app/assets/14987227/cce39e78-2df3-45a1-b013-03ca2fba5f43

## Tests

This PR does not yet contain tests. These will be written following confirmation on the component's visuals.
