### PR TITLE
Make fixes to social cards

### DIFF
--- a/gcp/social_card_tags.py
+++ b/gcp/social_card_tags.py
@@ -73,7 +73,7 @@ def get_image(path: str, query_params: dict, social_cards: dict = {}):
                 ".png",
                 ".jpeg",
                 ".jpg",
-                ".webp"
+                ".webp",
             ]:  # Twitter doesn't show the title so we include alternative versions.
                 for image_file in image_files:
                     if image_file.name.endswith(extension):

--- a/gcp/social_card_tags.py
+++ b/gcp/social_card_tags.py
@@ -6,7 +6,7 @@ from bs4 import BeautifulSoup
 # Load src/posts/posts.json
 with open("src/posts/posts.json") as f:
     posts: list = json.load(f)
-    post_by_slug = {post["filename"].split(".md")[0]: post for post in posts}
+    post_by_slug = {post["filename"].split(".")[0]: post for post in posts}
 
 
 def get_title(path: str, query_params: dict):
@@ -73,6 +73,7 @@ def get_image(path: str, query_params: dict, social_cards: dict = {}):
                 ".png",
                 ".jpeg",
                 ".jpg",
+                ".webp"
             ]:  # Twitter doesn't show the title so we include alternative versions.
                 for image_file in image_files:
                     if image_file.name.endswith(extension):


### PR DESCRIPTION
## Description

Fixes #1625.
Fixes #1626.

## Changes

First, this PR ensures that non-markdown posts are properly added to the `post_by_slug` dictionary in the social card generation code. Previously, the code generated a dictionary called `post_by_slug` that was used to generate social card elements, but it did this by taking all posts in `posts.json` and breaking their filename on `.md`, then extracting the first part, creating an invalid reference for all files not ending in `.md`, including the four most recent UK articles. By shortening this string tokenizer to `.`, all filenames are supported.

Second, it allows `.webp` image files to be added as an image to social cards.

## Screenshots

Unfortunately, these changes cannot be recorded or screenshotted, as they are run only on GCP build, and rely on files only present at that time.

## Tests

Unfortunately, this code is incredibly difficult to test, as its proper functioning requires files available within the deployment build. Therefore, no tests have been added, but this was tested locally by replicating the functions in a test file and comparing the output of articles with proper social cards to those without.
