### PR TITLE
Various UI fixes

### DIFF
--- a/src/controls/RadioButton.jsx
+++ b/src/controls/RadioButton.jsx
@@ -12,7 +12,6 @@ export default function RadioButton(props) {
         flexDirection: "row",
         flexWrap: "wrap",
         alignItems: "center",
-        justifyContent: "center",
       }}
     >
       {keys.map((key, index) => {

--- a/src/layout/CenteredMiddleColumn.jsx
+++ b/src/layout/CenteredMiddleColumn.jsx
@@ -1,7 +1,13 @@
 import useMobile from "../layout/Responsive";
 
 export default function CenteredMiddleColumn(props) {
-  const { title, description, children, marginTop } = props;
+  const {
+    title,
+    description,
+    children,
+    marginTop,
+    descriptionLabel = true,
+  } = props;
   const mobile = useMobile();
   return (
     <div
@@ -21,17 +27,19 @@ export default function CenteredMiddleColumn(props) {
 
         {description && (
           <>
-            <p
-              style={{
-                marginTop: 10,
-                marginBottom: 10,
-                color: "grey",
-                fontFamily: "Roboto",
-                display: "inline-block",
-              }}
-            >
-              Description
-            </p>
+            {descriptionLabel && (
+              <p
+                style={{
+                  marginTop: 10,
+                  marginBottom: 10,
+                  color: "grey",
+                  fontFamily: "Roboto",
+                  display: "inline-block",
+                }}
+              >
+                Description
+              </p>
+            )}
             <p style={{ fontFamily: "Roboto Serif" }}>{description}</p>
           </>
         )}

--- a/src/pages/APIDocumentationPage.jsx
+++ b/src/pages/APIDocumentationPage.jsx
@@ -371,7 +371,13 @@ export default function APIDocumentationPage({ metadata }) {
   );
 }
 
-export function CodeBlock({ data, title, language, maxHeight }) {
+export function CodeBlock({
+  data,
+  title,
+  language,
+  maxHeight,
+  showExpand = true,
+}) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
 
@@ -415,36 +421,38 @@ export function CodeBlock({ data, title, language, maxHeight }) {
           gap: "0.5rem",
         }}
       >
-        <Tooltip title={`${isExpanded ? "Close" : "Expand"} the code block`}>
-          <Button
-            type="default"
-            style={{
-              border: 0,
-              fontWeight: 500,
-              boxShadow: "none",
-            }}
-            onClick={() => setIsExpanded((prev) => !prev)}
-          >
-            <div
+        {showExpand && (
+          <Tooltip title={`${isExpanded ? "Close" : "Expand"} the code block`}>
+            <Button
+              type="default"
               style={{
-                display: "flex",
-                flexDirection: "row",
-                alignItems: "center",
-                justifyContent: "center",
-                gap: "0.5rem",
+                border: 0,
+                fontWeight: 500,
+                boxShadow: "none",
               }}
+              onClick={() => setIsExpanded((prev) => !prev)}
             >
-              {isExpanded ? <UpOutlined /> : <DownOutlined />}
-              <p
+              <div
                 style={{
-                  margin: 0,
+                  display: "flex",
+                  flexDirection: "row",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: "0.5rem",
                 }}
               >
-                {isExpanded ? "Shrink" : "Expand"}
-              </p>
-            </div>
-          </Button>
-        </Tooltip>
+                {isExpanded ? <UpOutlined /> : <DownOutlined />}
+                <p
+                  style={{
+                    margin: 0,
+                  }}
+                >
+                  {isExpanded ? "Shrink" : "Expand"}
+                </p>
+              </div>
+            </Button>
+          </Tooltip>
+        )}
         <Tooltip title="Copy the code block">
           <Button
             type="default"

--- a/src/pages/household/HouseholdIntro.jsx
+++ b/src/pages/household/HouseholdIntro.jsx
@@ -6,11 +6,13 @@ export default function HouseholdIntro() {
     <CenteredMiddleColumn
       title="Enter your household details"
       description="Tell us about your household to calculate your net income after taxes and benefits."
+      descriptionLabel={false}
+      marginTop="15%"
     >
       <SearchParamNavButton
         text="Enter my household"
         focus="input.household.taxYear"
-        style={{ margin: "20px auto 10px" }}
+        style={{ marginTop: 20 }}
       />
     </CenteredMiddleColumn>
   );

--- a/src/pages/household/input/CountChildren.jsx
+++ b/src/pages/household/input/CountChildren.jsx
@@ -161,9 +161,9 @@ export default function CountChildren(props) {
         }}
       />
       <SearchParamNavButton
-        text="Enter"
+        text="Submit"
         focus={`input.household.${metadata.basicInputs[0]}`}
-        style={{ margin: "20px auto 10px" }}
+        style={{ marginTop: 20 }}
       />
     </>
   );

--- a/src/pages/household/input/MaritalStatus.jsx
+++ b/src/pages/household/input/MaritalStatus.jsx
@@ -160,9 +160,9 @@ export default function MaritalStatus(props) {
       <>
         {radioButtonComponent}
         <SearchParamNavButton
-          text="Enter"
+          text="Submit"
           focus="input.household.children"
-          style={{ margin: "20px auto 10px" }}
+          style={{ marginTop: 20 }}
         />
       </>
     </CenteredMiddleColumn>

--- a/src/pages/household/input/TaxYear.jsx
+++ b/src/pages/household/input/TaxYear.jsx
@@ -86,9 +86,9 @@ export default function TaxYear(props) {
       />
       <SearchParamNavButton
         data-testid="taxyear_navbutton"
-        text="Enter"
+        text="Submit"
         focus="input.household.maritalStatus"
-        style={{ margin: "20px auto 10px" }}
+        style={{ marginTop: 20 }}
       />
     </CenteredMiddleColumn>
   );

--- a/src/pages/household/input/VariableEditor.jsx
+++ b/src/pages/household/input/VariableEditor.jsx
@@ -110,10 +110,10 @@ export default function VariableEditor(props) {
         {entityInputs}
         {nextVariable && (
           <SearchParamNavButton
-            text="Enter"
+            text="Submit"
             focus={nextVariable}
             type={"primary"}
-            style={{ margin: "20px auto 10px" }}
+            style={{ marginTop: 20, width: 125 }}
           />
         )}
       </div>

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -51,6 +51,7 @@ export default function HouseholdReproducibility(props) {
           data={lines.join("\n")}
           language={"python"}
           maxHeight="100%"
+          showExpand={false}
         />
         <div
           style={{

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -50,6 +50,7 @@ export default function PolicyReproducibility(props) {
         data={codeLines.join("\n")}
         language={"python"}
         maxHeight="100%"
+        showExpand={false}
       />
       <div
         style={{


### PR DESCRIPTION
## Description

Some low-priority UI improvements missed by #1670 

## Changes

- [x] Enter and radio button boxes left-aligned in household input pages.
- [x] Enter buttons changed to "Submit" in household input pages.
- [x] Reproduce in Python code blocks now hide the non-functional (because it's too tall already) expand button.
- [x] Household intro description no longer has a "description" label.

## Screenshots

N/A

## Tests

No tests added.
