### PR TITLE
Correct formatting for labor supply charts

### DIFF
--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -15,6 +15,7 @@ import { downloadCsv } from "./utils";
 import { useReactToPrint } from "react-to-print";
 import PolicyBreakdown from "./PolicyBreakdown";
 import { Helmet } from "react-helmet";
+import useCountryId from "../../../hooks/useCountryId";
 
 /**
  *
@@ -110,6 +111,7 @@ function getPolicyLabel(policy) {
  */
 export function DisplayImpact(props) {
   const { impact, policy, metadata, showPolicyImpactPopup } = props;
+  const countryId = useCountryId();
   const urlParams = new URLSearchParams(window.location.search);
   const focus = urlParams.get("focus");
   const region = urlParams.get("region");
@@ -149,6 +151,7 @@ export function DisplayImpact(props) {
       metadata: metadata,
       policyLabel: policyLabel,
       mobile: mobile,
+      countryId: countryId,
     });
     pane = chart;
     if (csv) {

--- a/src/pages/policy/output/LabourSupplyDecileAverageImpact.jsx
+++ b/src/pages/policy/output/LabourSupplyDecileAverageImpact.jsx
@@ -3,7 +3,6 @@ import ImpactChart from "./ImpactChart";
 import Plot from "react-plotly.js";
 import {
   formatCurrencyAbbr,
-  formatPercent,
   localeCode,
 } from "../../../lang/format";
 import { ChartLogo } from "../../../api/charts";

--- a/src/pages/policy/output/LabourSupplyDecileAverageImpact.jsx
+++ b/src/pages/policy/output/LabourSupplyDecileAverageImpact.jsx
@@ -1,10 +1,7 @@
 import style from "../../../style";
 import ImpactChart from "./ImpactChart";
 import Plot from "react-plotly.js";
-import {
-  formatCurrencyAbbr,
-  localeCode,
-} from "../../../lang/format";
+import { formatCurrencyAbbr, localeCode } from "../../../lang/format";
 import { ChartLogo } from "../../../api/charts";
 import { plotLayoutFont } from "pages/policy/output/utils";
 

--- a/src/pages/policy/output/LabourSupplyDecileAverageImpact.jsx
+++ b/src/pages/policy/output/LabourSupplyDecileAverageImpact.jsx
@@ -1,12 +1,16 @@
 import style from "../../../style";
 import ImpactChart from "./ImpactChart";
 import Plot from "react-plotly.js";
-import { formatPercent, localeCode } from "../../../lang/format";
+import {
+  formatCurrencyAbbr,
+  formatPercent,
+  localeCode,
+} from "../../../lang/format";
 import { ChartLogo } from "../../../api/charts";
 import { plotLayoutFont } from "pages/policy/output/utils";
 
 export default function LabourSupplyDecileAverageImpact(props) {
-  const { policyLabel, metadata, impact } = props;
+  const { policyLabel, metadata, impact, countryId } = props;
 
   const decileImpact = impact.labour_supply_response;
 
@@ -41,7 +45,12 @@ export default function LabourSupplyDecileAverageImpact(props) {
                 ),
               },
               text: substitutionChanges.map(
-                (value) => (value >= 0 ? "+" : "") + formatPercent(value),
+                (value) =>
+                  (value >= 0 ? "+" : "") +
+                  formatCurrencyAbbr(value, countryId, {
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 0,
+                  }),
               ),
               name: "Substitution effect",
             },
@@ -55,7 +64,12 @@ export default function LabourSupplyDecileAverageImpact(props) {
                 ),
               },
               text: incomeChanges.map(
-                (value) => (value >= 0 ? "+" : "") + formatPercent(value),
+                (value) =>
+                  (value >= 0 ? "+" : "") +
+                  formatCurrencyAbbr(value, countryId, {
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 0,
+                  }),
               ),
               name: "Income effect",
             },
@@ -80,7 +94,12 @@ export default function LabourSupplyDecileAverageImpact(props) {
                 },
               },
               text: overallChange.map(
-                (value) => (value >= 0 ? "+" : "") + formatPercent(value),
+                (value) =>
+                  (value >= 0 ? "+" : "") +
+                  formatCurrencyAbbr(value, countryId, {
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 0,
+                  }),
               ),
               name: "Overall change",
             },

--- a/src/pages/policy/output/LabourSupplyDecileRelativeImpact.jsx
+++ b/src/pages/policy/output/LabourSupplyDecileRelativeImpact.jsx
@@ -6,7 +6,7 @@ import { ChartLogo } from "../../../api/charts";
 import { plotLayoutFont } from "pages/policy/output/utils";
 
 export default function LabourSupplyDecileRelativeImpact(props) {
-  const { policyLabel, metadata, impact } = props;
+  const { policyLabel, metadata, impact, countryId } = props;
 
   const decileImpact = impact.labour_supply_response;
 
@@ -41,7 +41,12 @@ export default function LabourSupplyDecileRelativeImpact(props) {
                 ),
               },
               text: substitutionChanges.map(
-                (value) => (value >= 0 ? "+" : "") + formatPercent(value),
+                (value) =>
+                  (value >= 0 ? "+" : "") +
+                  formatPercent(value, countryId, {
+                    maximumFractionDigits: 1,
+                    minimumFractionDigits: 1,
+                  }),
               ),
               name: "Substitution effect",
             },
@@ -55,7 +60,12 @@ export default function LabourSupplyDecileRelativeImpact(props) {
                 ),
               },
               text: incomeChanges.map(
-                (value) => (value >= 0 ? "+" : "") + formatPercent(value),
+                (value) =>
+                  (value >= 0 ? "+" : "") +
+                  formatPercent(value, countryId, {
+                    maximumFractionDigits: 1,
+                    minimumFractionDigits: 1,
+                  }),
               ),
               name: "Income effect",
             },
@@ -80,7 +90,12 @@ export default function LabourSupplyDecileRelativeImpact(props) {
                 },
               },
               text: overallChange.map(
-                (value) => (value >= 0 ? "+" : "") + formatPercent(value),
+                (value) =>
+                  (value >= 0 ? "+" : "") +
+                  formatPercent(value, countryId, {
+                    maximumFractionDigits: 1,
+                    minimumFractionDigits: 1,
+                  }),
               ),
               name: "Overall change",
             },


### PR DESCRIPTION
## Description

Fixes #1792.

## Changes

This makes the requested changes to the LSR chart decile labels. That said, it does not handle the strange y-axis formatting noted in the issue description itself.

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/14987227/ce143d85-6be5-4960-b322-284083d5c451

## Tests

N/A
