### PR TITLE
Added conditional language formatter check

### DIFF
--- a/src/layout/CodeBlock.jsx
+++ b/src/layout/CodeBlock.jsx
@@ -151,11 +151,7 @@ export default function CodeBlock({
           maxHeight={maxHeight ? maxHeight : !isExpanded && "260px"}
           editable={false}
           extensions={[
-            language === "json"
-              ? langs.json()
-              : language === "markdown"
-                ? langs.markdown()
-                : langs.json(),
+            language in langs ? langs[language]() : langs.json(),
             EditorView.lineWrapping,
           ]}
           theme={espresso}


### PR DESCRIPTION
## Description

Fixes #1758 

## Changes

Added a conditional check in ```CodeBlock``` that would render the appropriate language formatter if the language formatter is found, otherwise it will default to the ```.json``` formatter.

## Screenshots

![image](https://github.com/PolicyEngine/policyengine-app/assets/42430035/5b69286f-2cf2-4798-8f0e-e7d7994d49f6)
![image](https://github.com/PolicyEngine/policyengine-app/assets/42430035/9914e511-946a-4a89-8c47-38b268d5ff51)

## Tests

No new tests added.