### PR TITLE
correct rounding of percentages in parameter history hovercard

### DIFF
--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -245,7 +245,7 @@ export function getPlotlyAxisFormat(unit, values, precisionOverride) {
     const r = range();
     const s = unit === "/1" ? 100 : 1;
     const d = (r[1] - r[0]) * s;
-    return d > 10 ? 0 : d === 0 ? 1 : 1 - Math.round(Math.log10(d));
+    return d > 10 ? 0 : d === 0 ? 1 : 1 - Math.floor(Math.log10(d));
   };
 
   const isCurrency = Object.keys(currencyMap).includes(unit);


### PR DESCRIPTION
## Description

noticed that the `Math.round` was causing the rounding off to next digit 

## Changes

used `Math.floor` instead

## Screenshots

![Screenshot from 2024-04-18 01-19-40](https://github.com/PolicyEngine/policyengine-app/assets/111173270/1c23f074-eabb-4da2-83dd-1cd76593fe11)

LGTM

## Tests

have run `make test` and `make format` , both of them passing.