### PR TITLE
Add max width to ValueSetter

### DIFF
--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -356,8 +356,8 @@ function ValueSetter(props) {
     return (
       <StableInputNumber
         style={{
-          width: "100%",
           minWidth: "100px",
+          maxWidth: "150px",
         }}
         key={"input for" + parameter.parameter}
         {...(isCurrency


### PR DESCRIPTION
## Description

Fixes #1731.

## Changes

This PR removes the previous 100% width setting for the `ValueSetter` subcomponent of the `ParameterEditor` component, replacing it with a max width of 150px, allowing for a reasonable width on most viewpoints, but a guaranteed minimum of 100px at certain breakpoints when a user is setting an "advanced" start and end date, and thus a long-style date is displayed. 150px was chosen to allow for reasonable input of 7-digit-long numbers, such as a high income.

## Screenshots

The below screenshots illustrate the changes alongside the default "onward" date, a standard date period, and an "advanced" date period.

<img width="1440" alt="Screen Shot 2024-05-16 at 8 10 48 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/70418a91-f1a0-4bb1-a82d-e0969d0ffa16">
<img width="1440" alt="Screen Shot 2024-05-16 at 8 10 57 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/c371da8c-049a-40ff-a3d2-9bad497098fc">
<img width="1440" alt="Screen Shot 2024-05-16 at 8 11 09 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/bb6a517b-af67-4cce-9855-3b4ea13913e1">

## Tests

None have been added.
