### PR TITLE
Fix env var format in GH Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.2.0
         env:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           verbose: true
       - name: Set up Cloud SDK


### PR DESCRIPTION
## Description

Fixes #1764, whereby the env var that Codecov uses is formatted improperly