### PR TITLE
Use Enhanced CPS when specified for Reproduce in Python Microsimulation call

### DIFF
--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -206,7 +206,7 @@ export function getImplementationCode(type, region, timePeriod) {
   }
 
   const isCountryUS = US_REGIONS.includes(region);
-  //"reform=baseline_reform, dataset=\"enhanced_cps_" + timePeriod+"\""
+  
 
   return [
     "",

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -206,7 +206,6 @@ export function getImplementationCode(type, region, timePeriod) {
   }
 
   const isCountryUS = US_REGIONS.includes(region);
-  
 
   return [
     "",

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -213,13 +213,13 @@ export function getImplementationCode(type, region, timePeriod) {
     `baseline = Microsimulation(${
       isCountryUS
         ? region === "enhanced_us"
-          ? `reform=baseline_reform, dataset="enhanced_cps_${timePeriod}"`
+          ? `reform=baseline_reform, dataset="enhanced_cps_2022"`
           : `reform=baseline_reform`
         : ""
     })`,
     `reformed = Microsimulation(${
       region === "enhanced_us"
-        ? `reform=reform, dataset="enhanced_cps_${timePeriod}"`
+        ? `reform=reform, dataset="enhanced_cps_2022"`
         : `reform=reform`
     })`,
     `baseline_person = baseline.calc("household_net_income",

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -206,18 +206,27 @@ export function getImplementationCode(type, region, timePeriod) {
   }
 
   const isCountryUS = US_REGIONS.includes(region);
+  //"reform=baseline_reform, dataset=\"enhanced_cps_" + timePeriod+"\""
 
   return [
     "",
     "",
     `baseline = Microsimulation(${
-      isCountryUS ? "reform=baseline_reform" : ""
+      isCountryUS
+        ? region === "enhanced_us"
+          ? `reform=baseline_reform, dataset="enhanced_cps_${timePeriod}"`
+          : `reform=baseline_reform`
+        : ""
     })`,
-    "reformed = Microsimulation(reform=reform)",
-    `baseline_person = baseline.calc("household_net_income",`,
-    `    period=${timePeriod || defaultYear}, map_to="person")`,
-    `reformed_person = reformed.calc("household_net_income",`,
-    `    period=${timePeriod || defaultYear}, map_to="person")`,
+    `reformed = Microsimulation(${
+      region === "enhanced_us"
+        ? `reform=reform, dataset="enhanced_cps_${timePeriod}"`
+        : `reform=reform`
+    })`,
+    `baseline_person = baseline.calc("household_net_income",
+      period=${timePeriod || defaultYear}, map_to="person")`,
+    `reformed_person = reformed.calc("household_net_income",
+      period=${timePeriod || defaultYear}, map_to="person")`,
     "difference_person = reformed_person - baseline_person",
   ];
 }


### PR DESCRIPTION
## Description
Fixed #1624

## Changes

 Reproduce in Python gives a different code when enhanced CPS is enabled

 
## Screenshots
Before
<img width="1721" alt="Screenshot 2024-04-26 at 10 18 57 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/34841979/26284fc4-22f5-4745-aa2b-0d0c7bcc98b3">
After
<img width="1719" alt="Screenshot 2024-04-26 at 10 19 12 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/34841979/812de188-d0d3-4063-a175-48a373e93272">


## Tests
No test added 
