### PR TITLE
Remove extra copy button

### DIFF
--- a/src/pages/policy/output/Analysis.jsx
+++ b/src/pages/policy/output/Analysis.jsx
@@ -264,27 +264,7 @@ export default function Analysis(props) {
         />
       </div>
       {showPrompt ? (
-        <>
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "center",
-              paddingTop: 30,
-              marginBottom: 30,
-            }}
-          >
-            <Button
-              text="Copy"
-              style={{ margin: "20px auto 10px" }}
-              onClick={() => {
-                navigator.clipboard.writeText(lines.join("\n"));
-              }}
-            />
-          </div>
-          <p>
-            <CodeBlock lines={lines} language={"markdown"} data={prompt} />
-          </p>
-        </>
+        <CodeBlock lines={lines} language={"markdown"} data={prompt} />
       ) : null}
     </>
   );


### PR DESCRIPTION
## Description

Fixes #1756.

## Changes

This PR removes the now unnecessary copy button on the AI output page.

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/14987227/565897c5-d451-4fb7-89f7-b4d098ee6c1a

## Tests

None have been added.
