### PR TITLE
Set explicit title on callback page

### DIFF
--- a/src/layout/AuthCallback.jsx
+++ b/src/layout/AuthCallback.jsx
@@ -1,6 +1,14 @@
+import { Helmet } from "react-helmet";
 import Header from "../redesign/components/Header";
 
 // Empty component for smoothing post-login redirects visually
 export default function AuthCallback() {
-  return <Header />;
+  return (
+    <>
+      <Helmet>
+        <title>PolicyEngine</title>
+      </Helmet>
+      <Header />
+    </>
+  );
 }


### PR DESCRIPTION
## Description

Fixes #1654.

## Changes

This sets an explicit title on the `AuthCallback.jsx` component, preventing the implicit naming of the page to include "CALLBACK"

## Screenshots

Opening this as draft until #1659 and #1663 can be closed, as it's not possible to properly test these changes without those.

## Tests

N/A
