### PR TITLE
Remove rounding in parameter history hovercards

### DIFF
--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -50,6 +50,12 @@ export default function ParameterOverTime(props) {
   const xaxisFormat = getPlotlyAxisFormat("date", xaxisValues);
   const yaxisFormat = getPlotlyAxisFormat(parameter.unit, yaxisValues);
 
+  const calculateFormattedPercentage = (value) => {
+    const formattedPercentage = (value * 100).toFixed(2);
+    return `${formattedPercentage}%`;
+  };
+
+  const customdata = y.map(calculateFormattedPercentage);
   return (
     <>
       <Plot
@@ -65,6 +71,8 @@ export default function ParameterOverTime(props) {
               color: style.colors.GRAY,
             },
             name: "Current law",
+            customdata: customdata,
+            hovertemplate: "(%{x}, %{customdata}<extra></extra>)",
           },
           reformMap && {
             x: reformedX,

--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -50,12 +50,12 @@ export default function ParameterOverTime(props) {
   const xaxisFormat = getPlotlyAxisFormat("date", xaxisValues);
   const yaxisFormat = getPlotlyAxisFormat(parameter.unit, yaxisValues);
 
-  const calculateFormattedPercentage = (value) => {
-    const formattedPercentage = (value * 100).toFixed(2);
-    return `${formattedPercentage}%`;
-  };
+  // const calculateFormattedPercentage = (value) => {
+  //   const formattedPercentage = (value * 100).toFixed(2);
+  //   return `${formattedPercentage}%`;
+  // };
 
-  const customdata = y.map(calculateFormattedPercentage);
+  // const customdata = y.map(calculateFormattedPercentage);
   return (
     <>
       <Plot
@@ -72,7 +72,7 @@ export default function ParameterOverTime(props) {
             },
             name: "Current law",
             customdata: customdata,
-            hovertemplate: "(%{x}, %{customdata}<extra></extra>)",
+            // hovertemplate: "(%{x}, %{customdata}<extra></extra>)",
           },
           reformMap && {
             x: reformedX,
@@ -86,6 +86,7 @@ export default function ParameterOverTime(props) {
               color: style.colors.BLUE,
             },
             name: getReformPolicyLabel(policy),
+            // hovertemplate: "(%{x}, %{customdata}<extra></extra>)",
           },
         ].filter((x) => x)}
         layout={{

--- a/src/redesign/components/Research.jsx
+++ b/src/redesign/components/Research.jsx
@@ -444,6 +444,7 @@ function Checkbox({ label, checked, onCheck }) {
         }}
         onClick={() => {
           onCheck(!checked);
+          window.scrollTo(0, 0);
         }}
       />
       <p style={{ marginLeft: 15, margin: 0, fontFamily: "Roboto Serif" }}>


### PR DESCRIPTION
## Description

Don't round percentages in parameter history hovercards

## Screenshots
![94DB94C7-15AE-44D7-97C1-305F9FD6DDC5](https://github.com/PolicyEngine/policyengine-app/assets/100207648/a4fb272a-d3e5-46d1-89cf-5783c3706fc6)

## Tests

Please describe how the change has been tested.
