### PR TITLE
Changed API Status page route

### DIFF
--- a/src/PolicyEngine.jsx
+++ b/src/PolicyEngine.jsx
@@ -327,7 +327,7 @@ export default function PolicyEngine({ pathname }) {
           element={<APIDocumentationPage metadata={metadata} />}
         />
         <Route path="/uk/cec" element={<CitizensEconomicCouncil />} />
-        <Route path="/us/api" element={<StatusPage />} />
+        <Route path="/us/api_status" element={<StatusPage />} />
         <Route
           path="/us/trafwa-ctc-calculator"
           element={<TrafwaCalculator />}

--- a/src/PolicyEngine.jsx
+++ b/src/PolicyEngine.jsx
@@ -327,7 +327,7 @@ export default function PolicyEngine({ pathname }) {
           element={<APIDocumentationPage metadata={metadata} />}
         />
         <Route path="/uk/cec" element={<CitizensEconomicCouncil />} />
-        <Route path="/us/api_status" element={<StatusPage />} />
+        <Route path="/:countryId/api_status" element={<StatusPage />} />
         <Route
           path="/us/trafwa-ctc-calculator"
           element={<TrafwaCalculator />}


### PR DESCRIPTION
## Description

Fixes #1837 

## Changes

Changed the route of the api status page to ```/api_status``` so that it doesn't overwrite the api documentation page.

## Screenshots

![image](https://github.com/PolicyEngine/policyengine-app/assets/42430035/3332e83c-0b41-4fcb-ba07-ef210ea5b316)


## Tests

No new tests added.