### PR TITLE
Properly POST un-authed user policies

### DIFF
--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -162,7 +162,7 @@ export default function UserProfilePage(props) {
         };
 
         try {
-          await postUserPolicy(countryId, policy);
+          await postUserPolicy(policy.country_id, policy);
         } catch (err) {
           // If for some reason, policy addition fails,
           // add it to a failed attempts array - this will
@@ -430,12 +430,13 @@ function UserProfileSection(props) {
 
 function PolicySimulationCard(props) {
   const { metadata, userPolicy, keyValue } = props;
+  console.log(Object.keys(metadata));
 
   const CURRENT_API_VERSION = metadata?.version;
   const geography =
     metadata.economy_options.region.filter(
       (region) => region.name === userPolicy.geography,
-    )[0].label || "Unknown";
+    )[0]?.label || "Unknown";
 
   const apiVersion = userPolicy.api_version;
   const dateAdded = userPolicy.added_date;

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -75,7 +75,11 @@ export default function PolicyOutput(props) {
         let failedAttempts = [];
         let policyId = null;
         try {
-          policyId = await postUserPolicy(countryId, policyToSave);
+          policyId = await postUserPolicy(
+            policyToSave.country_id,
+            policyToSave,
+          );
+
           setUserPolicyId(policyId);
         } catch (err) {
           failedAttempts = failedAttempts.concat(policyToSave);


### PR DESCRIPTION
## Description

Fixes #1779.

## Changes

Previously, the front-end application stored an unauthenticated user's policies locally, then emitted them to the back end if/when they created an account. However, it did so using not the policy's country ID, but the country ID active in the app when the user logged in. This meant that if a user created a UK policy while not logged in, then logged in on the US site, a policy with a US country ID, but a UK geography would be created. This policy would then be included among their policies, and when an attempt to properly display the geography data occurred, it would crash the app.

This PR does two things:
1. Conditionally accesses the metadata describing a country's geography options, allowing an "Unknown" value to appear in cases where an error in geography is present, instead of crashing
2. Fixes the bug that created these policies incorrectly by emitting the country ID stored with the policy within the POST request to user_policies, instead of the current app country ID

## Screenshots

The below demonstrates the application working properly when an unauthenticated user creates a UK policy, then logs in on the US site.
https://github.com/PolicyEngine/policyengine-app/assets/14987227/a17d3ae0-0f70-4106-a017-f7ed890ff540

## Tests

None have been added.
