### PR TITLE
Repair errors in Reproduce in Python

### DIFF
--- a/src/__tests__/data/reformDefinitionCode.test.js
+++ b/src/__tests__/data/reformDefinitionCode.test.js
@@ -6,6 +6,7 @@ import {
   getReformCode,
   getSituationCode,
   getImplementationCode,
+  sanitizeStringToPython,
 } from "data/reformDefinitionCode";
 import {
   baselinePolicyUS,
@@ -253,5 +254,26 @@ describe("Test getImplementationCode", () => {
     const output = getImplementationCode("policy", "uk", 2024, testPolicy);
     expect(output).toBeInstanceOf(Array);
     expect(output).toContain("baseline = Microsimulation(reform=baseline)");
+  });
+});
+
+describe("Test sanitizeStringToPython", () => {
+  test("It should convert 'null' to 'None'", () => {
+    const testLine = "dworkin = null";
+
+    const testOutput = sanitizeStringToPython(testLine);
+    expect(testOutput).toBe("dworkin = None");
+  });
+  test("It should convert 'true' to 'True'", () => {
+    const testLine = "dworkin = true";
+
+    const testOutput = sanitizeStringToPython(testLine);
+    expect(testOutput).toBe("dworkin = True");
+  });
+  test("It should convert 'false' to 'False'", () => {
+    const testLine = "dworkin = false";
+
+    const testOutput = sanitizeStringToPython(testLine);
+    expect(testOutput).toBe("dworkin = False");
   });
 });

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -55,16 +55,11 @@ export function getBaselineCode(policy, metadata) {
     return [];
   }
   let json_str = JSON.stringify(policy.baseline.data, null, 2);
+  json_str = sanitizeStringToPython(json_str);
   let lines = [""].concat(json_str.split("\n"));
   lines[1] = "baseline = Reform.from_dict({" + lines[0];
   lines[lines.length - 1] =
     lines[lines.length - 1] + ', country_id="' + metadata.countryId + '")';
-  lines = lines.map((line) => {
-    return line
-      .replace(/true/g, "True")
-      .replace(/false/g, "False")
-      .replace(/null/g, "None");
-  });
   return lines;
 }
 
@@ -73,16 +68,11 @@ export function getReformCode(policy, metadata) {
     return [];
   }
   let json_str = JSON.stringify(policy.reform.data, null, 2);
+  json_str = sanitizeStringToPython(json_str);
   let lines = [""].concat(json_str.split("\n"));
   lines[1] = "reform = Reform.from_dict({" + lines[0];
   lines[lines.length - 1] =
     lines[lines.length - 1] + ', country_id="' + metadata.countryId + '")';
-  lines = lines.map((line) => {
-    return line
-      .replace(/true/g, "True")
-      .replace(/false/g, "False")
-      .replace(/null/g, "None");
-  });
   return lines;
 }
 
@@ -129,10 +119,7 @@ export function getSituationCode(
 
   let householdJson = JSON.stringify(householdInputCopy, null, 2);
   // It's Python-safe, so we need to make true -> True and false -> False and null -> None
-  householdJson = householdJson
-    .replace(/true/g, "True")
-    .replace(/false/g, "False")
-    .replace(/null/g, "None");
+  householdJson = sanitizeStringToPython(householdJson);
 
   let lines = [
     "",
@@ -264,4 +251,18 @@ export function doesParamNameContainNumber(paramName) {
   }
 
   return false;
+}
+
+/**
+ * Utility function to sanitize a string and ensure that it's valid Python;
+ * currently converts JS 'null', 'true', and 'false' to Python
+ * 'None', 'True', and 'False'
+ * @param {String} string
+ * @returns {String}
+ */
+export function sanitizeStringToPython(string) {
+  return string
+    .replace(/true/g, "True")
+    .replace(/false/g, "False")
+    .replace(/null/g, "None");
 }

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -59,6 +59,12 @@ export function getBaselineCode(policy, metadata) {
   lines[1] = "baseline = Reform.from_dict({" + lines[0];
   lines[lines.length - 1] =
     lines[lines.length - 1] + ', country_id="' + metadata.countryId + '")';
+  lines = lines.map((line) => {
+    return line
+      .replace(/true/g, "True")
+      .replace(/false/g, "False")
+      .replace(/null/g, "None");
+  });
   return lines;
 }
 
@@ -71,6 +77,12 @@ export function getReformCode(policy, metadata) {
   lines[1] = "reform = Reform.from_dict({" + lines[0];
   lines[lines.length - 1] =
     lines[lines.length - 1] + ', country_id="' + metadata.countryId + '")';
+  lines = lines.map((line) => {
+    return line
+      .replace(/true/g, "True")
+      .replace(/false/g, "False")
+      .replace(/null/g, "None");
+  });
   return lines;
 }
 
@@ -153,7 +165,7 @@ export function getImplementationCode(type, region, timePeriod, policy) {
   const hasBaseline = Object.keys(policy?.baseline?.data).length > 0;
   const hasReform = Object.keys(policy?.reform?.data).length > 0;
   const hasDatasetSpecified = region === "enhanced_us";
-  const dataset = hasDatasetSpecified ? 'dataset="enhanced_cps_2022"' : "";
+  const dataset = hasDatasetSpecified ? '"enhanced_cps_2022"' : "";
 
   return [
     "",


### PR DESCRIPTION
## Description

Fixes #1782.

## Changes

Fixes two errors in the Reproduce in Python block: sanitizes outputs to ensure that reform code uses Python `True`, `False`, and `None`; and removes an error that prints `dataset=` twice when using `enhanced_cps` for calculations.

## Screenshots

<img width="1440" alt="Screen Shot 2024-05-15 at 11 27 35 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/be7751fb-2053-4aee-aabd-38fa5463e013">

## Tests

None have been added.
