### PR TITLE
Add token fetching information to API documentation page

### DIFF
--- a/src/pages/APIDocumentationPage.jsx
+++ b/src/pages/APIDocumentationPage.jsx
@@ -334,9 +334,11 @@ export default function APIDocumentationPage({ metadata }) {
           </a>
           ) simulates tax-benefit policy outcomes and reform impacts for
           households. Access to the API requires a <b>Client ID</b> and{" "}
-          <b>Client Secret</b> given by PolicyEngine. Use these credentials to request an authentication token, which expires monthly. This token must be passed within the authorization heading of
-          each request you make to the API. For more information or to request
-          your own Client ID, reach out to PolicyEngine at{" "}
+          <b>Client Secret</b> given by PolicyEngine. Use these credentials to
+          request an authentication token, which expires monthly. This token
+          must be passed within the authorization heading of each request you
+          make to the API. For more information or to request your own Client
+          ID, reach out to PolicyEngine at{" "}
           <a href="mailto: hello@policyengine.org">hello@policyengine.org</a>.
         </p>
         <br />

--- a/src/pages/APIDocumentationPage.jsx
+++ b/src/pages/APIDocumentationPage.jsx
@@ -333,12 +333,10 @@ export default function APIDocumentationPage({ metadata }) {
             https://household.api.policyengine.org
           </a>
           ) simulates tax-benefit policy outcomes and reform impacts for
-          households. Access to the API requires a &quot;client ID&quot; and
-          &quot;client secret&quot; given by PolicyEngine. This two items are
-          then used to request a token, which expires monthly for security
-          reasons. This token must be passed within the authorization heading of
+          households. Access to the API requires a <b>Client ID</b> and{" "}
+          <b>Client Secret</b> given by PolicyEngine. Use these credentials to request an authentication token, which expires monthly. This token must be passed within the authorization heading of
           each request you make to the API. For more information or to request
-          your own client ID, feel free to reach out to PolicyEngine at{" "}
+          your own Client ID, reach out to PolicyEngine at{" "}
           <a href="mailto: hello@policyengine.org">hello@policyengine.org</a>.
         </p>
         <br />

