### PR TITLE
Temporarily disable relative LSR impacts

### DIFF
--- a/src/pages/policy/output/ImpactTypes.jsx
+++ b/src/pages/policy/output/ImpactTypes.jsx
@@ -20,11 +20,13 @@ import {
   LabourSupplyDecileAbsoluteImpactSubstitution,
   LabourSupplyDecileAbsoluteImpactTotal,
 } from "./labourSupply/LabourSupplyDecileAbsoluteImpacts";
+/*
 import {
   LabourSupplyDecileRelativeImpactIncome,
   LabourSupplyDecileRelativeImpactSubstitution,
   LabourSupplyDecileRelativeImpactTotal,
 } from "./labourSupply/LabourSupplyDecileRelativeImpacts";
+*/
 import Analysis from "./Analysis";
 
 const map = {
@@ -44,12 +46,14 @@ const map = {
   "povertyImpact.regular.byRace": povertyImpactByRace,
   inequalityImpact: inequalityImpact,
   // cliffImpact: cliffImpact,
+  /*
   "laborSupplyImpact.earnings.byDecile.relative.total":
     LabourSupplyDecileRelativeImpactTotal,
   "laborSupplyImpact.earnings.byDecile.relative.income":
     LabourSupplyDecileRelativeImpactIncome,
   "laborSupplyImpact.earnings.byDecile.relative.substitution":
     LabourSupplyDecileRelativeImpactSubstitution,
+  */
   "laborSupplyImpact.earnings.byDecile.absolute.total":
     LabourSupplyDecileAbsoluteImpactTotal,
   "laborSupplyImpact.earnings.byDecile.absolute.income":

--- a/src/pages/policy/output/tree.js
+++ b/src/pages/policy/output/tree.js
@@ -181,6 +181,7 @@ export function getPolicyOutputTree(countryId) {
                   name: "policyOutput.laborSupplyImpact.earnings.byDecile",
                   label: "By decile",
                   children: [
+                    /*
                     {
                       name: "policyOutput.laborSupplyImpact.earnings.byDecile.relative",
                       label: "Relative",
@@ -199,6 +200,7 @@ export function getPolicyOutputTree(countryId) {
                         },
                       ],
                     },
+                    */
                     {
                       name: "policyOutput.laborSupplyImpact.earnings.byDecile.absolute",
                       label: "Absolute",


### PR DESCRIPTION
## Description

Fixes #1835.

## Changes

Pursuant to the discussion in https://github.com/PolicyEngine/policyengine-api/pull/1540, this temporarily disables relative outputs until they are correctly calculated against baseline earnings.

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/14987227/3d131b19-d2f8-4dbe-a3c6-b93c54bb8001

## Tests

N/A
