### PR TITLE
 Remove deprecated Twitter code #1642

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,6 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
-    <script async src="https://platform.twitter.com/widgets.js"></script>
     <script>
       (function (w, d, s, l, i) {
         w[l] = w[l] || [];


### PR DESCRIPTION
## Description

 Remove deprecated Twitter code #1642

## Changes

 Removed script tag with deprecated Twitter code in index.html

## Screenshots
![Screenshot 2024-04-27 101429](https://github.com/PolicyEngine/policyengine-app/assets/93756533/17252687-a103-40d6-bda2-d558ca5a3b41)

## Tests

The change has been tested on running at local host.
