### PR TITLE
Remove Jest warnings

### DIFF
--- a/src/__tests__/pages/APIDocumentationPage.test.js
+++ b/src/__tests__/pages/APIDocumentationPage.test.js
@@ -26,6 +26,19 @@ beforeAll(async () => {
   metadataUS = await fetchMetadata("us");
   metadataUK = await fetchMetadata("uk");
   metadataCA = await fetchMetadata("ca");
+
+  document.createRange = () => {
+    const range = new Range();
+
+    range.getBoundingClientRect = jest.fn();
+
+    range.getClientRects = jest.fn(() => ({
+      item: () => null,
+      length: 0,
+    }));
+
+    return range;
+  };
 });
 
 afterEach(() => {

--- a/src/layout/CodeBlock.jsx
+++ b/src/layout/CodeBlock.jsx
@@ -141,8 +141,10 @@ export default function CodeBlock({
       <Card
         style={{}}
         loading={!data}
-        bodyStyle={{
-          padding: 0,
+        styles={{
+          body: {
+            padding: 0,
+          },
         }}
         title={cardTitleComponent}
       >

--- a/src/pages/APIDocumentationPage.jsx
+++ b/src/pages/APIDocumentationPage.jsx
@@ -249,7 +249,7 @@ function VariableParameterExplorer(props) {
         <Input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          bordered={false}
+          variant="borderless"
           placeholder="Search for a variable or parameter"
           style={{
             fontSize: 20,


### PR DESCRIPTION
## Description

Fixes #1718.

## Changes

This PR brings some implementations of Ant Design up-to-date and stubs a function that CodeMirror relies upon, but has no impact upon our tests, merely causing warnings.

## Screenshots

N/A

## Tests

N/A
