### PR TITLE
Improve ParameterEditor policy dates

### DIFF
--- a/src/__tests__/pages/policy/PolicyRightSidebar.test.js
+++ b/src/__tests__/pages/policy/PolicyRightSidebar.test.js
@@ -1,8 +1,10 @@
 import { fireEvent, render, waitFor } from "@testing-library/react";
-import { useSearchParams } from "react-router-dom";
+import { BrowserRouter, useSearchParams } from "react-router-dom";
 import fetch from "node-fetch";
-import PolicyRightSidebar from "pages/policy/PolicyRightSidebar";
+import PolicyRightSidebar, { SinglePolicyChange } from "pages/policy/PolicyRightSidebar";
 import "@testing-library/jest-dom";
+import { defaultForeverYear } from "../../../data/constants";
+import { formatFullDate } from "../../../lang/format";
 
 jest.mock("react-router-dom", () => {
   const originalModule = jest.requireActual("react-router-dom");
@@ -245,3 +247,171 @@ describe("Enhanced CPS selector", () => {
     );
   });
 });
+
+describe("SinglePolicyChange", () => {
+  const testCountryId = "us";
+  const testValue = 3;
+  const testParamLabel = "maxwell";
+
+  test("Should display simple, single-year policies correctly", () => {
+
+    // This must be declared here, and not in describe
+    // block, because "beforeAll" doesn't run before describe
+    // setup - strange pattern
+    const allParams = metadataUS.parameters;
+    const testStartDate = "2024-01-01";
+    const testEndDate = "2024-12-31";
+
+    const {getByText} = render(
+      <BrowserRouter>
+        <SinglePolicyChange 
+          startDateStr={testStartDate}
+          endDateStr={testEndDate}
+          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          value={testValue}
+          paramLabel={testParamLabel}
+          countryId={testCountryId}
+        />
+      </BrowserRouter>
+    );
+
+    expect(getByText("2024")).toBeInTheDocument();
+  });
+  test("Should display simple, multi-year policies correctly", () => {
+
+    const allParams = metadataUS.parameters;
+    const testStartDate = "2024-01-01";
+    const testEndDate = "2025-12-31";
+
+    const {getByText} = render(
+      <BrowserRouter>
+        <SinglePolicyChange 
+          startDateStr={testStartDate}
+          endDateStr={testEndDate}
+          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          value={testValue}
+          paramLabel={testParamLabel}
+          countryId={testCountryId}
+        />
+      </BrowserRouter>
+    );
+
+    expect(getByText("2024 to 2025")).toBeInTheDocument();
+  });
+  test("Should display simple-start, forever policies correctly", () => {
+
+    const allParams = metadataUS.parameters;
+    const testStartDate = "2024-01-01";
+    const testEndDate = defaultForeverYear.concat("-12-31");
+
+    const {getByText} = render(
+      <BrowserRouter>
+        <SinglePolicyChange 
+          startDateStr={testStartDate}
+          endDateStr={testEndDate}
+          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          value={testValue}
+          paramLabel={testParamLabel}
+          countryId={testCountryId}
+        />
+      </BrowserRouter>
+    );
+
+    expect(getByText("2024 onward")).toBeInTheDocument();
+  });
+  test("Should display complex-start, forever policies correctly", () => {
+
+    const allParams = metadataUS.parameters;
+    const testStartDate = "2024-01-02";
+    const testEndDate = defaultForeverYear.concat("-12-31");
+
+    const {getByText} = render(
+      <BrowserRouter>
+        <SinglePolicyChange 
+          startDateStr={testStartDate}
+          endDateStr={testEndDate}
+          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          value={testValue}
+          paramLabel={testParamLabel}
+          countryId={testCountryId}
+        />
+      </BrowserRouter>
+    );
+
+    const startOutput = formatFullDate(testStartDate, testCountryId);
+
+    expect(getByText(`${startOutput} onward`)).toBeInTheDocument();
+  });
+  test("Should display complex-start, complex-end policies correctly", () => {
+
+    const allParams = metadataUS.parameters;
+    const testStartDate = "2024-01-02";
+    const testEndDate = "2025-12-30";
+
+    const {getByText} = render(
+      <BrowserRouter>
+        <SinglePolicyChange 
+          startDateStr={testStartDate}
+          endDateStr={testEndDate}
+          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          value={testValue}
+          paramLabel={testParamLabel}
+          countryId={testCountryId}
+        />
+      </BrowserRouter>
+    );
+
+    const startOutput = formatFullDate(testStartDate, testCountryId);
+    const endOutput = formatFullDate(testEndDate, testCountryId);
+
+    expect(getByText(`${startOutput} to ${endOutput}`)).toBeInTheDocument();
+  });
+  test("Should display complex-start, simple-end policies correctly", () => {
+
+    const allParams = metadataUS.parameters;
+    const testStartDate = "2024-01-02";
+    const testEndDate = "2025-12-31";
+
+    const {getByText} = render(
+      <BrowserRouter>
+        <SinglePolicyChange 
+          startDateStr={testStartDate}
+          endDateStr={testEndDate}
+          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          value={testValue}
+          paramLabel={testParamLabel}
+          countryId={testCountryId}
+        />
+      </BrowserRouter>
+    );
+
+    const startOutput = formatFullDate(testStartDate, testCountryId);
+    const endOutput = formatFullDate(testEndDate, testCountryId);
+
+    expect(getByText(`${startOutput} to ${endOutput}`)).toBeInTheDocument();
+  });
+  test("Should display simple-start, complex-end policies correctly", () => {
+
+    const allParams = metadataUS.parameters;
+    const testStartDate = "2024-01-01";
+    const testEndDate = "2025-12-30";
+
+    const {getByText} = render(
+      <BrowserRouter>
+        <SinglePolicyChange 
+          startDateStr={testStartDate}
+          endDateStr={testEndDate}
+          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          value={testValue}
+          paramLabel={testParamLabel}
+          countryId={testCountryId}
+        />
+      </BrowserRouter>
+    );
+
+    const startOutput = formatFullDate(testStartDate, testCountryId);
+    const endOutput = formatFullDate(testEndDate, testCountryId);
+
+    expect(getByText(`${startOutput} to ${endOutput}`)).toBeInTheDocument();
+  });
+})

