### PR TITLE
Re-fetch user after username update

### DIFF
--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -90,10 +90,13 @@ export default function UserProfilePage(props) {
             setAccessedUserProfile({});
             setDispState(STATES.NO_PROFILE);
           }
-          if (data.status < 200 || data.status >= 300) {
+          else if (data.status < 200 || data.status >= 300) {
             console.error("Error while fetching accessed user profile");
             console.error(dataJson);
             setAccessedUserProfile({});
+          } else if (isOwnProfile) {
+            setAccessedUserProfile(dataJson.result);
+            setDispState(STATES.OWN_PROFILE);
           } else {
             setAccessedUserProfile(dataJson.result);
             setDispState(STATES.OTHER_PROFILE);
@@ -111,15 +114,9 @@ export default function UserProfilePage(props) {
       return;
     }
 
-    if (!isOwnProfile) {
-      // Execute fetch
-      fetchProfile();
-    } else {
-      setDispState(STATES.OWN_PROFILE);
-      setAccessedUserProfile(authedUserProfile);
-      setIsHeaderLoading(false);
-    }
-  }, [countryId, isOwnProfile, authedUserProfile, accessedUserId, metadata]);
+    fetchProfile();
+
+  }, [countryId, isOwnProfile, accessedUserId, metadata]);
 
   useEffect(() => {
     async function fetchAccessedPolicies() {
@@ -150,6 +147,9 @@ export default function UserProfilePage(props) {
     async function emitPreAuthPolicies() {
       // Only run if the user has accessed their personal
       // profile page
+      if (!metadata) {
+        return;
+      }
 
       // Check if user has any policies from before account creation
       // or policies that have failed to emit correctly before

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -89,8 +89,7 @@ export default function UserProfilePage(props) {
           if (data.status === 404 && dataJson.status === "ok") {
             setAccessedUserProfile({});
             setDispState(STATES.NO_PROFILE);
-          }
-          else if (data.status < 200 || data.status >= 300) {
+          } else if (data.status < 200 || data.status >= 300) {
             console.error("Error while fetching accessed user profile");
             console.error(dataJson);
             setAccessedUserProfile({});
@@ -115,7 +114,6 @@ export default function UserProfilePage(props) {
     }
 
     fetchProfile();
-
   }, [countryId, isOwnProfile, accessedUserId, metadata]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Fixes #1655.

## Changes

Previously, if the user accessed their own profile, in order to avoid a fetch, the app set the user's data (which is fetched by the entire application on login) as the profile data. When a user would update their username, the UserProfilePage would correctly re-fetch the user object and set that as the user. However, on any load of the page that didn't fully reload the app, the component would re-set the authenticated user's (now stale) data as the profile, causing it to appear that the username didn't change.

These changes simplify the UserProfilePage component a bit, treating one's own user profile data (except anything sensitive) the same way another user's data would be treated, with a fetch on component load, enabling the post-username-change fetch to work properly and making the component slightly more maintainable.

## Screenshots

A video of the changes in action is available below.
https://github.com/PolicyEngine/policyengine-app/assets/14987227/8a5b1641-4b75-4656-9453-fd17779c07e6

## Tests

None have been added.
