### PR TITLE
Publicize public auth0 variables to allow contributions via fork

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,9 +1,5 @@
 name: Pull request
 
-env:
-  REACT_APP_AUTH0_DOMAIN: ${{ secrets.REACT_APP_AUTH0_DOMAIN }}
-  REACT_APP_AUTH0_CLIENT_ID: ${{ secrets.REACT_APP_AUTH0_CLIENT_ID }}
-
 on:
   pull_request:
     branches: [master]

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
 
-env:
-  REACT_APP_AUTH0_DOMAIN: ${{ secrets.REACT_APP_AUTH0_DOMAIN }}
-  REACT_APP_AUTH0_CLIENT_ID: ${{ secrets.REACT_APP_AUTH0_CLIENT_ID }}
-
 jobs:
   test:
     name: Deploy

--- a/src/auth/Auth0ProviderWithNavigate.jsx
+++ b/src/auth/Auth0ProviderWithNavigate.jsx
@@ -5,7 +5,6 @@ import { AUTH0_CLIENT_ID, AUTH0_DOMAIN } from "./authUtils";
 export default function Auth0ProviderWithNavigate({ children }) {
   const navigate = useNavigate();
 
-  const redirectUri = "https://policyengine.org/callback";
   const domain = AUTH0_DOMAIN;
   const clientId = AUTH0_CLIENT_ID;
 

--- a/src/auth/Auth0ProviderWithNavigate.jsx
+++ b/src/auth/Auth0ProviderWithNavigate.jsx
@@ -1,11 +1,13 @@
 import { useNavigate } from "react-router-dom";
 import { Auth0Provider } from "@auth0/auth0-react";
+import { AUTH0_CLIENT_ID, AUTH0_DOMAIN } from "./authUtils";
 
 export default function Auth0ProviderWithNavigate({ children }) {
   const navigate = useNavigate();
 
-  const domain = process.env.REACT_APP_AUTH0_DOMAIN;
-  const clientId = process.env.REACT_APP_AUTH0_CLIENT_ID;
+  const redirectUri = "https://policyengine.org/callback";
+  const domain = AUTH0_DOMAIN;
+  const clientId = AUTH0_CLIENT_ID;
 
   const redirectUri = process.env.REACT_APP_DEBUG
     ? "http://localhost:3000/callback"

--- a/src/auth/authUtils.js
+++ b/src/auth/authUtils.js
@@ -1,3 +1,7 @@
+// The below are two public values vital to auth0 local setup
+export const AUTH0_DOMAIN = "policyengine.uk.auth0.com";
+export const AUTH0_CLIENT_ID = "jbAXjeFRxGpGRxkedjt2wRLHJd26bwDS";
+
 /**
  * Provide login options for use with auth0
  * @param {String} countryId


### PR DESCRIPTION
## Description

Fixes #1653. 

## Changes

This PR takes two auth0 settings that were previously environment variables and makes them constants. As relayed in #1653, these values are public-facing, anyway, and setting them as constants ensures that contributors can properly run the app inside forks. We don't currently support any other configurations, so there seems to be no benefit to allowing these values to be overridden by environment variables, either.

## Screenshots

The app running without environment variables provided:
<img width="1440" alt="Screen Shot 2024-04-30 at 12 23 34 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/646a53ce-5ab2-4611-a2be-41ad93fb80cf">

## Tests

N/A
