### PR TITLE
Remove conditional disabled

### DIFF
--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -11,7 +11,7 @@ import { Select, Switch } from "antd";
 import useMobile from "../../../layout/Responsive";
 import SearchParamNavButton from "../../../controls/SearchParamNavButton";
 import gtag from "../../../api/analytics";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import StableInputNumber from "controls/StableInputNumber";
 import { defaultYear } from "data/constants";
 
@@ -28,10 +28,8 @@ export default function VariableEditor(props) {
     autoCompute,
     year,
   } = props;
-  const [edited, setEdited] = useState(false);
   const variableName = searchParams.get("focus").split(".").slice(-1)[0];
   const variable = metadata.variables[variableName];
-  const required = ["state_name"].includes(variableName);
   const entityPlural = metadata.entities[variable.entity].plural;
   const isSimulated = !variable.isInputVariable;
   const possibleEntities = Object.keys(householdInput[entityPlural]).filter(
@@ -72,7 +70,6 @@ export default function VariableEditor(props) {
         setHouseholdInput={setHouseholdInput}
         nextVariable={nextVariable}
         autoCompute={autoCompute}
-        setEdited={setEdited}
         year={year}
       />
     );
@@ -112,7 +109,7 @@ export default function VariableEditor(props) {
           <SearchParamNavButton
             text="Enter"
             focus={nextVariable}
-            type={required && !edited ? "disabled" : "primary"}
+            type={"primary"}
             style={{ margin: "20px auto 10px" }}
           />
         )}
@@ -134,7 +131,6 @@ function HouseholdVariableEntity(props) {
     setHouseholdInput,
     nextVariable,
     autoCompute,
-    setEdited,
     year,
   } = props;
   const possibleTimePeriods = Object.keys(
@@ -158,7 +154,6 @@ function HouseholdVariableEntity(props) {
             setHouseholdInput={setHouseholdInput}
             nextVariable={nextVariable}
             autoCompute={autoCompute}
-            setEdited={setEdited}
             year={year}
           />
         );
@@ -181,7 +176,6 @@ function HouseholdVariableEntityInput(props) {
     timePeriod,
     setHouseholdInput,
     autoCompute,
-    setEdited,
   } = props;
   const submitValue = (value) => {
     value = Number.isNaN(+value) ? value : +value;
@@ -201,7 +195,6 @@ function HouseholdVariableEntityInput(props) {
         },
       );
     }
-    setEdited(true);
   };
   const simulatedValue = getValueFromHousehold(
     variable.name,

--- a/src/style/colors.jsx
+++ b/src/style/colors.jsx
@@ -13,6 +13,8 @@ const TEAL_PRESSED = "#227773";
 const BLUE_98 = "#D8E6F3";
 const DARKEST_BLUE = "#0C1A27";
 const DARK_BLUE_HOVER = "#1d3e5e";
+const BLUE_LIGHT = "#D8E6F3";
+const BLUE_PRESSED = "#17354F";
 
 const colors = {
   WHITE,
@@ -30,6 +32,8 @@ const colors = {
   BLUE_98,
   DARKEST_BLUE,
   DARK_BLUE_HOVER,
+  BLUE_LIGHT,
+  BLUE_PRESSED,
 };
 
 export default colors;


### PR DESCRIPTION
## Description

Fixes #1660.

## Changes

It appears that code from a previous version of the application (see #114) purposely nudged a user to input their state by disabling the button in the `VariabledEditor` component until they had selected a state, then changed to be visible. Changes made probably as part of the recent auth update removed a couple of colors that this relied upon, causing the button to revert to Anki's default white.

However, it appears that there's no longer any need for the original changes, anyway. We now define a default state that is both visible to the user and the default for a user household without one that accesses the state selection page. As such, this PR re-inserts the deleted colors (just in case they're used somewhere else) and removes the code that conditionally disabled the state selection button.

## Screenshots

A video testing the changes is available below.
https://github.com/PolicyEngine/policyengine-app/assets/14987227/ae67f19f-d01c-4ecb-80c0-a650e2fa0ec3


## Tests

N/A
