### PR TITLE
PolicyEngine component test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -66,7 +66,7 @@ module.exports = {
   setupFiles: ["<rootDir>/src/__tests__/__setup__/setup.js"],
   testMatch: ["**/__tests__/**/*.test.js"],
   moduleNameMapper: {
-    "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+    "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|md)$":
       "<rootDir>/src/__tests__/__setup__/fileMock.js",
     "\\.(css|less)$": "<rootDir>/src/__tests__/__setup__/fileMock.js",
   },

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -99,9 +99,9 @@ describe("Test main PolicyEngine component", () => {
   test("Fetches reform policy data");
   test("Fetches user profile if user is logged in");
   test("Redirects from / to /[countryId]");
-  test("Loads auth callback");
+  test("Routes to auth callback");
   */
-  test("Loads about page for US", () => {
+  test("Routes to about page for US", () => {
 
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
@@ -120,7 +120,7 @@ describe("Test main PolicyEngine component", () => {
 
     expect(getByText("Our people")).toBeInTheDocument();
   });
-  test("Loads jobs page for UK", () => {
+  test("Routes to jobs page for UK", () => {
 
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
@@ -139,7 +139,7 @@ describe("Test main PolicyEngine component", () => {
 
     expect(getByText("Join Our Team")).toBeInTheDocument();
   });
-  test("Loads testimonials page for US", () => {
+  test("Routes to testimonials page for US", () => {
 
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
@@ -158,7 +158,7 @@ describe("Test main PolicyEngine component", () => {
 
     expect(getByText("What people say about PolicyEngine")).toBeInTheDocument();
   });
-  test("Loads calculator interstitial page for UK", () => {
+  test("Routes to calculator interstitial page for UK", () => {
 
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
@@ -177,7 +177,7 @@ describe("Test main PolicyEngine component", () => {
 
     expect(getByText("Choose a calculator")).toBeInTheDocument();
   });
-  test("Loads research page for US", () => {
+  test("Routes to research page for US", () => {
 
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
@@ -200,7 +200,7 @@ describe("Test main PolicyEngine component", () => {
     // expect(getByText("us")).toBeInTheDocument(); 
 
   });
-  test("Loads research page for UK", () => {
+  test("Routes to research page for UK", () => {
 
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
@@ -223,17 +223,75 @@ describe("Test main PolicyEngine component", () => {
     // expect(getByText("uk")).toBeInTheDocument(); 
   });
   /*
-  test("Loads contact page for US");
-  test("Loads donate page");
-  test("Loads individual blog posts");
-  test("Loads privacy page");
-  test("Loads T&C page");
-  test("Loads household page");
-  test("Loads policy page");
-  test("Loads user profile page");
-  test("Loads API documentation page");
-  test("Loads TRAFWA calculator");
-  test("Loads Citizens Economic Council page");
+  test("Routes to contact page for US"); Unclear if this page is meant to exist
+  */
+  test("Routes to donate page for UK", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/uk/donate",
+      origin: "https://www.policyengine.org/uk/donate"
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("The Difference Your Support Makes")).toBeInTheDocument();
+  });
+  /*
+  test("Routes to individual blog posts");
+  */
+  test("Routes to privacy page for UK", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/uk/privacy",
+      origin: "https://www.policyengine.org/uk/privacy"
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("Privacy")).toBeInTheDocument();
+  });
+  test("Routes to T&C page for US", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/us/terms",
+      origin: "https://www.policyengine.org/us/terms"
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("Terms of Service")).toBeInTheDocument();
+  });
+  /*
+  test("Routes to household page");
+  test("Routes to policy page");
+  test("Routes to user profile page");
+  test("Routes to API documentation page");
+  test("Routes to TRAFWA calculator");
+  test("Routes to Citizens Economic Council page");
   test("Redirects from /countryId/blog/slug to /countryId/research/slug");
   test("Redirects for unrecognized paths");
   */

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -1,7 +1,6 @@
 import "@testing-library/jest-dom";
-import { render, screen} from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { BrowserRouter, useSearchParams } from "react-router-dom";
-import fetch from "node-fetch";
 import postJson from "../posts/posts.json";
 
 import PolicyEngine from "../PolicyEngine";
@@ -26,25 +25,14 @@ jest.mock("react-router-dom", () => {
   };
 });
 
-let metadataUS = null;
-let metadataUK = null;
-
-const {location} = window;
+const { location } = window;
 
 beforeAll(async () => {
-  const res = await fetch("https://api.policyengine.org/us/metadata");
-  const metadataRaw = await res.json();
-  metadataUS = metadataRaw.result;
-
-  const resUK = await fetch("https://api.policyengine.org/uk/metadata");
-  const metadataRawUK = await resUK.json();
-  metadataUK = metadataRawUK.result;
-
   window.scrollTo = jest.fn();
 
   delete window.location;
   window.location = {
-    reload: jest.fn()
+    reload: jest.fn(),
   };
 });
 
@@ -55,7 +43,6 @@ afterAll(() => {
 
 describe("Test main PolicyEngine component", () => {
   test("Renders for US if proper data passed", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -63,20 +50,21 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/us",
-      origin: "https://www.policyengine.org/us"
+      origin: "https://www.policyengine.org/us",
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
-    expect(getByText("Computing Public Policy for Everyone")).toBeInTheDocument();
+    expect(
+      getByText("Computing Public Policy for Everyone"),
+    ).toBeInTheDocument();
     expect(getByText("Trusted across the US")).toBeInTheDocument();
-
   });
   test("Renders for UK if proper data passed", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -84,19 +72,21 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/uk",
-      origin: "https://www.policyengine.org/uk"
+      origin: "https://www.policyengine.org/uk",
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
-    expect(getByText("Computing Public Policy for Everyone")).toBeInTheDocument();
+    expect(
+      getByText("Computing Public Policy for Everyone"),
+    ).toBeInTheDocument();
     expect(getByText("Trusted across the UK")).toBeInTheDocument();
   });
   test("Routes to auth callback", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -104,19 +94,18 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/callback",
-      origin: "https://www.policyengine.org/callback"
+      origin: "https://www.policyengine.org/callback",
     };
 
-    const {queryByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { queryByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(queryByText("Follow us on social media")).not.toBeInTheDocument();
-
   });
   test("Routes to about page for US", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -124,18 +113,18 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/us/about",
-      origin: "https://www.policyengine.org/us/about"
+      origin: "https://www.policyengine.org/us/about",
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(getByText("Our people")).toBeInTheDocument();
   });
   test("Routes to jobs page for UK", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -143,18 +132,18 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/uk/jobs",
-      origin: "https://www.policyengine.org/uk/jobs"
+      origin: "https://www.policyengine.org/uk/jobs",
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(getByText("Join Our Team")).toBeInTheDocument();
   });
   test("Routes to testimonials page for US", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -162,18 +151,18 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/us/testimonials",
-      origin: "https://www.policyengine.org/us/testimonials"
+      origin: "https://www.policyengine.org/us/testimonials",
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(getByText("What people say about PolicyEngine")).toBeInTheDocument();
   });
   test("Routes to calculator interstitial page for UK", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -181,18 +170,18 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/uk/calculator",
-      origin: "https://www.policyengine.org/uk/calculator"
+      origin: "https://www.policyengine.org/uk/calculator",
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(getByText("Choose a calculator")).toBeInTheDocument();
   });
   test("Routes to research page for US", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -200,22 +189,21 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/us/research",
-      origin: "https://www.policyengine.org/us/research"
+      origin: "https://www.policyengine.org/us/research",
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(getByText("Research and analysis")).toBeInTheDocument();
     // The below test should be re-enabled when tags on the page are no longer text nodes
     // inside divs, which does not follow proper semantic HTML and cannot be tested using getByText
-    // expect(getByText("us")).toBeInTheDocument(); 
-
+    // expect(getByText("us")).toBeInTheDocument();
   });
   test("Routes to research page for UK", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -223,24 +211,21 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/uk/research",
-      origin: "https://www.policyengine.org/uk/research"
+      origin: "https://www.policyengine.org/uk/research",
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(getByText("Research and analysis")).toBeInTheDocument();
     // The below test should be re-enabled when tags on the page are no longer text nodes
     // inside divs, which does not follow proper semantic HTML and cannot be tested using getByText
-    // expect(getByText("uk")).toBeInTheDocument(); 
+    // expect(getByText("uk")).toBeInTheDocument();
   });
-  /*
-  test("Routes to contact page for US"); Unclear if this page is meant to exist
-  */
   test("Routes to donate page for UK", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -248,13 +233,14 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/uk/donate",
-      origin: "https://www.policyengine.org/uk/donate"
+      origin: "https://www.policyengine.org/uk/donate",
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(getByText("The Difference Your Support Makes")).toBeInTheDocument();
   });
@@ -264,20 +250,21 @@ describe("Test main PolicyEngine component", () => {
   // Processing markdown properly, which should be done to test blog files,
   // would likely require a custom webpack setup.
   test("Routes to individual blog posts for US", () => {
-
     global.fetch = jest.fn().mockImplementationOnce(() =>
       Promise.resolve({
         text: () => Promise.resolve("success"),
-      })
+      }),
     );
 
     // Filter posts.json for US articles
-    const filteredPostJson = postJson.filter((post) => post.tags.includes("us"));
+    const filteredPostJson = postJson.filter((post) =>
+      post.tags.includes("us"),
+    );
 
     // Choose one at random
     const randIndex = Math.floor(Math.random() * filteredPostJson.length);
 
-    const selectedPost = filteredPostJson[randIndex]
+    const selectedPost = filteredPostJson[randIndex];
     const postFilepath = selectedPost.filename.split(".")[0];
 
     useSearchParams.mockImplementation(() => {
@@ -287,18 +274,18 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: `/us/research/${postFilepath}`,
-      origin: `https://www.policyengine.org/us/research/${postFilepath}`
+      origin: `https://www.policyengine.org/us/research/${postFilepath}`,
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(getByText("Our organization")).toBeInTheDocument();
   });
   test("Routes to privacy page for UK", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -306,18 +293,18 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/uk/privacy",
-      origin: "https://www.policyengine.org/uk/privacy"
+      origin: "https://www.policyengine.org/uk/privacy",
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(getByText("Privacy")).toBeInTheDocument();
   });
   test("Routes to T&C page for US", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -325,13 +312,14 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/us/terms",
-      origin: "https://www.policyengine.org/us/terms"
+      origin: "https://www.policyengine.org/us/terms",
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(getByText("Terms of Service")).toBeInTheDocument();
   });
@@ -339,7 +327,6 @@ describe("Test main PolicyEngine component", () => {
   // more detailed testing should be done for the component
   // itself
   test("Routes to household page for US", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -347,21 +334,23 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/us/household",
-      origin: "https://www.policyengine.org/us/household"
+      origin: "https://www.policyengine.org/us/household",
     };
 
-    const {queryByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { queryByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
-    expect(queryByText("Computing Public Policy for Everyone")).not.toBeInTheDocument();
+    expect(
+      queryByText("Computing Public Policy for Everyone"),
+    ).not.toBeInTheDocument();
   });
   // Note: This test only determines if routing occurs;
   // more detailed testing should be done for the component
   // itself
   test("Routes to policy page for UK", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -369,18 +358,20 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/uk/policy",
-      origin: "https://www.policyengine.org/uk/policy"
+      origin: "https://www.policyengine.org/uk/policy",
     };
 
-    const {queryByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { queryByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
-    expect(queryByText("Computing Public Policy for Everyone")).not.toBeInTheDocument();
+    expect(
+      queryByText("Computing Public Policy for Everyone"),
+    ).not.toBeInTheDocument();
   });
   test("Routes to user profile page if supplied with a user ID for UK", () => {
-
     const testUserId = "1";
 
     useSearchParams.mockImplementation(() => {
@@ -390,25 +381,23 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: `/uk/profile/${testUserId}`,
-      origin: `https://www.policyengine.org/uk/profile/${testUserId}`
+      origin: `https://www.policyengine.org/uk/profile/${testUserId}`,
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(getByText("Profile")).toBeInTheDocument();
   });
-  // The below should be implemented once we properly handle this case
-  // test("Redirects if /profile is accessed by unauthenticated user");
   test("Routes to API documentation page for US", () => {
-
     // This test uses node-fetch to actually fetch country metadata,
     // but can't use fetch to fetch the API component's sample data,
     // and since it's not possible to conditionally polyfill fetch,
     // this is a better way of silencing the inevitable 404 error
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
 
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
@@ -417,18 +406,18 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/us/api",
-      origin: "https://www.policyengine.org/us/api"
+      origin: "https://www.policyengine.org/us/api",
     };
 
-    const {getByText} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
     expect(getByText("PolicyEngine API Documentation")).toBeInTheDocument();
   });
   test("Routes to TRAFWA calculator", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -436,19 +425,20 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/us/trafwa-ctc-calculator",
-      origin: "https://www.policyengine.org/us/trafwa-ctc-calculator"
+      origin: "https://www.policyengine.org/us/trafwa-ctc-calculator",
     };
 
-    const {getByTitle} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByTitle } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
-    expect(getByTitle("TRAFWA Child Tax Credit Calculator")).toBeInTheDocument();
-    
+    expect(
+      getByTitle("TRAFWA Child Tax Credit Calculator"),
+    ).toBeInTheDocument();
   });
   test("Routes to Citizens Economic Council page", () => {
-
     useSearchParams.mockImplementation(() => {
       return [new URLSearchParams(), jest.fn()];
     });
@@ -456,15 +446,17 @@ describe("Test main PolicyEngine component", () => {
     window.location = {
       ...window.location,
       pathname: "/uk/cec",
-      origin: "https://www.policyengine.org/uk/cec"
+      origin: "https://www.policyengine.org/uk/cec",
     };
 
-    const {getByTitle} = render(
-    <BrowserRouter>
-      <PolicyEngine />
-    </BrowserRouter>);
+    const { getByTitle } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
 
-    expect(getByTitle("Citizens' Economic Council reform simulator")).toBeInTheDocument();
-
+    expect(
+      getByTitle("Citizens' Economic Council reform simulator"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -289,9 +289,73 @@ describe("Test main PolicyEngine component", () => {
   test("Routes to household page");
   test("Routes to policy page");
   test("Routes to user profile page");
-  test("Routes to API documentation page");
-  test("Routes to TRAFWA calculator");
-  test("Routes to Citizens Economic Council page");
+  */
+  test("Routes to API documentation page for US", () => {
+
+    // This test uses node-fetch to actually fetch country metadata,
+    // but can't use fetch to fetch the API component's sample data,
+    // and since it's not possible to conditionally polyfill fetch,
+    // this is a better way of silencing the inevitable 404 error
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/us/api",
+      origin: "https://www.policyengine.org/us/api"
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("PolicyEngine API Documentation")).toBeInTheDocument();
+  });
+  test("Routes to TRAFWA calculator", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/us/trafwa-ctc-calculator",
+      origin: "https://www.policyengine.org/us/trafwa-ctc-calculator"
+    };
+
+    const {getByTitle} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByTitle("TRAFWA Child Tax Credit Calculator")).toBeInTheDocument();
+    
+  });
+  test("Routes to Citizens Economic Council page", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/uk/cec",
+      origin: "https://www.policyengine.org/uk/cec"
+    };
+
+    const {getByTitle} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByTitle("Citizens' Economic Council reform simulator")).toBeInTheDocument();
+
+  });
+  /*
   test("Redirects from /countryId/blog/slug to /countryId/research/slug");
   test("Redirects for unrecognized paths");
   */

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -28,6 +28,8 @@ jest.mock("react-router-dom", () => {
 let metadataUS = null;
 let metadataUK = null;
 
+const {location} = window;
+
 beforeAll(async () => {
   const res = await fetch("https://api.policyengine.org/us/metadata");
   const metadataRaw = await res.json();
@@ -36,6 +38,17 @@ beforeAll(async () => {
   const resUK = await fetch("https://api.policyengine.org/uk/metadata");
   const metadataRawUK = await resUK.json();
   metadataUK = metadataRawUK.result;
+
+  window.scrollTo = jest.fn();
+
+  delete window.location;
+  window.location = {
+    reload: jest.fn()
+  };
+});
+
+afterAll(() => {
+  window.location = location;
 });
 
 describe("Test main PolicyEngine component", () => {
@@ -45,11 +58,8 @@ describe("Test main PolicyEngine component", () => {
       return [new URLSearchParams(), jest.fn()];
     });
 
-    window.scrollTo = jest.fn();
-
-    delete window.location;
     window.location = {
-      reload: jest.fn(),
+      ...window.location,
       pathname: "/us",
       origin: "https://www.policyengine.org/us"
     };

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -95,17 +95,6 @@ describe("Test main PolicyEngine component", () => {
     expect(getByText("Computing Public Policy for Everyone")).toBeInTheDocument();
     expect(getByText("Trusted across the UK")).toBeInTheDocument();
   });
-
-  // Wasn't able at the moment to figure out how to properly execute
-  // the below tests
-  /*
-  test("Metadata re-fetches if country ID changes");
-  test("Fetches baseline policy data");
-  test("Fetches reform policy data");
-  */
-  /*
-  test("Redirects from / to /[countryId]");
-  */
   test("Routes to auth callback", () => {
 
     useSearchParams.mockImplementation(() => {
@@ -478,9 +467,4 @@ describe("Test main PolicyEngine component", () => {
     expect(getByTitle("Citizens' Economic Council reform simulator")).toBeInTheDocument();
 
   });
-  /*
-  test("Redirects from /countryId/blog/slug to /countryId/research/slug");
-  */
-  // The below should be implemented once we properly handle this case
-  // test("Redirects for unrecognized paths and removes garbage values");
 });

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -1,0 +1,56 @@
+import "@testing-library/jest-dom";
+import { render, waitFor } from "@testing-library/react";
+import { BrowserRouter, useSearchParams } from "react-router-dom";
+import fetch from "node-fetch";
+
+import PolicyEngine from "../redesign/components/PolicyEngine";
+
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useSearchParams: jest.fn(),
+  };
+});
+
+let metadataUS = null;
+let metadataUK = null;
+beforeAll(async () => {
+  const res = await fetch("https://api.policyengine.org/us/metadata");
+  const metadataRaw = await res.json();
+  metadataUS = metadataRaw.result;
+
+  const resUK = await fetch("https://api.policyengine.org/uk/metadata");
+  const metadataRawUK = await resUK.json();
+  metadataUK = metadataRawUK.result;
+});
+
+describe("Test main PolicyEngine component", () => {
+  test("Renders for US if proper data passed");
+  test("Renders for UK if proper data passed");
+  test("Metadata re-fetches if country ID changes");
+  test("Fetches baseline policy data");
+  test("Fetches reform policy data");
+  test("Fetches user profile if user is logged in");
+  test("Redirects from / to /[countryId]");
+  test("Loads auth callback");
+  test("Loads about page");
+  test("Loads jobs page");
+  test("Loads testimonials page");
+  test("Loads calculator interstitial page");
+  test("Loads research page");
+  test("Loads contact page");
+  test("Loads donate page");
+  test("Loads individual blog posts");
+  test("Loads privacy page");
+  test("Loads T&C page");
+  test("Loads household page");
+  test("Loads policy page");
+  test("Loads user profile page");
+  test("Loads API documentation page");
+  test("Loads TRAFWA calculator");
+  test("Loads Citizens Economic Council page");
+  test("Redirects from /countryId/blog/slug to /countryId/research/slug");
+  test("Redirects for unrecognized paths");
+})

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -100,10 +100,84 @@ describe("Test main PolicyEngine component", () => {
   test("Fetches user profile if user is logged in");
   test("Redirects from / to /[countryId]");
   test("Loads auth callback");
-  test("Loads about page");
-  test("Loads jobs page");
-  test("Loads testimonials page");
-  test("Loads calculator interstitial page");
+  */
+  test("Loads about page for US", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/us/about",
+      origin: "https://www.policyengine.org/us/about"
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("Our people")).toBeInTheDocument();
+  });
+  test("Loads jobs page for UK", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/uk/jobs",
+      origin: "https://www.policyengine.org/uk/jobs"
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("Join Our Team")).toBeInTheDocument();
+  });
+  test("Loads testimonials page for US", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/us/testimonials",
+      origin: "https://www.policyengine.org/us/testimonials"
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("What people say about PolicyEngine")).toBeInTheDocument();
+  });
+  test("Loads calculator interstitial page for UK", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/uk/calculator",
+      origin: "https://www.policyengine.org/uk/calculator"
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("Choose a calculator")).toBeInTheDocument();
+  });
+  /*
   test("Loads research page");
   test("Loads contact page");
   test("Loads donate page");

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -70,10 +70,30 @@ describe("Test main PolicyEngine component", () => {
     </BrowserRouter>);
 
     expect(getByText("Computing Public Policy for Everyone")).toBeInTheDocument();
+    expect(getByText("Trusted across the US")).toBeInTheDocument();
 
   });
+  test("Renders for UK if proper data passed", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/uk",
+      origin: "https://www.policyengine.org/uk"
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("Computing Public Policy for Everyone")).toBeInTheDocument();
+    expect(getByText("Trusted across the UK")).toBeInTheDocument();
+  });
   /*
-  test("Renders for UK if proper data passed");
   test("Metadata re-fetches if country ID changes");
   test("Fetches baseline policy data");
   test("Fetches reform policy data");

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import { render, waitFor } from "@testing-library/react";
 import { BrowserRouter, useSearchParams } from "react-router-dom";
 import fetch from "node-fetch";
+import postJson from "../posts/posts.json";
 
 import PolicyEngine from "../redesign/components/PolicyEngine";
 
@@ -93,10 +94,15 @@ describe("Test main PolicyEngine component", () => {
     expect(getByText("Computing Public Policy for Everyone")).toBeInTheDocument();
     expect(getByText("Trusted across the UK")).toBeInTheDocument();
   });
+
+  // Wasn't able at the moment to figure out how to properly execute
+  // the below tests
   /*
   test("Metadata re-fetches if country ID changes");
   test("Fetches baseline policy data");
   test("Fetches reform policy data");
+  */
+  /*
   test("Fetches user profile if user is logged in");
   test("Redirects from / to /[countryId]");
   test("Routes to auth callback");
@@ -244,8 +250,37 @@ describe("Test main PolicyEngine component", () => {
 
     expect(getByText("The Difference Your Support Makes")).toBeInTheDocument();
   });
+
+  // This test needs to be debugged for a Jest import error
   /*
-  test("Routes to individual blog posts");
+  test("Routes to individual blog posts for US", () => {
+
+    // Filter posts.json for US articles
+    const filteredPostJson = postJson.filter((post) => post.tags.includes("us"));
+
+    // Choose one at random
+    const randIndex = Math.floor(Math.random() * filteredPostJson.length);
+
+    const selectedPost = filteredPostJson[randIndex]
+    const postFilepath = selectedPost.filename.split(".")[0];
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: `/us/research/${postFilepath}`,
+      origin: `https://www.policyengine.org/us/research/${postFilepath}`
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText(selectedPost.title)).toBeInTheDocument();
+  });
   */
   test("Routes to privacy page for UK", () => {
 

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, waitFor } from "@testing-library/react";
+import { render} from "@testing-library/react";
 import { BrowserRouter, useSearchParams } from "react-router-dom";
 import fetch from "node-fetch";
 import postJson from "../posts/posts.json";
@@ -270,9 +270,17 @@ describe("Test main PolicyEngine component", () => {
     expect(getByText("The Difference Your Support Makes")).toBeInTheDocument();
   });
 
-  // This test needs to be debugged for a Jest import error
-  /*
+  // This test only ensures that the JS page renders, not that markdown is transformed,
+  // as markdown files are stubbed out in our current implementation of Jest.
+  // Processing markdown properly, which should be done to test blog files,
+  // would likely require a custom webpack setup.
   test("Routes to individual blog posts for US", () => {
+
+    global.fetch = jest.fn().mockImplementationOnce(() =>
+      Promise.resolve({
+        text: () => Promise.resolve("success"),
+      })
+    );
 
     // Filter posts.json for US articles
     const filteredPostJson = postJson.filter((post) => post.tags.includes("us"));
@@ -298,9 +306,8 @@ describe("Test main PolicyEngine component", () => {
       <PolicyEngine />
     </BrowserRouter>);
 
-    expect(getByText(selectedPost.title)).toBeInTheDocument();
+    expect(getByText("Our organization")).toBeInTheDocument();
   });
-  */
   test("Routes to privacy page for UK", () => {
 
     useSearchParams.mockImplementation(() => {
@@ -342,7 +349,9 @@ describe("Test main PolicyEngine component", () => {
   /*
   test("Routes to household page");
   test("Routes to policy page");
-  test("Routes to user profile page");
+  test("Routes to user profile page if user is logged in");
+  test("Routes to user profile page if supplied with a user ID");
+  test("Redirects if /profile is accessed by unauthenticated user"); // This will currently fail
   */
   test("Routes to API documentation page for US", () => {
 
@@ -411,6 +420,6 @@ describe("Test main PolicyEngine component", () => {
   });
   /*
   test("Redirects from /countryId/blog/slug to /countryId/research/slug");
-  test("Redirects for unrecognized paths");
+  test("Redirects for unrecognized paths and removes garbage values"); // This would currently fail
   */
 });

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -4,7 +4,7 @@ import { BrowserRouter, useSearchParams } from "react-router-dom";
 import fetch from "node-fetch";
 import postJson from "../posts/posts.json";
 
-import PolicyEngine from "../redesign/components/PolicyEngine";
+import PolicyEngine from "../PolicyEngine";
 
 jest.mock("react-router-dom", () => {
   const originalModule = jest.requireActual("react-router-dom");
@@ -105,8 +105,27 @@ describe("Test main PolicyEngine component", () => {
   /*
   test("Fetches user profile if user is logged in");
   test("Redirects from / to /[countryId]");
-  test("Routes to auth callback");
   */
+  test("Routes to auth callback", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/callback",
+      origin: "https://www.policyengine.org/callback"
+    };
+
+    const {queryByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(queryByText("Follow us on social media")).not.toBeInTheDocument();
+
+  });
   test("Routes to about page for US", () => {
 
     useSearchParams.mockImplementation(() => {

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -349,7 +349,6 @@ describe("Test main PolicyEngine component", () => {
   /*
   test("Routes to household page");
   test("Routes to policy page");
-  test("Routes to user profile page if user is logged in");
   test("Routes to user profile page if supplied with a user ID");
   test("Redirects if /profile is accessed by unauthenticated user"); // This will currently fail
   */

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -14,8 +14,20 @@ jest.mock("react-router-dom", () => {
   };
 });
 
+jest.mock("react-plotly.js", () => jest.fn());
+
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useSearchParams: jest.fn(),
+  };
+});
+
 let metadataUS = null;
 let metadataUK = null;
+
 beforeAll(async () => {
   const res = await fetch("https://api.policyengine.org/us/metadata");
   const metadataRaw = await res.json();
@@ -27,7 +39,30 @@ beforeAll(async () => {
 });
 
 describe("Test main PolicyEngine component", () => {
-  test("Renders for US if proper data passed");
+  test("Renders for US if proper data passed", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.scrollTo = jest.fn();
+
+    delete window.location;
+    window.location = {
+      reload: jest.fn(),
+      pathname: "/us",
+      origin: "https://www.policyengine.org/us"
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("Computing Public Policy for Everyone")).toBeInTheDocument();
+
+  });
+  /*
   test("Renders for UK if proper data passed");
   test("Metadata re-fetches if country ID changes");
   test("Fetches baseline policy data");
@@ -53,4 +88,5 @@ describe("Test main PolicyEngine component", () => {
   test("Loads Citizens Economic Council page");
   test("Redirects from /countryId/blog/slug to /countryId/research/slug");
   test("Redirects for unrecognized paths");
-})
+  */
+});

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -177,9 +177,53 @@ describe("Test main PolicyEngine component", () => {
 
     expect(getByText("Choose a calculator")).toBeInTheDocument();
   });
+  test("Loads research page for US", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/us/research",
+      origin: "https://www.policyengine.org/us/research"
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("Research and analysis")).toBeInTheDocument();
+    // The below test should be re-enabled when tags on the page are no longer text nodes
+    // inside divs, which does not follow proper semantic HTML and cannot be tested using getByText
+    // expect(getByText("us")).toBeInTheDocument(); 
+
+  });
+  test("Loads research page for UK", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/uk/research",
+      origin: "https://www.policyengine.org/uk/research"
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("Research and analysis")).toBeInTheDocument();
+    // The below test should be re-enabled when tags on the page are no longer text nodes
+    // inside divs, which does not follow proper semantic HTML and cannot be tested using getByText
+    // expect(getByText("uk")).toBeInTheDocument(); 
+  });
   /*
-  test("Loads research page");
-  test("Loads contact page");
+  test("Loads contact page for US");
   test("Loads donate page");
   test("Loads individual blog posts");
   test("Loads privacy page");

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render} from "@testing-library/react";
+import { render, screen} from "@testing-library/react";
 import { BrowserRouter, useSearchParams } from "react-router-dom";
 import fetch from "node-fetch";
 import postJson from "../posts/posts.json";
@@ -104,7 +104,6 @@ describe("Test main PolicyEngine component", () => {
   test("Fetches reform policy data");
   */
   /*
-  test("Fetches user profile if user is logged in");
   test("Redirects from / to /[countryId]");
   */
   test("Routes to auth callback", () => {
@@ -391,10 +390,29 @@ describe("Test main PolicyEngine component", () => {
 
     expect(queryByText("Computing Public Policy for Everyone")).not.toBeInTheDocument();
   });
-  /*
-  test("Routes to user profile page if supplied with a user ID");
-  test("Redirects if /profile is accessed by unauthenticated user"); // This will currently fail
-  */
+  test("Routes to user profile page if supplied with a user ID for UK", () => {
+
+    const testUserId = "1";
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: `/uk/profile/${testUserId}`,
+      origin: `https://www.policyengine.org/uk/profile/${testUserId}`
+    };
+
+    const {getByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(getByText("Profile")).toBeInTheDocument();
+  });
+  // The below should be implemented once we properly handle this case
+  // test("Redirects if /profile is accessed by unauthenticated user");
   test("Routes to API documentation page for US", () => {
 
     // This test uses node-fetch to actually fetch country metadata,
@@ -462,6 +480,7 @@ describe("Test main PolicyEngine component", () => {
   });
   /*
   test("Redirects from /countryId/blog/slug to /countryId/research/slug");
-  test("Redirects for unrecognized paths and removes garbage values"); // This would currently fail
   */
+  // The below should be implemented once we properly handle this case
+  // test("Redirects for unrecognized paths and removes garbage values");
 });

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -50,6 +50,7 @@ beforeAll(async () => {
 
 afterAll(() => {
   window.location = location;
+  jest.resetAllMocks();
 });
 
 describe("Test main PolicyEngine component", () => {
@@ -346,9 +347,51 @@ describe("Test main PolicyEngine component", () => {
 
     expect(getByText("Terms of Service")).toBeInTheDocument();
   });
+  // Note: This test only determines if routing occurs;
+  // more detailed testing should be done for the component
+  // itself
+  test("Routes to household page for US", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/us/household",
+      origin: "https://www.policyengine.org/us/household"
+    };
+
+    const {queryByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(queryByText("Computing Public Policy for Everyone")).not.toBeInTheDocument();
+  });
+  // Note: This test only determines if routing occurs;
+  // more detailed testing should be done for the component
+  // itself
+  test("Routes to policy page for UK", () => {
+
+    useSearchParams.mockImplementation(() => {
+      return [new URLSearchParams(), jest.fn()];
+    });
+
+    window.location = {
+      ...window.location,
+      pathname: "/uk/policy",
+      origin: "https://www.policyengine.org/uk/policy"
+    };
+
+    const {queryByText} = render(
+    <BrowserRouter>
+      <PolicyEngine />
+    </BrowserRouter>);
+
+    expect(queryByText("Computing Public Policy for Everyone")).not.toBeInTheDocument();
+  });
   /*
-  test("Routes to household page");
-  test("Routes to policy page");
   test("Routes to user profile page if supplied with a user ID");
   test("Redirects if /profile is accessed by unauthenticated user"); // This will currently fail
   */


### PR DESCRIPTION
## Description

Fixes #1722.

## Changes

This PR introduces a series of tests for the `PolicyEngine.jsx` component that are aimed to help prevent future changes that would cause white-screening upon merging of code with obvious defects, e.g., import errors. These tests also aim to test the PolicyEngine component's use of `react-router-dom`. However, some tests that would make sense were not included due to the difficulty of mocking the relevant component.

## Screenshots

N/A

## Tests

N/A
