### PR TITLE
fix(login-button): adjust sizes to match COMPUTE POLICY IMPACT button

### DIFF
--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -19,7 +19,7 @@ import {
 import { loginOptions, logoutOptions } from "../auth/authUtils";
 import { Dropdown } from "antd";
 
-const BAR_TOP_PADDING = 10 // Desired top padding, px
+const BAR_TOP_PADDING = 10; // Desired top padding, px
 const BAR_BOTTOM_PADDING = 10; // Desired bottom padding, px
 const BAR_TOP_PADDING_DEFAULT = 8;
 const BAR_BOTTOM_PADDING_DEFAULT = 8;
@@ -213,9 +213,16 @@ function LoginButton() {
   const { loginWithRedirect, isAuthenticated, user, isLoading } = useAuth0();
   const displayCategory = useDisplayCategory();
 
-  const BAR_TOP_PADDING_CURRENT = displayCategory === "mobile" ? BAR_TOP_PADDING : BAR_TOP_PADDING_DEFAULT;
-  const BAR_BOTTOM_PADDING_CURRENT = displayCategory === "mobile" ? BAR_BOTTOM_PADDING : BAR_BOTTOM_PADDING_DEFAULT;
-  const desiredHeight = style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING_CURRENT - BAR_BOTTOM_PADDING_CURRENT;
+  const BAR_TOP_PADDING_CURRENT =
+    displayCategory === "mobile" ? BAR_TOP_PADDING : BAR_TOP_PADDING_DEFAULT;
+  const BAR_BOTTOM_PADDING_CURRENT =
+    displayCategory === "mobile"
+      ? BAR_BOTTOM_PADDING
+      : BAR_BOTTOM_PADDING_DEFAULT;
+  const desiredHeight =
+    style.spacing.HEADER_HEIGHT -
+    BAR_TOP_PADDING_CURRENT -
+    BAR_BOTTOM_PADDING_CURRENT;
 
   const sharedStyle = {
     color: style.colors.WHITE,
@@ -332,9 +339,16 @@ function Hamburger() {
   const [isOpen, setIsOpen] = useState(false);
   const displayCategory = useDisplayCategory();
 
-  const BAR_TOP_PADDING_CURRENT = displayCategory === "mobile" ? BAR_TOP_PADDING : BAR_TOP_PADDING_DEFAULT;
-  const BAR_BOTTOM_PADDING_CURRENT = displayCategory === "mobile" ? BAR_BOTTOM_PADDING : BAR_BOTTOM_PADDING_DEFAULT;
-  const desiredHeight = style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING_CURRENT - BAR_BOTTOM_PADDING_CURRENT;
+  const BAR_TOP_PADDING_CURRENT =
+    displayCategory === "mobile" ? BAR_TOP_PADDING : BAR_TOP_PADDING_DEFAULT;
+  const BAR_BOTTOM_PADDING_CURRENT =
+    displayCategory === "mobile"
+      ? BAR_BOTTOM_PADDING
+      : BAR_BOTTOM_PADDING_DEFAULT;
+  const desiredHeight =
+    style.spacing.HEADER_HEIGHT -
+    BAR_TOP_PADDING_CURRENT -
+    BAR_BOTTOM_PADDING_CURRENT;
 
   return (
     <>

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -10,7 +10,6 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import LinkButton from "../controls/LinkButton";
 import { useAuth0 } from "@auth0/auth0-react";
-import { useEffect } from "react";
 import {
   UserOutlined,
   LoadingOutlined,
@@ -210,17 +209,12 @@ function MobileCalculatorButton() {
 function LoginButton() {
   const countryId = useCountryId();
   const { loginWithRedirect, isAuthenticated, user, isLoading } = useAuth0();
-  const [isMobile, setIsMobile] = useState(window.innerWidth <= 767);
+  const displayCategory = useDisplayCategory();
 
-  useEffect(() => {
-    const handleResize = () => setIsMobile(window.innerWidth <= 767);
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
-  const desiredHeight = isMobile
-    ? 44
-    : style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING + 4;
+  const desiredHeight =
+    displayCategory === "mobile"
+      ? 44
+      : style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING + 4;
 
   const sharedStyle = {
     color: style.colors.WHITE,
@@ -335,17 +329,12 @@ function LoginMenu() {
 
 function Hamburger() {
   const [isOpen, setIsOpen] = useState(false);
-  const [isMobile, setIsMobile] = useState(window.innerWidth <= 767);
+  const displayCategory = useDisplayCategory();
 
-  useEffect(() => {
-    const handleResize = () => setIsMobile(window.innerWidth <= 767);
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
-  const desiredHeight = isMobile
-    ? 44
-    : style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING + 4;
+  const desiredHeight =
+    displayCategory === "mobile"
+      ? 44
+      : style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING + 4;
 
   return (
     <>

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -180,7 +180,9 @@ function MobileCalculatorButton() {
   const countryId = useCountryId();
 
   const desiredHeight =
-    style.spacing.HEADER_HEIGHT - BAR_BOTTOM_PADDING_MOBILE - BAR_BOTTOM_PADDING_MOBILE;
+    style.spacing.HEADER_HEIGHT -
+    BAR_BOTTOM_PADDING_MOBILE -
+    BAR_BOTTOM_PADDING_MOBILE;
   return (
     <div
       style={{
@@ -214,7 +216,9 @@ function LoginButton() {
   const displayCategory = useDisplayCategory();
 
   const BAR_TOP_PADDING_CURRENT =
-    displayCategory === "mobile" ? BAR_TOP_PADDING_MOBILE : BAR_TOP_PADDING_DEFAULT;
+    displayCategory === "mobile"
+      ? BAR_TOP_PADDING_MOBILE
+      : BAR_TOP_PADDING_DEFAULT;
   const BAR_BOTTOM_PADDING_CURRENT =
     displayCategory === "mobile"
       ? BAR_BOTTOM_PADDING_MOBILE
@@ -340,7 +344,9 @@ function Hamburger() {
   const displayCategory = useDisplayCategory();
 
   const BAR_TOP_PADDING_CURRENT =
-    displayCategory === "mobile" ? BAR_TOP_PADDING_MOBILE : BAR_TOP_PADDING_DEFAULT;
+    displayCategory === "mobile"
+      ? BAR_TOP_PADDING_MOBILE
+      : BAR_TOP_PADDING_DEFAULT;
   const BAR_BOTTOM_PADDING_CURRENT =
     displayCategory === "mobile"
       ? BAR_BOTTOM_PADDING_MOBILE

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -214,11 +214,13 @@ function LoginButton() {
 
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth <= 767);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  const desiredHeight = isMobile ? 44 : style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING + 4;
+  const desiredHeight = isMobile
+    ? 44
+    : style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING + 4;
 
   const sharedStyle = {
     color: style.colors.WHITE,
@@ -235,7 +237,7 @@ function LoginButton() {
         alignItems: "center",
         justifyContent: "center",
         cursor: "pointer",
-        border: `1px solid ${style.colors.WHITE}`
+        border: `1px solid ${style.colors.WHITE}`,
       }}
       onClick={
         !isAuthenticated
@@ -256,7 +258,7 @@ function LoginButton() {
           style={{
             width: "100%",
             height: "100%",
-            objectFit: "cover"
+            objectFit: "cover",
           }}
         />
       ) : isLoading || isAuthenticated ? (
@@ -337,12 +339,13 @@ function Hamburger() {
 
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth <= 767);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  const desiredHeight = isMobile ? 44 : style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING + 4;
-
+  const desiredHeight = isMobile
+    ? 44
+    : style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING + 4;
 
   return (
     <>

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -19,8 +19,10 @@ import {
 import { loginOptions, logoutOptions } from "../auth/authUtils";
 import { Dropdown } from "antd";
 
-const BAR_TOP_PADDING = 10; // Desired top padding, px
+const BAR_TOP_PADDING = 10 // Desired top padding, px
 const BAR_BOTTOM_PADDING = 10; // Desired bottom padding, px
+const BAR_TOP_PADDING_DEFAULT = 8;
+const BAR_BOTTOM_PADDING_DEFAULT = 8;
 const BAR_SIDE_PADDING = 16;
 const LINKS = [
   {
@@ -211,10 +213,9 @@ function LoginButton() {
   const { loginWithRedirect, isAuthenticated, user, isLoading } = useAuth0();
   const displayCategory = useDisplayCategory();
 
-  const desiredHeight =
-    displayCategory === "mobile"
-      ? 44
-      : style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING + 4;
+  const BAR_TOP_PADDING_CURRENT = displayCategory === "mobile" ? BAR_TOP_PADDING : BAR_TOP_PADDING_DEFAULT;
+  const BAR_BOTTOM_PADDING_CURRENT = displayCategory === "mobile" ? BAR_BOTTOM_PADDING : BAR_BOTTOM_PADDING_DEFAULT;
+  const desiredHeight = style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING_CURRENT - BAR_BOTTOM_PADDING_CURRENT;
 
   const sharedStyle = {
     color: style.colors.WHITE,
@@ -331,10 +332,9 @@ function Hamburger() {
   const [isOpen, setIsOpen] = useState(false);
   const displayCategory = useDisplayCategory();
 
-  const desiredHeight =
-    displayCategory === "mobile"
-      ? 44
-      : style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING + 4;
+  const BAR_TOP_PADDING_CURRENT = displayCategory === "mobile" ? BAR_TOP_PADDING : BAR_TOP_PADDING_DEFAULT;
+  const BAR_BOTTOM_PADDING_CURRENT = displayCategory === "mobile" ? BAR_BOTTOM_PADDING : BAR_BOTTOM_PADDING_DEFAULT;
+  const desiredHeight = style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING_CURRENT - BAR_BOTTOM_PADDING_CURRENT;
 
   return (
     <>

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import LinkButton from "../controls/LinkButton";
 import { useAuth0 } from "@auth0/auth0-react";
+import { useEffect } from "react";
 import {
   UserOutlined,
   LoadingOutlined,
@@ -209,8 +210,15 @@ function MobileCalculatorButton() {
 function LoginButton() {
   const countryId = useCountryId();
   const { loginWithRedirect, isAuthenticated, user, isLoading } = useAuth0();
-  const desiredHeight =
-    style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING;
+  const [isMobile, setIsMobile] = useState(window.innerWidth <= 767);
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth <= 767);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const desiredHeight = isMobile ? 44 : style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING + 4;
 
   const sharedStyle = {
     color: style.colors.WHITE,
@@ -227,7 +235,7 @@ function LoginButton() {
         alignItems: "center",
         justifyContent: "center",
         cursor: "pointer",
-        border: `1px solid ${style.colors.WHITE}`,
+        border: `1px solid ${style.colors.WHITE}`
       }}
       onClick={
         !isAuthenticated
@@ -247,7 +255,8 @@ function LoginButton() {
           alt="Profile"
           style={{
             width: "100%",
-            objectFit: "cover",
+            height: "100%",
+            objectFit: "cover"
           }}
         />
       ) : isLoading || isAuthenticated ? (
@@ -324,9 +333,16 @@ function LoginMenu() {
 
 function Hamburger() {
   const [isOpen, setIsOpen] = useState(false);
+  const [isMobile, setIsMobile] = useState(window.innerWidth <= 767);
 
-  const desiredHeight =
-    style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING;
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth <= 767);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const desiredHeight = isMobile ? 44 : style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING + 4;
+
 
   return (
     <>

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -19,8 +19,8 @@ import {
 import { loginOptions, logoutOptions } from "../auth/authUtils";
 import { Dropdown } from "antd";
 
-const BAR_TOP_PADDING = 10; // Desired top padding, px
-const BAR_BOTTOM_PADDING = 10; // Desired bottom padding, px
+const BAR_TOP_PADDING_MOBILE = 10; // Desired top padding, px
+const BAR_BOTTOM_PADDING_MOBILE = 10; // Desired bottom padding, px
 const BAR_TOP_PADDING_DEFAULT = 8;
 const BAR_BOTTOM_PADDING_DEFAULT = 8;
 const BAR_SIDE_PADDING = 16;
@@ -169,7 +169,7 @@ function MobileHeaderLogo() {
         alt="PolicyEngine logo"
         style={{
           height: style.spacing.HEADER_HEIGHT,
-          padding: `${BAR_TOP_PADDING}px 0 ${BAR_BOTTOM_PADDING}px 0`,
+          padding: `${BAR_BOTTOM_PADDING_MOBILE}px 0 ${BAR_BOTTOM_PADDING_MOBILE}px 0`,
         }}
       />
     </Link>
@@ -180,7 +180,7 @@ function MobileCalculatorButton() {
   const countryId = useCountryId();
 
   const desiredHeight =
-    style.spacing.HEADER_HEIGHT - BAR_TOP_PADDING - BAR_BOTTOM_PADDING;
+    style.spacing.HEADER_HEIGHT - BAR_BOTTOM_PADDING_MOBILE - BAR_BOTTOM_PADDING_MOBILE;
   return (
     <div
       style={{
@@ -214,10 +214,10 @@ function LoginButton() {
   const displayCategory = useDisplayCategory();
 
   const BAR_TOP_PADDING_CURRENT =
-    displayCategory === "mobile" ? BAR_TOP_PADDING : BAR_TOP_PADDING_DEFAULT;
+    displayCategory === "mobile" ? BAR_TOP_PADDING_MOBILE : BAR_TOP_PADDING_DEFAULT;
   const BAR_BOTTOM_PADDING_CURRENT =
     displayCategory === "mobile"
-      ? BAR_BOTTOM_PADDING
+      ? BAR_BOTTOM_PADDING_MOBILE
       : BAR_BOTTOM_PADDING_DEFAULT;
   const desiredHeight =
     style.spacing.HEADER_HEIGHT -
@@ -340,10 +340,10 @@ function Hamburger() {
   const displayCategory = useDisplayCategory();
 
   const BAR_TOP_PADDING_CURRENT =
-    displayCategory === "mobile" ? BAR_TOP_PADDING : BAR_TOP_PADDING_DEFAULT;
+    displayCategory === "mobile" ? BAR_TOP_PADDING_MOBILE : BAR_TOP_PADDING_DEFAULT;
   const BAR_BOTTOM_PADDING_CURRENT =
     displayCategory === "mobile"
-      ? BAR_BOTTOM_PADDING
+      ? BAR_BOTTOM_PADDING_MOBILE
       : BAR_BOTTOM_PADDING_DEFAULT;
   const desiredHeight =
     style.spacing.HEADER_HEIGHT -
@@ -404,7 +404,7 @@ function MainHeaderLogo() {
         style={{
           objectFit: "contain",
           height: style.spacing.HEADER_HEIGHT,
-          padding: `${BAR_TOP_PADDING}px 0 ${BAR_BOTTOM_PADDING}px 0`,
+          padding: `${BAR_TOP_PADDING_MOBILE}px 0 ${BAR_BOTTOM_PADDING_MOBILE}px 0`,
         }}
       />
     </Link>


### PR DESCRIPTION
## Description

Fixes #1811. Ensure the login button, profile picture, and hamburger menu are the same size as the COMPUTE POLICY IMPACT button.


## Changes

- Increased height and width by 4px for the login button and profile picture.
- Adjusted the hamburger menu size to match.
- Added responsive design adjustments for mobile view.
- Used state to track screen size and apply conditional styling.

## Screenshots

<img width="901" alt="Screenshot 2024-05-24 at 22 21 26" src="https://github.com/PolicyEngine/policyengine-app/assets/128366307/796a1d12-b871-460a-b0fd-2c4ff5d8697d">
<img width="614" alt="Screenshot 2024-05-24 at 22 21 52" src="https://github.com/PolicyEngine/policyengine-app/assets/128366307/f5ecb100-5122-416c-b885-8d5ec40258b0">


Closes #1811 
