### PR TITLE
Rounded Round LSR headlines to two decimals

### DIFF
--- a/src/pages/policy/output/labourSupply/LaborSupplyHoursImpact.jsx
+++ b/src/pages/policy/output/labourSupply/LaborSupplyHoursImpact.jsx
@@ -98,7 +98,7 @@ function title(policyLabel, change, metadata) {
   const regionPhrase = region ? ` in ${region}` : "";
   const term1 = `hours worked${regionPhrase}`;
   const term2 = formatPercent(Math.abs(change), metadata.countryId, {
-    maximumFractionDigits: 1,
+    maximumFractionDigits: 2,
   });
   const signTerm = change > 0 ? "increase" : "decrease";
   const msg =


### PR DESCRIPTION
## Description

Changed `maximumFractionDigits` from 1 to 2 in the title part for LabourSupplyHoursImpact
Fixes #1820
## Changes
![image](https://github.com/PolicyEngine/policyengine-app/assets/30971624/2441b0c1-1613-43f5-9817-71f7054404f3)

![Screenshot_2](https://github.com/PolicyEngine/policyengine-app/assets/30971624/4e833a28-73a0-447e-b306-fb185aa1a8a0)


## Tests

Passes all the tests.