### PR TITLE
Reorganize LSR link tree

### DIFF
--- a/src/pages/policy/output/ImpactTypes.jsx
+++ b/src/pages/policy/output/ImpactTypes.jsx
@@ -30,7 +30,7 @@ import Analysis from "./Analysis";
 const map = {
   "budgetaryImpact.overall": budgetaryImpact,
   "budgetaryImpact.byProgram": detailedBudgetaryImpact,
-  "laborSupplyImpact.overall": laborSupplyImpact,
+  "laborSupplyImpact.earnings.overall": laborSupplyImpact,
   "distributionalImpact.incomeDecile.average": averageImpactByDecile,
   "distributionalImpact.wealthDecile.average": averageImpactByWealthDecile,
   "distributionalImpact.incomeDecile.relative": relativeImpactByDecile,
@@ -44,17 +44,17 @@ const map = {
   "povertyImpact.regular.byRace": povertyImpactByRace,
   inequalityImpact: inequalityImpact,
   // cliffImpact: cliffImpact,
-  "laborSupplyImpact.byDecile.relative.total":
+  "laborSupplyImpact.earnings.byDecile.relative.total":
     LabourSupplyDecileRelativeImpactTotal,
-  "laborSupplyImpact.byDecile.relative.income":
+  "laborSupplyImpact.earnings.byDecile.relative.income":
     LabourSupplyDecileRelativeImpactIncome,
-  "laborSupplyImpact.byDecile.relative.substitution":
+  "laborSupplyImpact.earnings.byDecile.relative.substitution":
     LabourSupplyDecileRelativeImpactSubstitution,
-  "laborSupplyImpact.byDecile.absolute.total":
+  "laborSupplyImpact.earnings.byDecile.absolute.total":
     LabourSupplyDecileAbsoluteImpactTotal,
-  "laborSupplyImpact.byDecile.absolute.income":
+  "laborSupplyImpact.earnings.byDecile.absolute.income":
     LabourSupplyDecileAbsoluteImpactIncome,
-  "laborSupplyImpact.byDecile.absolute.substitution":
+  "laborSupplyImpact.earnings.byDecile.absolute.substitution":
     LabourSupplyDecileAbsoluteImpactSubstitution,
   "laborSupplyImpact.hours": lsrHoursImpact,
   analysis: Analysis,

--- a/src/pages/policy/output/tree.js
+++ b/src/pages/policy/output/tree.js
@@ -165,51 +165,57 @@ export function getPolicyOutputTree(countryId) {
               ? "Labour supply impact (experimental)"
               : "Labor supply impact (experimental)",
           children: [
-            {
-              name: "policyOutput.laborSupplyImpact.overall",
-              label: "Overall",
-            },
             countryId === "us" && {
               name: "policyOutput.laborSupplyImpact.hours",
               label: "Hours worked",
             },
             {
-              name: "policyOutput.laborSupplyImpact.byDecile",
-              label: "By decile",
+              name: "policyOutput.laborSupplyImpact.earnings",
+              label: "Earnings",
               children: [
                 {
-                  name: "policyOutput.laborSupplyImpact.byDecile.relative",
-                  label: "Relative",
-                  children: [
-                    {
-                      name: "policyOutput.laborSupplyImpact.byDecile.relative.total",
-                      label: "Total",
-                    },
-                    {
-                      name: "policyOutput.laborSupplyImpact.byDecile.relative.income",
-                      label: "Income effect",
-                    },
-                    {
-                      name: "policyOutput.laborSupplyImpact.byDecile.relative.substitution",
-                      label: "Substitution effect",
-                    },
-                  ],
+                  name: "policyOutput.laborSupplyImpact.earnings.overall",
+                  label: "Overall",
                 },
                 {
-                  name: "policyOutput.laborSupplyImpact.byDecile.absolute",
-                  label: "Absolute",
+                  name: "policyOutput.laborSupplyImpact.earnings.byDecile",
+                  label: "By decile",
                   children: [
                     {
-                      name: "policyOutput.laborSupplyImpact.byDecile.absolute.total",
-                      label: "Total",
+                      name: "policyOutput.laborSupplyImpact.earnings.byDecile.relative",
+                      label: "Relative",
+                      children: [
+                        {
+                          name: "policyOutput.laborSupplyImpact.earnings.byDecile.relative.total",
+                          label: "Total",
+                        },
+                        {
+                          name: "policyOutput.laborSupplyImpact.earnings.byDecile.relative.income",
+                          label: "Income effect",
+                        },
+                        {
+                          name: "policyOutput.laborSupplyImpact.earnings.byDecile.relative.substitution",
+                          label: "Substitution effect",
+                        },
+                      ],
                     },
                     {
-                      name: "policyOutput.laborSupplyImpact.byDecile.absolute.income",
-                      label: "Income effect",
-                    },
-                    {
-                      name: "policyOutput.laborSupplyImpact.byDecile.absolute.substitution",
-                      label: "Substitution effect",
+                      name: "policyOutput.laborSupplyImpact.earnings.byDecile.absolute",
+                      label: "Absolute",
+                      children: [
+                        {
+                          name: "policyOutput.laborSupplyImpact.earnings.byDecile.absolute.total",
+                          label: "Total",
+                        },
+                        {
+                          name: "policyOutput.laborSupplyImpact.earnings.byDecile.absolute.income",
+                          label: "Income effect",
+                        },
+                        {
+                          name: "policyOutput.laborSupplyImpact.earnings.byDecile.absolute.substitution",
+                          label: "Substitution effect",
+                        },
+                      ],
                     },
                   ],
                 },


### PR DESCRIPTION
## Description

Fixes #1825.

## Changes

This PR reorganizes the left-hand bar's link section according to the description in #1825, albeit leaving out the portions of the "hours worked" section that do not yet exist.

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/14987227/c6d148a8-24d4-4b7f-b0e7-e9d1e78187fc

## Tests

None have been added.
