### PR TITLE
Remove budgetary impact statements

### DIFF
--- a/src/pages/policy/output/labourSupply/LaborSupplyResponse.jsx
+++ b/src/pages/policy/output/labourSupply/LaborSupplyResponse.jsx
@@ -108,34 +108,6 @@ export default function lsrImpact(props) {
   const { impact, policyLabel, metadata, mobile } = props;
   const incomeEffect = impact.labour_supply_response.income_lsr;
   const substitutionEffect = impact.labour_supply_response.substitution_lsr;
-  const budgetaryImpact = impact.budget.budgetary_impact;
-  const budgetaryImpactLSRChange = impact.labour_supply_response.revenue_change;
-  const originalBudgetaryImpact = budgetaryImpact - budgetaryImpactLSRChange;
-  const originalBudgetaryImpactStr = formatCurrencyAbbr(
-    originalBudgetaryImpact,
-    metadata.countryId,
-    {
-      maximumFractionDigits: 1,
-    },
-  );
-  const newBudgetaryImpactStr = formatCurrencyAbbr(
-    budgetaryImpact,
-    metadata.countryId,
-    {
-      maximumFractionDigits: 1,
-    },
-  );
-  const changeStr = formatCurrencyAbbr(
-    Math.abs(budgetaryImpactLSRChange),
-    metadata.countryId,
-    {
-      maximumFractionDigits: 1,
-    },
-  );
-  const relChangeStr = Math.round(
-    Math.abs(budgetaryImpact / originalBudgetaryImpact - 1) * 100,
-    1,
-  );
 
   const labels = ["Income effect", "Substitution effect", "Net change"];
   const values = [
@@ -143,8 +115,6 @@ export default function lsrImpact(props) {
     substitutionEffect / 1e9,
     incomeEffect / 1e9 + substitutionEffect / 1e9,
   ];
-  const budgetaryImpactPositive = budgetaryImpact > 0;
-  const originalImpactPositive = originalBudgetaryImpact > 0;
   const chart = (
     <ImpactChart title={title(policyLabel, values[2], metadata)}>
       <ImpactPlot

--- a/src/pages/policy/output/labourSupply/LaborSupplyResponse.jsx
+++ b/src/pages/policy/output/labourSupply/LaborSupplyResponse.jsx
@@ -147,16 +147,6 @@ export default function lsrImpact(props) {
   const originalImpactPositive = originalBudgetaryImpact > 0;
   const chart = (
     <ImpactChart title={title(policyLabel, values[2], metadata)}>
-      <p style={{ marginBottom: 30 }}>
-        This{" "}
-        {budgetaryImpactPositive === originalImpactPositive
-          ? "raises"
-          : "lowers"}{" "}
-        the budgetary impact of the reform by {changeStr} (from{" "}
-        {originalBudgetaryImpactStr} to {newBudgetaryImpactStr}, a{" "}
-        {relChangeStr}% {budgetaryImpactLSRChange > 0 ? "increase" : "decrease"}
-        ).
-      </p>
       <ImpactPlot
         values={values}
         labels={labels}


### PR DESCRIPTION
## Description

Fixes #1829.

## Changes

This PR removes the budgetary impact statement from the LSR overall earnings impact component.

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/14987227/d7a39bfa-ea3d-415e-b525-4ec7a0ab0bca

## Tests

N/A
