### PR TITLE
fixed bug of percentage y axis formats over parameter graphs

### DIFF
--- a/src/pages/policy/input/ParameterOverTime.jsx
+++ b/src/pages/policy/input/ParameterOverTime.jsx
@@ -55,7 +55,7 @@ export default function ParameterOverTime(props) {
   const xaxisFormat = getPlotlyAxisFormat("date", xaxisValues);
   const yaxisFormat = getPlotlyAxisFormat(parameter.unit, yaxisValues);
   const customdata = y.map(calculateFormattedPercentage);
-  const reformedCustomdata = reformedY.map(calculateFormattedPercentage);
+  //const reformedCustomdata = reformedY.map(calculateFormattedPercentage);
 
   return (
     <>
@@ -73,7 +73,7 @@ export default function ParameterOverTime(props) {
             },
             name: "Current law",
             customdata: customdata,
-            hovertemplate: "%{x|%b, %Y}: %{customdata}<extra></extra>",
+            hovertemplate: "%{x}: %{customdata}<extra></extra>",
           },
           reformMap && {
             x: reformedX,
@@ -87,16 +87,13 @@ export default function ParameterOverTime(props) {
               color: style.colors.BLUE,
             },
             name: getReformPolicyLabel(policy),
-            customdata: reformedCustomdata,
-            hovertemplate: "%{x|%b, %Y}: %{customdata}<extra></extra>",
+            //customdata: reformedCustomdata,
+            //hovertemplate: "%{x|%b, %Y}: %{customdata}<extra></extra>",
           },
         ].filter((x) => x)}
         layout={{
           xaxis: { ...xaxisFormat },
-          yaxis: {
-            ...yaxisFormat,
-            tickformat: ",.0%",
-          },
+          yaxis: { ...yaxisFormat },
           legend: {
             // Position above the plot
             y: 1.2,


### PR DESCRIPTION
## Description

fixes #1631

changed the yaxis format accordingly

## Screenshots

![Screenshot from 2024-04-23 09-46-51](https://github.com/PolicyEngine/policyengine-app/assets/111173270/76359e00-92f9-4019-99c7-f4b601726c79)


## Tests

have run `make test` and `make format` both of them passing
