### PR TITLE
Fix maximum fractional digits to 2 unconditionally

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -250,7 +250,7 @@ function HouseholdVariableEntityInput(props) {
   let control;
   if (variable.valueType === "float" || variable.valueType === "int") {
     const isCurrency = Object.keys(currencyMap).includes(variable.unit);
-    const maximumFractionDigits = isCurrency ? 2 : 16;
+    const maximumFractionDigits = 2;
     const onPressEnter = (_, value) =>
       submitValue(+value.toFixed(maximumFractionDigits));
     control = (

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -82,7 +82,7 @@ export default function ParameterEditor(props) {
     const isPercent = parameter.unit === "/1";
     const scale = isPercent ? 100 : 1;
     const isCurrency = Object.keys(currencyMap).includes(parameter.unit);
-    const maximumFractionDigits = isCurrency ? 2 : 16;
+    const maximumFractionDigits = 2;
     control = (
       <StableInputNumber
         key={"input for" + parameter.parameter}


### PR DESCRIPTION
## Description

- We fix #1355 by making changes in the API and core repos (see https://github.com/PolicyEngine/policyengine-api/issues/1195).
- We fix #1568 by fixing the maximum digits to 2 for numerical inputs in the household and policy editors.

## Screenshots

rate with the correct unit rounded to two places (input was `7.248`):

<img width="1260" alt="Screenshot 2024-04-05 at 10 31 45 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/e160fced-9843-486b-bc7e-116542e87ce8">

threshold with the correct unit rounded to two places (input was `180,000.501`):

<img width="1260" alt="Screenshot 2024-04-05 at 11 00 34 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/c667d259-3538-406f-80ef-a34393a83356">

age rounded to two places (input was `40.111`):

<img width="445" alt="Screenshot 2024-04-05 at 11 02 21 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/31144719/17f42ed7-2bff-41ab-a45e-97a4dbd13657">


## Tests

We checked that the household and policy editors were working correctly for a couple of cases.
