### PR TITLE
Properly display left-hand filters on Research page

### DIFF
--- a/src/pages/Research.jsx
+++ b/src/pages/Research.jsx
@@ -22,6 +22,7 @@ import { motion } from "framer-motion";
 import FontIcon from "../layout/FontIcon";
 import { Helmet } from "react-helmet";
 import { Checkbox } from "antd";
+import { useWindowHeight } from "../hooks/useWindow";
 
 export default function Research() {
   return (
@@ -290,15 +291,21 @@ function BlogPostSearchTools({
       />
     </>
   );
+
   const displayCategory = useDisplayCategory();
+  // Three display values, in pixels
+  const windowHeight = useWindowHeight();
+  const TOP = 150;
+  const BOTTOM_MARGIN = 24;
   if (displayCategory === "desktop") {
     return (
       <div
         style={{
           position: "sticky",
-          top: 150,
+          top: TOP,
           display: "flex",
           flexDirection: "column",
+          maxHeight: windowHeight - TOP - BOTTOM_MARGIN
         }}
       >
         {textBox}

--- a/src/pages/Research.jsx
+++ b/src/pages/Research.jsx
@@ -237,6 +237,8 @@ function BlogPostSearchTools({
     authorKeys.map((key) => [key, authors[key].name]),
   );
 
+  const [expandedList, setExpandedList] = useState(null);
+
   const textBox = (
     <TextBox
       placeholder="Search by keyword, author, etc."
@@ -274,6 +276,8 @@ function BlogPostSearchTools({
         keyToLabel={topicLabels}
         checkedValues={filteredTopics}
         setCheckedValues={setFilteredTopics}
+        expandedList={expandedList}
+        setExpandedList={setExpandedList}
       />
       <ExpandableCheckBoxList
         title="Location"
@@ -281,6 +285,8 @@ function BlogPostSearchTools({
         keyToLabel={locationLabels}
         checkedValues={filteredLocations}
         setCheckedValues={setFilteredLocations}
+        expandedList={expandedList}
+        setExpandedList={setExpandedList}
       />
       <ExpandableCheckBoxList
         title="Author"
@@ -288,6 +294,8 @@ function BlogPostSearchTools({
         keyToLabel={authorKeyToLabel}
         checkedValues={filteredAuthors}
         setCheckedValues={setFilteredAuthors}
+        expandedList={expandedList}
+        setExpandedList={setExpandedList}
       />
     </>
   );
@@ -305,7 +313,7 @@ function BlogPostSearchTools({
           top: TOP,
           display: "flex",
           flexDirection: "column",
-          maxHeight: windowHeight - TOP - BOTTOM_MARGIN
+          maxHeight: windowHeight - TOP - BOTTOM_MARGIN,
         }}
       >
         {textBox}
@@ -351,9 +359,15 @@ function ExpandableCheckBoxList({
   keyToLabel,
   checkedValues,
   setCheckedValues,
+  expandedList,
+  setExpandedList,
 }) {
   return (
-    <Expandable title={title}>
+    <Expandable
+      title={title}
+      expandedList={expandedList}
+      setExpandedList={setExpandedList}
+    >
       {keys.map((key) => (
         <AntCheckbox
           key={key}
@@ -387,15 +401,34 @@ function ExpandableCheckBoxList({
   );
 }
 
-function Expandable({ title, children }) {
-  const [expanded, setExpanded] = useState(false);
+function Expandable({ title, expandedList, setExpandedList, children }) {
+  const expanded = expandedList === title;
   const contentRef = useRef();
   const titleRef = useRef();
+
+  const contentHeight = contentRef.current?.getBoundingClientRect().height;
+  const titleHeight = 31;
+
+  function handleExpand() {
+    if (expanded) {
+      setExpandedList(null);
+    } else {
+      setExpandedList(title);
+    }
+  }
+
   const titleComponent = (
     <div
-      style={{ display: "flex", alignItems: "center", position: expanded && "sticky", top: expanded && 0, zIndex: expanded && 3, backgroundColor: style.colors.WHITE }}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        position: "sticky",
+        top: 0,
+        zIndex: 3,
+        backgroundColor: style.colors.WHITE,
+      }}
       ref={titleRef}
-      onClick={() => setExpanded(!expanded)}
+      onClick={() => handleExpand()}
     >
       <p style={{ margin: 0 }}>{title}</p>
       <FontIcon
@@ -414,21 +447,15 @@ function Expandable({ title, children }) {
       style={{
         cursor: "pointer",
         overflowY: expanded ? "scroll" : "hidden",
+        overflowX: "hidden",
         marginTop: 10,
-        position: "relative"
+        position: "relative",
       }}
       initial={{
-        maxHeight: 30,
+        maxHeight: titleHeight,
       }}
       animate={{
-        maxHeight: expanded
-          ? contentRef.current?.getBoundingClientRect().height +
-            titleRef.current?.getBoundingClientRect().height
-          : titleRef.current?.getBoundingClientRect().height,
-      }}
-      transition={{
-        duration: 0.3,
-        easings: "ease-out",
+        maxHeight: expanded ? contentHeight + titleHeight : titleHeight,
       }}
     >
       {titleComponent}

--- a/src/pages/Research.jsx
+++ b/src/pages/Research.jsx
@@ -393,7 +393,7 @@ function Expandable({ title, children }) {
   const titleRef = useRef();
   const titleComponent = (
     <div
-      style={{ display: "flex", alignItems: "center" }}
+      style={{ display: "flex", alignItems: "center", position: expanded && "sticky", top: expanded && 0, zIndex: expanded && 3, backgroundColor: style.colors.WHITE }}
       ref={titleRef}
       onClick={() => setExpanded(!expanded)}
     >
@@ -413,8 +413,9 @@ function Expandable({ title, children }) {
     <motion.div
       style={{
         cursor: "pointer",
-        overflowY: "hidden",
+        overflowY: expanded ? "scroll" : "hidden",
         marginTop: 10,
+        position: "relative"
       }}
       initial={{
         maxHeight: 30,


### PR DESCRIPTION
## Description

Fixes #1554.

## Changes

This PR alters the way that the filters panel on the left-hand side of the Research page is displayed in order to ensure that a user is able to see all possible filters on the page. Previously, when a user opened a filter tab, the items simply expanded to be fully open, often expanding beyond the bottom of the page.

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/14987227/b0712ffa-487f-4413-93fb-2cd7da39eaad

## Tests

N/A
