### PR TITLE
Fixed Labor supply chart pages display "undefined" as part of their title

### DIFF
--- a/src/pages/policy/output/tree.js
+++ b/src/pages/policy/output/tree.js
@@ -18,16 +18,16 @@ export const policyOutputs = {
   "laborSupplyImpact.byDecile.relative.total":
     "Labor supply impact by decile (relative)",
   "laborSupplyImpact.byDecile.relative.income":
-    "Labor supply impact by decile (relative)",
+    "Labor supply income effect impact by decile (relative)",
   "laborSupplyImpact.byDecile.relative.substitution":
-    "Labor supply impact by decile (relative)",
+    "Labor supply substitution effect impact by decile (relative)",
   "laborSupplyImpact.byDecile.absolute.total":
     "Labor supply impact by decile (absolute)",
   "laborSupplyImpact.byDecile.absolute.income":
-    "Labor supply impact by decile (absolute)",
+    "Labor supply income effect impact by decile (absolute)",
   "laborSupplyImpact.byDecile.absolute.substitution":
-    "Labor supply impact by decile (absolute)",
-  "laborSupplyImpact.hours": "Labor supply impact by hours worked",
+    "Labor supply substitution effect impact by decile (absolute)",
+  "laborSupplyImpact.hours": "Labor supply impact upon hours worked",
   "laborSupplyImpact.overall": "Overall labor supply impact",
   "povertyImpact.regular.byAge": "Regular poverty impact by age",
   "povertyImpact.regular.byRace": "Regular poverty impact by race",
@@ -40,11 +40,6 @@ export const policyOutputs = {
   "distributionalImpact.incomeDecile.average":
     "Distributional impact by income decile (average)",
   "budgetaryImpact.overall": "Overall budgetary impact",
-  laborSupplyImpact: "Labor supply impact (experimental)",
-  laborSupplyDecileRelativeImpact:
-    "Labor supply relative impact by decile (experimental)",
-  laborSupplyDecileAbsoluteImpact:
-    "Labor supply absolute impact by decile (experimental)",
   analysis: "AI summary (experimental)",
   codeReproducibility: "Reproduce in Python",
 };

--- a/src/pages/policy/output/tree.js
+++ b/src/pages/policy/output/tree.js
@@ -1,3 +1,5 @@
+import PolicyOutput from "./PolicyOutput";
+
 export const policyOutputs = {
   policyBreakdown: "Overview",
   netIncome: "Budgetary impact",
@@ -15,6 +17,31 @@ export const policyOutputs = {
   racialPovertyImpact: "Poverty impact by race and ethnicity",
   inequalityImpact: "Income inequality impact",
   // cliffImpact: "Cliff impact",
+  "laborSupplyImpact.byDecile.relative.total":
+    "Labor supply impact by decile (relative)",
+  "laborSupplyImpact.byDecile.relative.income":
+    "Labor supply impact by decile (relative)",
+  "laborSupplyImpact.byDecile.relative.substitution":
+    "Labor supply impact by decile (relative)",
+  "laborSupplyImpact.byDecile.absolute.total":
+    "Labor supply impact by decile (absolute)",
+  "laborSupplyImpact.byDecile.absolute.income":
+    "Labor supply impact by decile (absolute)",
+  "laborSupplyImpact.byDecile.absolute.substitution":
+    "Labor supply impact by decile (absolute)",
+  "laborSupplyImpact.hours": "Labor supply impact by hours worked",
+  "laborSupplyImpact.overall": "Overall labor supply impact",
+  "povertyImpact.regular.byAge": "Regular poverty impact by age",
+  "povertyImpact.regular.byRace": "Regular poverty impact by race",
+  "povertyImpact.regular.byGender": "Regular poverty impact by gender",
+  "povertyImpact.deep.byAge": "Deep poverty impact by age",
+  "povertyImpact.deep.byGender": "Deep poverty impact by gender",
+  "winnersAndLosers.incomeDecile": "Winners and losers by income decile",
+  "distributionalImpact.incomeDecile.relative":
+    "Distributional impact by income decile (relative)",
+  "distributionalImpact.incomeDecile.average":
+    "Distributional impact by income decile (average)",
+  "budgetaryImpact.overall": "Overall budgetary impact",
   laborSupplyImpact: "Labor supply impact (experimental)",
   laborSupplyDecileRelativeImpact:
     "Labor supply relative impact by decile (experimental)",

--- a/src/pages/policy/output/tree.js
+++ b/src/pages/policy/output/tree.js
@@ -1,5 +1,3 @@
-import PolicyOutput from "./PolicyOutput";
-
 export const policyOutputs = {
   policyBreakdown: "Overview",
   netIncome: "Budgetary impact",


### PR DESCRIPTION
## Description

Fixes #1813
Added page titles to `policyOutputs` so that it displays the title properly instead of undefined.

## Changes
The title is now displayed properly on all pages :)

![image](https://github.com/PolicyEngine/policyengine-app/assets/30971624/222259f5-3775-400e-988e-bdad8a367c3d)

![image](https://github.com/PolicyEngine/policyengine-app/assets/30971624/ec234439-91c3-49bf-b44d-0b9733fc5b42)


## Tests

Passes all the tests.
