### PR TITLE
Upgrade to Codecov v4 to see if token-based upload will function correctly

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,4 +42,7 @@ jobs:
       - name: Test repository
         run: make test
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,4 @@ jobs:
       - name: Test repository
         run: make test
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: {{ secrets.CODECOV_TOKEN }}
-          verbose: true
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,4 +42,7 @@ jobs:
       - name: Test repository
         run: make test
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: {{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,8 +21,9 @@ jobs:
       - name: Run tests
         run: make test
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: {{ secrets.CODECOV_TOKEN }}
           verbose: true
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: {{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1


### PR DESCRIPTION
## Description

Fixes #1725.

## Changes

Since the introduction of `codecov_actions` v4, we've used v3 in order to continue allowing outside contributors to contribute via fork. However, Codecov has implemented fixes that now allow contributors to contribute via fork, but with a catch - they contribute via Codecov's public key, which is constantly rate-limited by GitHub. At the moment, we only sporadically get successful public contribution coverage data because this token is constantly rate-limited, so this PR attempts an upgrade to v4 to at least see if we can successfully provide stability to the coverage measurement of the deployed app, since it's possible that we could utilize a private token for the GitHub Actions push action.

Please note that this may fail, requiring a return to the previous v3 and a different solution, or further tweaks to make v4 work properly.

## Screenshots

N/A

## Tests

N/A