--- a/src/__tests__/pages/policy/PolicyRightSidebar.test.js
+++ b/src/__tests__/pages/policy/PolicyRightSidebar.test.js
@@ -1,7 +1,9 @@
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { BrowserRouter, useSearchParams } from "react-router-dom";
 import fetch from "node-fetch";
-import PolicyRightSidebar, { SinglePolicyChange } from "pages/policy/PolicyRightSidebar";
+import PolicyRightSidebar, {
+  SinglePolicyChange,
+} from "pages/policy/PolicyRightSidebar";
 import "@testing-library/jest-dom";
 import { defaultForeverYear } from "../../../data/constants";
 import { formatFullDate } from "../../../lang/format";
@@ -254,7 +256,6 @@ describe("SinglePolicyChange", () => {
   const testParamLabel = "maxwell";
 
   test("Should display simple, single-year policies correctly", () => {
-
     // This must be declared here, and not in describe
     // block, because "beforeAll" doesn't run before describe
     // setup - strange pattern
@@ -262,80 +263,85 @@ describe("SinglePolicyChange", () => {
     const testStartDate = "2024-01-01";
     const testEndDate = "2024-12-31";
 
-    const {getByText} = render(
+    const { getByText } = render(
       <BrowserRouter>
-        <SinglePolicyChange 
+        <SinglePolicyChange
           startDateStr={testStartDate}
           endDateStr={testEndDate}
-          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          parameterMetadata={
+            allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]
+          }
           value={testValue}
           paramLabel={testParamLabel}
           countryId={testCountryId}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     expect(getByText("2024")).toBeInTheDocument();
   });
   test("Should display simple, multi-year policies correctly", () => {
-
     const allParams = metadataUS.parameters;
     const testStartDate = "2024-01-01";
     const testEndDate = "2025-12-31";
 
-    const {getByText} = render(
+    const { getByText } = render(
       <BrowserRouter>
-        <SinglePolicyChange 
+        <SinglePolicyChange
           startDateStr={testStartDate}
           endDateStr={testEndDate}
-          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          parameterMetadata={
+            allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]
+          }
           value={testValue}
           paramLabel={testParamLabel}
           countryId={testCountryId}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     expect(getByText("2024 to 2025")).toBeInTheDocument();
   });
   test("Should display simple-start, forever policies correctly", () => {
-
     const allParams = metadataUS.parameters;
     const testStartDate = "2024-01-01";
     const testEndDate = defaultForeverYear.concat("-12-31");
 
-    const {getByText} = render(
+    const { getByText } = render(
       <BrowserRouter>
-        <SinglePolicyChange 
+        <SinglePolicyChange
           startDateStr={testStartDate}
           endDateStr={testEndDate}
-          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          parameterMetadata={
+            allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]
+          }
           value={testValue}
           paramLabel={testParamLabel}
           countryId={testCountryId}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     expect(getByText("2024 onward")).toBeInTheDocument();
   });
   test("Should display complex-start, forever policies correctly", () => {
-
     const allParams = metadataUS.parameters;
     const testStartDate = "2024-01-02";
     const testEndDate = defaultForeverYear.concat("-12-31");
 
-    const {getByText} = render(
+    const { getByText } = render(
       <BrowserRouter>
-        <SinglePolicyChange 
+        <SinglePolicyChange
           startDateStr={testStartDate}
           endDateStr={testEndDate}
-          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          parameterMetadata={
+            allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]
+          }
           value={testValue}
           paramLabel={testParamLabel}
           countryId={testCountryId}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     const startOutput = formatFullDate(testStartDate, testCountryId);
@@ -343,22 +349,23 @@ describe("SinglePolicyChange", () => {
     expect(getByText(`${startOutput} onward`)).toBeInTheDocument();
   });
   test("Should display complex-start, complex-end policies correctly", () => {
-
     const allParams = metadataUS.parameters;
     const testStartDate = "2024-01-02";
     const testEndDate = "2025-12-30";
 
-    const {getByText} = render(
+    const { getByText } = render(
       <BrowserRouter>
-        <SinglePolicyChange 
+        <SinglePolicyChange
           startDateStr={testStartDate}
           endDateStr={testEndDate}
-          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          parameterMetadata={
+            allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]
+          }
           value={testValue}
           paramLabel={testParamLabel}
           countryId={testCountryId}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     const startOutput = formatFullDate(testStartDate, testCountryId);
@@ -367,22 +374,23 @@ describe("SinglePolicyChange", () => {
     expect(getByText(`${startOutput} to ${endOutput}`)).toBeInTheDocument();
   });
   test("Should display complex-start, simple-end policies correctly", () => {
-
     const allParams = metadataUS.parameters;
     const testStartDate = "2024-01-02";
     const testEndDate = "2025-12-31";
 
-    const {getByText} = render(
+    const { getByText } = render(
       <BrowserRouter>
-        <SinglePolicyChange 
+        <SinglePolicyChange
           startDateStr={testStartDate}
           endDateStr={testEndDate}
-          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          parameterMetadata={
+            allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]
+          }
           value={testValue}
           paramLabel={testParamLabel}
           countryId={testCountryId}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     const startOutput = formatFullDate(testStartDate, testCountryId);
@@ -391,22 +399,23 @@ describe("SinglePolicyChange", () => {
     expect(getByText(`${startOutput} to ${endOutput}`)).toBeInTheDocument();
   });
   test("Should display simple-start, complex-end policies correctly", () => {
-
     const allParams = metadataUS.parameters;
     const testStartDate = "2024-01-01";
     const testEndDate = "2025-12-30";
 
-    const {getByText} = render(
+    const { getByText } = render(
       <BrowserRouter>
-        <SinglePolicyChange 
+        <SinglePolicyChange
           startDateStr={testStartDate}
           endDateStr={testEndDate}
-          parameterMetadata={allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]}
+          parameterMetadata={
+            allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]
+          }
           value={testValue}
           paramLabel={testParamLabel}
           countryId={testCountryId}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     const startOutput = formatFullDate(testStartDate, testCountryId);
@@ -414,4 +423,4 @@ describe("SinglePolicyChange", () => {
 
     expect(getByText(`${startOutput} to ${endOutput}`)).toBeInTheDocument();
   });
-})
+});

--- a/src/__tests__/pages/policy/PolicyRightSidebar.test.js
+++ b/src/__tests__/pages/policy/PolicyRightSidebar.test.js
@@ -423,4 +423,28 @@ describe("SinglePolicyChange", () => {
 
     expect(getByText(`${startOutput} to ${endOutput}`)).toBeInTheDocument();
   });
+  test("Should display rare use case of single-day policies as full date", () => {
+    const allParams = metadataUS.parameters;
+    const testStartDate = "2024-01-01";
+    const testEndDate = "2024-01-01";
+
+    const { getByText } = render(
+      <BrowserRouter>
+        <SinglePolicyChange
+          startDateStr={testStartDate}
+          endDateStr={testEndDate}
+          parameterMetadata={
+            allParams[Object.keys(allParams)[Object.keys(allParams).length / 2]]
+          }
+          value={testValue}
+          paramLabel={testParamLabel}
+          countryId={testCountryId}
+        />
+      </BrowserRouter>,
+    );
+
+    const output = formatFullDate(testStartDate, testCountryId);
+
+    expect(getByText(output)).toBeInTheDocument();
+  });
 });

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -780,6 +780,12 @@ function formatDateString(startDateStr, endDateStr, countryId) {
   const isSimpleStart = startDateArr[1] === "01" && startDateArr[2] === "01";
   const isSimpleEnd = endDateArr[1] === "12" && endDateArr[2] === "31";
 
+  // In the rare case that a policy is valid for only a single day,
+  // return just that day
+  if (startDateStr === endDateStr) {
+    return formatFullDate(startDateStr, countryId);
+  }
+
   // Get simple-date, single-year policies out of the way, as they
   // only have one component to the string
   if (isSimpleStart && isSimpleEnd && startDateArr[0] === endDateArr[0]) {

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -326,9 +326,7 @@ export function SinglePolicyChange(props) {
           </>
         )}
       </div>
-      <div style={{ fontStyle: "italic" }}>
-        {dateString}
-      </div>
+      <div style={{ fontStyle: "italic" }}>{dateString}</div>
     </div>
   );
 }
@@ -772,7 +770,6 @@ export default function PolicyRightSidebar(props) {
 }
 
 function formatDateString(startDateStr, endDateStr, countryId) {
-
   // Determine if policy runs forever
   const FOREVER_DATE = String(defaultForeverYear).concat("-12-31");
   const isEndForever = endDateStr === FOREVER_DATE;
@@ -792,16 +789,12 @@ function formatDateString(startDateStr, endDateStr, countryId) {
   // If either date isn't simple, neither should be, unless end is FOREVER_DATE
   if (!isSimpleStart || !isSimpleEnd) {
     return formatFullDate(startDateStr, countryId).concat(
-      isEndForever
-        ? " onward"
-        : ` to ${formatFullDate(endDateStr, countryId)}`
-      );
+      isEndForever ? " onward" : ` to ${formatFullDate(endDateStr, countryId)}`,
+    );
   }
 
   // Otherwise, display only year, again being mindful of FOREVER_DATE
   return startDateArr[0].concat(
-    isEndForever
-      ? " onward"
-      : ` to ${endDateArr[0]}`
+    isEndForever ? " onward" : ` to ${endDateArr[0]}`,
   );
 }

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -268,7 +268,7 @@ function PolicyNamer(props) {
   );
 }
 
-function SinglePolicyChange(props) {
+export function SinglePolicyChange(props) {
   const {
     startDateStr,
     endDateStr,
@@ -781,7 +781,7 @@ function formatDateString(startDateStr, endDateStr, countryId) {
   const endDateArr = endDateStr.split("-");
 
   const isSimpleStart = startDateArr[1] === "01" && startDateArr[2] === "01";
-  const isSimpleEnd = endDateArr[1] === "12" && startDateArr[2] === "31";
+  const isSimpleEnd = endDateArr[1] === "12" && endDateArr[2] === "31";
 
   // Get simple-date, single-year policies out of the way, as they
   // only have one component to the string

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -281,9 +281,6 @@ function SinglePolicyChange(props) {
   const oldValStr = formatVariableValue(parameterMetadata, oldVal);
   const newValueStr = formatVariableValue(parameterMetadata, value);
 
-  const FOREVER_DATE = String(defaultForeverYear).concat("-12-31");
-  const isEndForever = endDateStr === FOREVER_DATE;
-
   const isBool =
     parameterMetadata.unit === "bool" || parameterMetadata.unit === "abolition";
   const prefix = isBool
@@ -293,6 +290,8 @@ function SinglePolicyChange(props) {
     : value > oldVal
       ? "Raise"
       : "Lower";
+
+  const dateString = formatDateString(startDateStr, endDateStr, countryId);
 
   return (
     <div
@@ -328,7 +327,7 @@ function SinglePolicyChange(props) {
         )}
       </div>
       <div style={{ fontStyle: "italic" }}>
-        {`from ${formatFullDate(startDateStr, countryId)} ${isEndForever ? "onward" : `to ${formatFullDate(endDateStr, countryId)}`}`}
+        {dateString}
       </div>
     </div>
   );
@@ -769,5 +768,40 @@ export default function PolicyRightSidebar(props) {
         )}
       </div>
     </div>
+  );
+}
+
+function formatDateString(startDateStr, endDateStr, countryId) {
+
+  // Determine if policy runs forever
+  const FOREVER_DATE = String(defaultForeverYear).concat("-12-31");
+  const isEndForever = endDateStr === FOREVER_DATE;
+
+  const startDateArr = startDateStr.split("-");
+  const endDateArr = endDateStr.split("-");
+
+  const isSimpleStart = startDateArr[1] === "01" && startDateArr[2] === "01";
+  const isSimpleEnd = endDateArr[1] === "12" && startDateArr[2] === "31";
+
+  // Get simple-date, single-year policies out of the way, as they
+  // only have one component to the string
+  if (isSimpleStart && isSimpleEnd && startDateArr[0] === endDateArr[0]) {
+    return String(startDateArr[0]);
+  }
+
+  // If either date isn't simple, neither should be, unless end is FOREVER_DATE
+  if (!isSimpleStart || !isSimpleEnd) {
+    return formatFullDate(startDateStr, countryId).concat(
+      isEndForever
+        ? " onward"
+        : ` to ${formatFullDate(endDateStr, countryId)}`
+      );
+  }
+
+  // Otherwise, display only year, again being mindful of FOREVER_DATE
+  return startDateArr[0].concat(
+    isEndForever
+      ? " onward"
+      : ` to ${endDateArr[0]}`
   );
 }


### PR DESCRIPTION
## Description

Fixes #1679. This provides better styling and handling of dates within the `ParameterEditor` component.

## Changes

This creates a new utility function within `PolicyRightSidebar.jsx` to handle the slightly more complex date formatting required of the issue.

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/14987227/f51c3e34-0f4b-48d2-8a31-4bf776741360

## Tests

Tests have been added to ensure that `PolicyRightSidebar`'s relevant sub-component, `SinglePolicyChange`, properly displays dates for a variety of cases.
