### PR TITLE
Correct household API audience value

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 /build/**
+/src/__tests__/__setup__/data.json

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,5 @@ yarn-error.log*
 /requirements.txt
 **/__pycache__
 .env
-/src/_tests__/__setup__/data.json
+/src/__tests__/__setup__/data.json
 .idea

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/src/__tests__/__setup__/data.json
 
 # production
 /build

--- a/src/pages/APIDocumentationPage.jsx
+++ b/src/pages/APIDocumentationPage.jsx
@@ -105,7 +105,7 @@ const tokenFetchCode = `import http.client
 
 conn = http.client.HTTPSConnection("policyengine.uk.auth0.com")
 
-payload = "{\"client_id\":\"YOUR_CLIENT_ID\",\"client_secret\":\"YOUR_CLIENT_SECRET\",\"audience\":\"https://policyengine.uk.auth0.com/api/v2/\",\"grant_type\":\"client_credentials\"}"
+payload = "{\"client_id\":\"YOUR_CLIENT_ID\",\"client_secret\":\"YOUR_CLIENT_SECRET\",\"audience\":\"https://household.api.policyengine.org\",\"grant_type\":\"client_credentials\"}"
 
 headers = { 'content-type': "application/json" }
 


### PR DESCRIPTION
## Description

Fixes #1800.
Fixes #1801.

## Changes

This PR corrects the audience value utilized for fetching household API access tokens, as documented in the `APIDocumentationPage` component. It also adds sample test metadata to various ignorelists.

## Screenshots

<img width="1440" alt="Screen Shot 2024-05-21 at 4 10 09 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/a4d3aedb-7c5e-47ed-9b6a-c3d1ba3d0317">

## Tests

N/A