--- a/src/pages/APIDocumentationPage.jsx
+++ b/src/pages/APIDocumentationPage.jsx
@@ -464,7 +464,6 @@ function APIEndpoint({
       <p>{description}</p>
 
       <div
-        data-testid="APIEndpoint_json_blocks"
         style={{
           display: "flex",
           flexDirection: displayCategory === "mobile" && "column",

--- a/src/pages/APIDocumentationPage.jsx
+++ b/src/pages/APIDocumentationPage.jsx
@@ -100,6 +100,26 @@ const examplePolicies = {
   uk: "Universal Credit entitlement",
 };
 
+const tokenFetchCode = `import http.client
+
+conn = http.client.HTTPSConnection("policyengine.uk.auth0.com")
+
+payload = "{\\"client_id\\":\\"YOUR_CLIENT_ID\\", \\"client_secret\\":\\"YOUR_CLIENT_SECRET\\"}"
+
+headers = { 'content-type': "application/json" }
+
+conn.request("POST", "/oauth/token", payload, headers)
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`;
+
+const tokenOutputCode = `{
+  "access_token": "YOUR_ACCESS_TOKEN",
+  "token_type": "Bearer"
+}`;
+
 export function APIResultCard(props) {
   const { metadata, type, setSelectedCard } = props;
 
@@ -313,11 +333,12 @@ export default function APIDocumentationPage({ metadata }) {
             https://household.api.policyengine.org
           </a>
           ) simulates tax-benefit policy outcomes and reform impacts for
-          households. Access to the API requires an authentication token, which
-          will expire monthly for security reasons. This token must be passed
-          within the authorization heading of each request you make to the API.
-          For more information or to request your own token, feel free to reach
-          out to PolicyEngine at{" "}
+          households. Access to the API requires a &quot;client ID&quot; and
+          &quot;client secret&quot; given by PolicyEngine. This two items are
+          then used to request a token, which expires monthly for security
+          reasons. This token must be passed within the authorization heading of
+          each request you make to the API. For more information or to request
+          your own client ID, feel free to reach out to PolicyEngine at{" "}
           <a href="mailto: hello@policyengine.org">hello@policyengine.org</a>.
         </p>
         <br />
@@ -325,6 +346,9 @@ export default function APIDocumentationPage({ metadata }) {
         <ul>
           <li>
             <a href="#calculate">Calculate household-level policy outcomes</a>
+          </li>
+          <li>
+            <a href="#fetch_token">Fetch an authentication token</a>
           </li>
           <li>
             <a href="#variables">Variable and parameter metadata search</a>
@@ -346,6 +370,16 @@ export default function APIDocumentationPage({ metadata }) {
             : exampleInputs.default
         }
         countryId={countryId}
+        displayCategory={displayCategory}
+      />
+      <APIEndpointStatic
+        id="fetch_token"
+        title="Fetch an authentication token"
+        description={
+          'Execute a credentials exchange, using your client ID and client secret to obtain an authentication token. This token must be included within the authorization header of every HTTP request you make to the PolicyEngine API in the format "Bearer YOUR_TOKEN" (including the space). Tokens expire every month for security purposes.'
+        }
+        exampleInput={tokenFetchCode}
+        exampleOutput={tokenOutputCode}
         displayCategory={displayCategory}
       />
       <VariableParameterExplorer
@@ -446,6 +480,48 @@ function APIEndpoint({
           data={JSON.stringify(outputJson, null, 2)}
           title="Output"
         />
+      </div>
+      {children}
+    </Section>
+  );
+}
+
+function APIEndpointStatic({
+  pattern,
+  method,
+  title,
+  description,
+  children,
+  exampleInput,
+  id,
+  displayCategory,
+  exampleOutput,
+}) {
+  const hasInput = Boolean(exampleInput);
+
+  return (
+    <Section>
+      <h3 id={id}>{title}</h3>
+      <h5>
+        <code>
+          {method} {pattern}
+        </code>
+      </h5>
+      <p>{description}</p>
+
+      <div
+        data-testid="APIEndpoint_json_blocks"
+        style={{
+          display: "flex",
+          flexDirection: displayCategory === "mobile" && "column",
+          gap: displayCategory === "mobile" ? "2rem" : "50px",
+          marginTop: displayCategory === "mobile" ? "2rem" : 40,
+        }}
+      >
+        {hasInput && (
+          <CodeBlock language="python" data={exampleInput} title="Input" />
+        )}
+        <CodeBlock language="json" data={exampleOutput} title="Output" />
       </div>
       {children}
     </Section>

--- a/src/pages/APIDocumentationPage.jsx
+++ b/src/pages/APIDocumentationPage.jsx
@@ -464,6 +464,7 @@ function APIEndpoint({
       <p>{description}</p>
 
       <div
+        data-testid="APIEndpoint_json_blocks"
         style={{
           display: "flex",
           flexDirection: displayCategory === "mobile" && "column",
@@ -509,7 +510,6 @@ function APIEndpointStatic({
       <p>{description}</p>
 
       <div
-        data-testid="APIEndpoint_json_blocks"
         style={{
           display: "flex",
           flexDirection: displayCategory === "mobile" && "column",


### PR DESCRIPTION
## Description

Fixes #1773. 

## Changes

This PR adds a section to describe the process of fetching an authentication token for the household API. It creates a new component, APIEndpointStatic, that is similar to APIEndpoint, but does not execute a fetch request. It also adds relevant information about the process.

I was unsure whether the section should be placed above or below the policy outcomes calculation section. I placed it under, but please feel free to move it in review.

## Screenshots

A video of the component in action is available below.
https://github.com/PolicyEngine/policyengine-app/assets/14987227/6fe68ebb-61d5-42a8-a3c8-8c9147448578

## Tests

N/A
