### PR TITLE
Add reform stacking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "husky": "^9.0.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.4.3",
+        "jest-when": "^3.6.0",
         "lint-staged": "^15.2.5",
         "node-fetch": "^3.3.2",
         "prettier": "^3.2.5",
@@ -16473,6 +16474,15 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-when": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.6.0.tgz",
+      "integrity": "sha512-+cZWTy0ekAJo7M9Om0Scdor1jm3wDiYJWmXE8U22UVnkH54YCXAuaqz3P+up/FdtOg8g4wHOxV7Thd7nKhT6Dg==",
+      "dev": true,
+      "peerDependencies": {
+        "jest": ">= 25"
       }
     },
     "node_modules/jest-worker": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "husky": "^9.0.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.4.3",
+    "jest-when": "^3.6.0",
     "lint-staged": "^15.2.5",
     "node-fetch": "^3.3.2",
     "prettier": "^3.2.5",

--- a/src/__tests__/pages/policy/PolicySearch.test.js
+++ b/src/__tests__/pages/policy/PolicySearch.test.js
@@ -13,28 +13,29 @@ const testSearchResults = {
   result: [
     {
       id: 1,
-      label: "Test stacking policy"
-    }
-  ]
+      label: "Test stacking policy",
+    },
+  ],
 };
 
 const testSearchResultsWrapper = {
-  json: () => Promise.resolve(testSearchResults)
+  json: () => Promise.resolve(testSearchResults),
 };
 
 const testStackingPolicy = {
-  "cruft": {
-    "2024-01-01.2100-12-31": true
-  }
+  cruft: {
+    "2024-01-01.2100-12-31": true,
+  },
 };
 
 const testStackingPolicyWrapper = {
   ok: true,
-  json: () => Promise.resolve({
-    result: {
-      policy_json: testStackingPolicy
-    }
-  })
+  json: () =>
+    Promise.resolve({
+      result: {
+        policy_json: testStackingPolicy,
+      },
+    }),
 };
 
 const mockCountryApiCall = jest.fn();
@@ -55,22 +56,22 @@ jest.mock("../../../api/call.js", () => {
   return {
     __esModule: true,
     ...originalModule,
-    countryApiCall: (...args) => mockCountryApiCall(...args)
-  }
+    countryApiCall: (...args) => mockCountryApiCall(...args),
+  };
 });
 
 const mockGetNewPolicyId = jest.fn();
 mockGetNewPolicyId.mockReturnValue({
   status: "ok",
-  policy_id: 2
+  policy_id: 2,
 });
 
 jest.mock("../../../api/parameters.js", () => {
   const originalModule = jest.requireActual("../../../api/parameters.js");
   return {
     ...originalModule,
-    getNewPolicyId: () => mockGetNewPolicyId()
-  }
+    getNewPolicyId: () => mockGetNewPolicyId(),
+  };
 });
 
 afterAll(() => {
@@ -79,7 +80,6 @@ afterAll(() => {
 
 describe("PolicySearch", () => {
   test("Should render", () => {
-
     const testProps = {
       metadata: metadataUS,
       target: "reform",
@@ -88,92 +88,87 @@ describe("PolicySearch", () => {
 
     metadataUS = {
       ...metadataUS,
-      countryId: "us"
+      countryId: "us",
     };
 
     render(
       <BrowserRouter>
-        <PolicySearch {...testProps}/>
-      </BrowserRouter>
+        <PolicySearch {...testProps} />
+      </BrowserRouter>,
     );
 
     const heading = screen.getByText("Current law");
     expect(heading).toBeInTheDocument();
   });
   test("On current law, should disable stacking", () => {
-
     const testProps = {
       metadata: metadataUS,
       target: "reform",
       policy: baselinePolicyUS,
-      displayStack: true
+      displayStack: true,
     };
 
     render(
       <BrowserRouter>
-        <PolicySearch {...testProps}/>
-      </BrowserRouter>
+        <PolicySearch {...testProps} />
+      </BrowserRouter>,
     );
 
-    const stackButton = screen.getByRole("button", {name: /plus/i});
+    const stackButton = screen.getByRole("button", { name: /plus/i });
     expect(stackButton).toBeInTheDocument();
     expect(stackButton).toBeDisabled();
-
   });
   test("On current law, should allow policy selection", () => {
-
     const testProps = {
       metadata: metadataUS,
       target: "reform",
       policy: baselinePolicyUS,
-      displayStack: true
+      displayStack: true,
     };
 
     render(
       <BrowserRouter>
-        <PolicySearch {...testProps}/>
-      </BrowserRouter>
+        <PolicySearch {...testProps} />
+      </BrowserRouter>,
     );
 
-    const checkmarkButton = screen.getByRole("button", {name: /check/i});
+    const checkmarkButton = screen.getByRole("button", { name: /check/i });
     expect(checkmarkButton).toBeInTheDocument();
     expect(checkmarkButton).not.toBeDisabled();
   });
   test("Should stack policies", async () => {
-
     const testBasePolicy = {
       baseline: {
         data: {},
         label: "Current law",
-        id: 2
+        id: 2,
       },
       reform: {
         data: {
           maxwell: {
-            "2024-01-01.2100-12-31": true
+            "2024-01-01.2100-12-31": true,
           },
           dworkin: {
-            "2024-01-01.2100-12-31": true
+            "2024-01-01.2100-12-31": true,
           },
         },
         label: "Test base policy",
-      }
+      },
     };
 
     const testProps = {
       metadata: metadataUS,
       target: "reform",
       policy: testBasePolicy,
-      displayStack: true
+      displayStack: true,
     };
-
 
     const user = userEvent.setup();
 
     render(
       <BrowserRouter>
-        <PolicySearch {...testProps}/>
-      </BrowserRouter>
+        <PolicySearch {...testProps} />
+      </BrowserRouter>,
     );
 
     // Find the input
@@ -185,12 +180,12 @@ describe("PolicySearch", () => {
 
     // Select the only returned policy and click "plus" to stack it
     const policyItem = screen.getByText(/#1 test stacking policy/i);
-    const plusButton = screen.getByRole("button", {name: /plus/i});
+    const plusButton = screen.getByRole("button", { name: /plus/i });
     await user.click(policyItem);
     await user.click(plusButton);
 
     // Ensure that new policy is created
+    const params = new URLSearchParams(window.location.params);
     expect(params.get("reform")).toBe("2");
-
   });
-})
+});

--- a/src/__tests__/pages/policy/PolicySearch.test.js
+++ b/src/__tests__/pages/policy/PolicySearch.test.js
@@ -185,7 +185,7 @@ describe("PolicySearch", () => {
     await user.click(plusButton);
 
     // Ensure that new policy is created
-    const params = new URLSearchParams(window.location.params);
+    const params = new URLSearchParams(window.location.search);
     expect(params.get("reform")).toBe("2");
   });
 });

--- a/src/__tests__/pages/policy/PolicySearch.test.js
+++ b/src/__tests__/pages/policy/PolicySearch.test.js
@@ -64,8 +64,41 @@ describe("PolicySearch", () => {
     expect(checkmarkButton).toBeInTheDocument();
     expect(checkmarkButton).not.toBeDisabled();
   });
+  test("Should stack non-conflicting policies", () => {
+
+    const testBasePolicy = {
+      "maxwell": {
+        "2024-01-01.2100-12-31": true
+      },
+      "dworkin": {
+        "2024-01-01.2100-12-31": true
+      }
+    };
+
+    const testStackingPolicy = {
+      "cruft": {
+        "2024-01-01.2100-12-31": true
+      }
+    };
+
+    const testProps = {
+      metadata: metadataUS,
+      target: "reform",
+      policy: testBasePolicy,
+      displayStack: true
+    };
+
+    render(
+      <BrowserRouter>
+        <PolicySearch {...testProps}/>
+      </BrowserRouter>
+    );
+
+    const checkmarkButton = screen.getByRole("button", {name: /check/i});
+    expect(checkmarkButton).toBeInTheDocument();
+    expect(checkmarkButton).not.toBeDisabled();
+  });
   /*
-  test("Should stack non-conflicting policies");
   test("On conflicting policies, should prefer second over first");
   */
 })

--- a/src/__tests__/pages/policy/PolicySearch.test.js
+++ b/src/__tests__/pages/policy/PolicySearch.test.js
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { BrowserRouter } from "react-router-dom";
+import { baselinePolicyUS } from "../../__setup__/sampleData";
+import PolicySearch from "../../../pages/policy/PolicySearch";
+import data from "../../__setup__/data.json";
+
+let metadataUS = data["metadataUS"];
+
+describe("PolicySearch", () => {
+  test("Should render", () => {
+
+    const testProps = {
+      metadata: metadataUS,
+      target: "reform",
+      policy: baselinePolicyUS,
+    };
+
+    render(
+      <BrowserRouter>
+        <PolicySearch {...testProps}/>
+      </BrowserRouter>
+    );
+
+    const heading = screen.getByText("Current law");
+    expect(heading).toBeInTheDocument();
+  });
+  /*
+  test("On current law, should disable stacking");
+  test("On current law, should allow policy selection");
+  test("Should stack non-conflicting policies");
+  test("On conflicting policies, should prefer second over first");
+  */
+})

--- a/src/__tests__/pages/policy/PolicySearch.test.js
+++ b/src/__tests__/pages/policy/PolicySearch.test.js
@@ -25,8 +25,27 @@ describe("PolicySearch", () => {
     const heading = screen.getByText("Current law");
     expect(heading).toBeInTheDocument();
   });
+  test("On current law, should disable stacking", () => {
+
+    const testProps = {
+      metadata: metadataUS,
+      target: "reform",
+      policy: baselinePolicyUS,
+      displayStack: true
+    };
+
+    render(
+      <BrowserRouter>
+        <PolicySearch {...testProps}/>
+      </BrowserRouter>
+    );
+
+    const stackButton = screen.getByRole("button", {name: /plus/i});
+    expect(stackButton).toBeInTheDocument();
+    expect(stackButton).toBeDisabled();
+
+  });
   /*
-  test("On current law, should disable stacking");
   test("On current law, should allow policy selection");
   test("Should stack non-conflicting policies");
   test("On conflicting policies, should prefer second over first");

--- a/src/__tests__/pages/policy/PolicySearch.test.js
+++ b/src/__tests__/pages/policy/PolicySearch.test.js
@@ -45,8 +45,26 @@ describe("PolicySearch", () => {
     expect(stackButton).toBeDisabled();
 
   });
+  test("On current law, should allow policy selection", () => {
+
+    const testProps = {
+      metadata: metadataUS,
+      target: "reform",
+      policy: baselinePolicyUS,
+      displayStack: true
+    };
+
+    render(
+      <BrowserRouter>
+        <PolicySearch {...testProps}/>
+      </BrowserRouter>
+    );
+
+    const checkmarkButton = screen.getByRole("button", {name: /check/i});
+    expect(checkmarkButton).toBeInTheDocument();
+    expect(checkmarkButton).not.toBeDisabled();
+  });
   /*
-  test("On current law, should allow policy selection");
   test("Should stack non-conflicting policies");
   test("On conflicting policies, should prefer second over first");
   */

--- a/src/controls/Button.jsx
+++ b/src/controls/Button.jsx
@@ -58,6 +58,19 @@ export const buttonStyles = {
  */
 export default function Button(props) {
   let { text, onClick, width, type, size, height, style } = props;
+
+  // This is an ugly solution to the fact that Ant Design needs these props
+  // for tooltips, but if we add all possible props, various other Ant Design
+  // props override our own design elements; see
+  // https://ant.design/components/tooltip#why-sometime-not-work-on-hoc
+  const {onMouseEnter, onMouseLeave, onPointerEnter, onPointerLeave, onFocus } = props;
+  const tooltipProps = {
+    onMouseEnter,
+    onMouseLeave,
+    onPointerEnter,
+    onPointerLeave,
+    onFocus
+  };
   // Assign fallback values for styling
   if (!type || !Object.keys(buttonStyles).includes(type)) {
     type = "primary";
@@ -76,10 +89,6 @@ export default function Button(props) {
         height: height || "auto",
         borderRadius: 0,
         padding: "15px 30px",
-        /*
-        paddingLeft: 30,
-        paddingRight: 30,
-        */
         fontSize: 14,
         fontFamily: "Roboto",
         fontWeight: 500,
@@ -116,6 +125,7 @@ export default function Button(props) {
             : "300px"
       }
       onClick={onClick}
+      {...tooltipProps}
     >
       {text}
     </AntButton>

--- a/src/controls/Button.jsx
+++ b/src/controls/Button.jsx
@@ -75,9 +75,11 @@ export default function Button(props) {
         width: width,
         height: height || "auto",
         borderRadius: 0,
-        padding: 15,
+        padding: "15px 30px",
+        /*
         paddingLeft: 30,
         paddingRight: 30,
+        */
         fontSize: 14,
         fontFamily: "Roboto",
         fontWeight: 500,

--- a/src/controls/Button.jsx
+++ b/src/controls/Button.jsx
@@ -82,7 +82,7 @@ export default function Button(props) {
         display: "flex",
         alignItems: "center",
         borderColor: buttonStyles[type].standard.borderColor,
-        borderWidth: 3,
+        borderWidth: 1,
         backgroundColor: buttonStyles[type].standard.backgroundColor,
         textTransform: "uppercase",
         width: width,

--- a/src/controls/Button.jsx
+++ b/src/controls/Button.jsx
@@ -63,13 +63,19 @@ export default function Button(props) {
   // for tooltips, but if we add all possible props, various other Ant Design
   // props override our own design elements; see
   // https://ant.design/components/tooltip#why-sometime-not-work-on-hoc
-  const {onMouseEnter, onMouseLeave, onPointerEnter, onPointerLeave, onFocus } = props;
+  const {
+    onMouseEnter,
+    onMouseLeave,
+    onPointerEnter,
+    onPointerLeave,
+    onFocus,
+  } = props;
   const tooltipProps = {
     onMouseEnter,
     onMouseLeave,
     onPointerEnter,
     onPointerLeave,
-    onFocus
+    onFocus,
   };
   // Assign fallback values for styling
   if (!type || !Object.keys(buttonStyles).includes(type)) {

--- a/src/pages/household/HouseholdRightSidebar.jsx
+++ b/src/pages/household/HouseholdRightSidebar.jsx
@@ -52,8 +52,6 @@ export default function HouseholdRightSidebar(props) {
     policy,
     year,
   } = props;
-  // eslint-disable-next-line no-unused-vars
-  const [_, setShowReformSearch] = useState(false);
   const [searchParams] = useSearchParams();
   const hasReform = searchParams.get("reform") !== null;
   const focus = searchParams.get("focus") || "";
@@ -162,7 +160,6 @@ export default function HouseholdRightSidebar(props) {
               policy={policy}
               target="reform"
               width="100%"
-              onSelect={() => setShowReformSearch(false)}
             />
           }
         />

--- a/src/pages/household/HouseholdRightSidebar.jsx
+++ b/src/pages/household/HouseholdRightSidebar.jsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   formatVariableValue,

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -591,7 +591,7 @@ export default function PolicyRightSidebar(props) {
                 policy={policy}
                 target="reform"
                 width="100%"
-                enableStack
+                displayStack
               />
             }
           />

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -597,6 +597,7 @@ export default function PolicyRightSidebar(props) {
                   policy={policy}
                   target="reform"
                   width="100%"
+                  enableStack
                 />
               </div>
             }

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -582,7 +582,7 @@ export default function PolicyRightSidebar(props) {
             setPolicy={setPolicy}
           />
         }
-        <div style={{ paddingLeft: 5 }}>
+        <div style={{ padding: "0px 4px" }}>
           <Collapsible
             label="Find an existing policy"
             child={

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -586,20 +586,13 @@ export default function PolicyRightSidebar(props) {
           <Collapsible
             label="Find an existing policy"
             child={
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                }}
-              >
-                <PolicySearch
-                  metadata={metadata}
-                  policy={policy}
-                  target="reform"
-                  width="100%"
-                  enableStack
-                />
-              </div>
+              <PolicySearch
+                metadata={metadata}
+                policy={policy}
+                target="reform"
+                width="100%"
+                enableStack
+              />
             }
           />
         </div>

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -432,8 +432,6 @@ export default function PolicyRightSidebar(props) {
   const focus = searchParams.get("focus") || "";
   const stateAbbreviation = focus.split(".")[2];
   const hasHousehold = searchParams.get("household") !== null;
-  // eslint-disable-next-line no-unused-vars
-  const [_, setShowReformSearch] = useState(false);
   const options = metadata.economy_options.region.map((stateAbbreviation) => {
     return { value: stateAbbreviation.name, label: stateAbbreviation.label };
   });
@@ -599,7 +597,6 @@ export default function PolicyRightSidebar(props) {
                   policy={policy}
                   target="reform"
                   width="100%"
-                  onSelect={() => setShowReformSearch(false)}
                 />
               </div>
             }

--- a/src/pages/policy/PolicySearch.jsx
+++ b/src/pages/policy/PolicySearch.jsx
@@ -40,6 +40,18 @@ export default function PolicySearch(props) {
     setSearchParams(newSearch);
   }
 
+  function handleStack() {
+    // Set some sort of loading?
+
+    // Fetch policy to stack
+
+    // Do some sort of reconciling of these policies - what if parameters conflict?
+
+    // Create new policy with those parameters and emit to back end, receiving back ID
+
+    // Mimic handleCheckmark and setSearchParams using new ID
+  }
+
   // The search should query the API, but limited to one request every 1000ms.
   const onSearch = (searchText) => {
     setValue(searchText);

--- a/src/pages/policy/PolicySearch.jsx
+++ b/src/pages/policy/PolicySearch.jsx
@@ -1,9 +1,13 @@
 import { AutoComplete, Space, Tooltip } from "antd";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { apiCall, copySearchParams, countryApiCall } from "../../api/call";
+import { copySearchParams, countryApiCall } from "../../api/call";
 import Button from "../../controls/Button";
-import { CheckOutlined, LoadingOutlined, PlusOutlined } from "@ant-design/icons";
+import {
+  CheckOutlined,
+  LoadingOutlined,
+  PlusOutlined,
+} from "@ant-design/icons";
 import { getNewPolicyId } from "../../api/parameters";
 import style from "../../style";
 
@@ -27,7 +31,9 @@ export default function PolicySearch(props) {
   const [lastRequestTime, setLastRequestTime] = useState(0);
   const [lastSearch, setLastSearch] = useState("");
 
-  const disableStack = policy.baseline.label === "Current law" && policy.reform.label === "Current law";
+  const disableStack =
+    policy.baseline.label === "Current law" &&
+    policy.reform.label === "Current law";
 
   useEffect(() => {
     setValue(defaultLabel);
@@ -53,13 +59,10 @@ export default function PolicySearch(props) {
 
     // Fetch policy to stack
     try {
-      const res = await countryApiCall(
-        countryId,
-        `/policy/${policyId}`
-      );
+      const res = await countryApiCall(countryId, `/policy/${policyId}`);
       if (!res.ok) {
         console.error("Network error while fetching existing policy");
-        console.error(res)
+        console.error(res);
         setIsError(true);
         setIsStackerLoading(false);
       } else {
@@ -69,17 +72,14 @@ export default function PolicySearch(props) {
 
         let newPolicyData = {
           ...policy.reform.data,
-          ...policyToStack.policy_json
-        }
+          ...policyToStack.policy_json,
+        };
 
         // Create new policy with those parameters and emit to back end, receiving back ID
-        const newPolicyRes = await getNewPolicyId(
-          countryId,
-          newPolicyData
-        );
+        const newPolicyRes = await getNewPolicyId(countryId, newPolicyData);
         if (!newPolicyRes.status === "ok") {
           console.error("Network error while creating new policy");
-          console.error(newPolicyRes)
+          console.error(newPolicyRes);
           setIsError(true);
           setIsStackerLoading(false);
         } else {
@@ -90,8 +90,7 @@ export default function PolicySearch(props) {
           setIsStackerLoading(false);
         }
       }
-    }
-    catch (err) {
+    } catch (err) {
       console.error("Error while fetching existing policy");
       console.error(err);
       setIsError(true);
@@ -107,13 +106,13 @@ export default function PolicySearch(props) {
       const res = await countryApiCall(
         metadata.countryId,
         `/policies?query=${searchText}&unique_only=true`,
-      )
+      );
       const resJson = await res.json();
       setPolicies(
         resJson.result.map((item) => {
           return {
             value: item.id,
-            label: `#${item.id} ${item.label}`
+            label: `#${item.id} ${item.label}`,
           };
         }) || [],
       );
@@ -147,69 +146,66 @@ export default function PolicySearch(props) {
         gap: "10px",
       }}
     >
-    <Space.Compact
-      style={{
-        width: width || "100%",
-        maxWidth: "100%",
-      }}
-    >
-      <AutoComplete
-        options={policies || [{ value: defaultId, label: defaultLabel }]}
-        onSelect={(value, option) => handleClickOnItem(value, option)}
-        onSearch={onSearch}
-        placeholder={defaultLabel}
-        value={value === defaultLabel ? null : value}
-        style={{overflow: "hidden", width: "100%"}}
-      />
+      <Space.Compact
+        style={{
+          width: width || "100%",
+          maxWidth: "100%",
+        }}
+      >
+        <AutoComplete
+          options={policies || [{ value: defaultId, label: defaultLabel }]}
+          onSelect={(value, option) => handleClickOnItem(value, option)}
+          onSearch={onSearch}
+          placeholder={defaultLabel}
+          value={value === defaultLabel ? null : value}
+          style={{ overflow: "hidden", width: "100%" }}
+        />
         {displayStack && (
-            <Tooltip
-              title={isStackerLoading ? "Loading" : disableStack ? "" : "Add to current policy"}
-            >
-              <Button
-                type={disableStack ? "disabled" : "secondary"}
-                onClick={() => handleStack(countryId)}
-                style={{
-                  padding: "unset",
-                  borderWidth: "1px",
-                  minWidth: "32px",
-                  aspectRatio: "1"
-                }}
-                text={isStackerLoading
-                  ? <LoadingOutlined />
-                  : <PlusOutlined />
-                }
-              />
-            </Tooltip>
-          )
-        }
-        <Tooltip
-          title="Use this policy; it will replace your current policy"
-        >
+          <Tooltip
+            title={
+              isStackerLoading
+                ? "Loading"
+                : disableStack
+                  ? ""
+                  : "Add to current policy"
+            }
+          >
+            <Button
+              type={disableStack ? "disabled" : "secondary"}
+              onClick={() => handleStack(countryId)}
+              style={{
+                padding: "unset",
+                borderWidth: "1px",
+                minWidth: "32px",
+                aspectRatio: "1",
+              }}
+              text={isStackerLoading ? <LoadingOutlined /> : <PlusOutlined />}
+            />
+          </Tooltip>
+        )}
+        <Tooltip title="Use this policy; it will replace your current policy">
           <Button
             type="primary"
             onClick={handleCheckmarkButton}
             style={{
               padding: "unset",
               minWidth: "32px",
-              aspectRatio: "1"
+              aspectRatio: "1",
             }}
             text={<CheckOutlined />}
           />
         </Tooltip>
-    </Space.Compact>
-    {
-      isError && (
+      </Space.Compact>
+      {isError && (
         <p
           style={{
             margin: 0,
-            color: style.colors.DARK_RED
+            color: style.colors.DARK_RED,
           }}
         >
           We&apos;ve encountered an error; please try again later
         </p>
-      )
-    }
+      )}
     </div>
   );
-
 }

--- a/src/pages/policy/PolicySearch.jsx
+++ b/src/pages/policy/PolicySearch.jsx
@@ -1,4 +1,4 @@
-import { AutoComplete, Space } from "antd";
+import { AutoComplete, Space, Tooltip } from "antd";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { copySearchParams, countryApiCall } from "../../api/call";
@@ -73,7 +73,6 @@ export default function PolicySearch(props) {
   );
   */
 
-
   return (
       <Space.Compact
         style={{
@@ -96,27 +95,78 @@ export default function PolicySearch(props) {
           placeholder={defaultLabel}
           value={value === defaultLabel ? null : value}
         />
-        <Button
-          type="secondary"
-          onClick={() => {}}
-          width={50}
-          style={{
-            padding: "unset",
-            borderWidth: "1px"
-          }}
-          text={<PlusOutlined />}
-        />
-        <Button
-          type="primary"
-          onClick={() => {}}
-          width={50}
-          style={{
-            padding: "unset"
-          }}
-          text={<CheckOutlined />}
-        />
+        <Tooltip
+          title="Add to current policy"
+        >
+          <Button
+            type="secondary"
+            onClick={() => {}}
+            width={50}
+            style={{
+              padding: "unset",
+              borderWidth: "1px"
+            }}
+            text={<PlusOutlined />}
+          />
+        </Tooltip>
+        <Tooltip
+          title="Use this policy; it will replace your current policy"
+        >
+          <Button
+            type="primary"
+            onClick={() => {}}
+            width={50}
+            style={{
+              padding: "unset"
+            }}
+            text={<CheckOutlined />}
+          />
+        </Tooltip>
       </Space.Compact>
   );
+
+  /*
+  return (
+    <>
+        <Tooltip
+          title="Add to current policy"
+          defaultOpen={true}
+        >
+          <Button
+            text="Test text"
+          />
+          <Button
+            type="secondary"
+            onClick={() => {}}
+            width={50}
+            style={{
+              padding: "unset",
+              borderWidth: "1px"
+            }}
+            text={<PlusOutlined />}
+          />
+        </Tooltip>
+        <Tooltip
+          title="Test AntButton"
+        >
+          <AntButton>Test text</AntButton>
+        </Tooltip>
+        <Tooltip
+          title="Use this policy; it will replace your current policy"
+        >
+          <Button
+            type="primary"
+            onClick={() => {}}
+            width={50}
+            style={{
+              padding: "unset"
+            }}
+            text={<CheckOutlined />}
+          />
+        </Tooltip>
+    </>
+  )
+  */
 }
 
   /*

--- a/src/pages/policy/PolicySearch.jsx
+++ b/src/pages/policy/PolicySearch.jsx
@@ -6,6 +6,38 @@ import Button from "../../controls/Button";
 import { CheckOutlined, PlusOutlined } from "@ant-design/icons";
 import useCountryId from "../../hooks/useCountryId";
 
+/**
+ * Stacks policyJsonToStack on top of a given currentPolicy, ignoring
+ * the baseline policy, policyId, and label
+ * @param {Object} currentPolicy This is a fully policy object, containing
+ * baseline and reform sub-objects, within which the data sub-object houses
+ * reform definitions
+ * @param {Object} policyJsonToStack The JSON of the policy reforms from a 
+ * fetched policy; this is not a full policy object
+ * @returns {Object} The combined policies as a full policy object; 
+ * conflicts are resolved in favor of policyJsonToStack
+ */
+export function stackPolicies(currentPolicy, policyJsonToStack) {
+
+  // Populate newPolicy with the current policy
+  let newPolicy = {...currentPolicy};
+
+  // Spread the reform object's data sub-object items into this policy;
+  // this will override any previously set value in currentPolicy
+  newPolicy = {
+    ...newPolicy,
+    reform: {
+      ...newPolicy.reform,
+      data: {
+        ...newPolicy.reform.data,
+        ...policyJsonToStack
+      }
+    }
+  }
+
+  return newPolicy;
+}
+
 export default function PolicySearch(props) {
   const { metadata, target, policy, width, enableStack } = props;
   const [searchParams, setSearchParams] = useSearchParams();
@@ -60,17 +92,8 @@ export default function PolicySearch(props) {
         console.log(policyToStack);
         // Reconcile policies; when conflicts occur, defer to newer policy
 
-        let newPolicy = {...policy};
-        newPolicy = {
-          ...newPolicy,
-          reform: {
-            ...newPolicy.reform,
-            data: {
-              ...newPolicy.reform.data,
-              ...policyToStack.policy_json
-            }
-          }
-        }
+        let newPolicy = stackPolicies(policy, policyToStack.policy_json);
+        console.log(newPolicy);
 
         /*
         console.log(policy);

--- a/src/pages/policy/PolicySearch.jsx
+++ b/src/pages/policy/PolicySearch.jsx
@@ -6,6 +6,7 @@ import Button from "../../controls/Button";
 import { CheckOutlined, PlusOutlined } from "@ant-design/icons";
 import useCountryId from "../../hooks/useCountryId";
 import { getNewPolicyId } from "../../api/parameters";
+import style from "../../style";
 
 export default function PolicySearch(props) {
   const { metadata, target, policy, width, enableStack } = props;
@@ -18,6 +19,7 @@ export default function PolicySearch(props) {
   }
   const [value, setValue] = useState(defaultLabel);
   const [policyId, setPolicyId] = useState(searchParams.get(target));
+  const [isError, setIsError] = useState(false);
 
   const [policies, setPolicies] = useState([]);
   const [lastRequestTime, setLastRequestTime] = useState(0);
@@ -55,6 +57,7 @@ export default function PolicySearch(props) {
       if (!res.ok) {
         console.error("Network error while fetching existing policy");
         console.error(res)
+        setIsError(true);
       } else {
         const resJson = await res.json();
         const policyToStack = resJson.result;
@@ -73,6 +76,7 @@ export default function PolicySearch(props) {
         if (!newPolicyRes.status === "ok") {
           console.error("Network error while creating new policy");
           console.error(newPolicyRes)
+          setIsError(true);
         } else {
           // Mimic handleCheckmark and setSearchParams using new ID
           let newSearch = copySearchParams(searchParams);
@@ -84,6 +88,7 @@ export default function PolicySearch(props) {
     catch (err) {
       console.error("Error while fetching existing policy");
       console.error(err);
+      setIsError(true);
     }
   }
 
@@ -113,6 +118,15 @@ export default function PolicySearch(props) {
   };
 
   return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "flex-start",
+        alignItems: "flex-start",
+        gap: "10px"
+      }}
+    >
     <Space.Compact
       style={{
         width: width || "100%",
@@ -157,6 +171,19 @@ export default function PolicySearch(props) {
           />
         </Tooltip>
     </Space.Compact>
+    {
+      isError && (
+        <p
+          style={{
+            margin: 0,
+            color: style.colors.DARK_RED
+          }}
+        >
+          We&apos;ve encountered an error; please try again later
+        </p>
+      )
+    }
+    </div>
   );
 
 }

--- a/src/pages/policy/PolicySearch.jsx
+++ b/src/pages/policy/PolicySearch.jsx
@@ -20,6 +20,8 @@ export default function PolicySearch(props) {
   const [lastRequestTime, setLastRequestTime] = useState(0);
   const [lastSearch, setLastSearch] = useState("");
 
+  const disableStack = policy.baseline.label === "Current law" && policy.reform.label === "Current law";
+
   useEffect(() => {
     setValue(defaultLabel);
   }, [defaultLabel]);
@@ -79,10 +81,10 @@ export default function PolicySearch(props) {
     />
         {enableStack && (
             <Tooltip
-              title="Add to current policy"
+              title={disableStack ? "" : "Add to current policy"}
             >
               <Button
-                type="secondary"
+                type={disableStack ? "disabled" : "secondary"}
                 onClick={() => {}}
                 width={50}
                 style={{

--- a/src/pages/policy/PolicySearch.jsx
+++ b/src/pages/policy/PolicySearch.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { copySearchParams, countryApiCall } from "../../api/call";
 import Button from "../../controls/Button";
-import { CheckOutlined } from "@ant-design/icons";
+import { CheckOutlined, PlusOutlined } from "@ant-design/icons";
 
 export default function PolicySearch(props) {
   const { metadata, target, policy, width, onSelect } = props;
@@ -95,6 +95,16 @@ export default function PolicySearch(props) {
           style={{ width: width || 200 }}
           placeholder={defaultLabel}
           value={value === defaultLabel ? null : value}
+        />
+        <Button
+          type="secondary"
+          onClick={() => {}}
+          width={50}
+          style={{
+            padding: "unset",
+            borderWidth: "1px"
+          }}
+          text={<PlusOutlined />}
         />
         <Button
           type="primary"

--- a/src/pages/policy/PolicySearch.jsx
+++ b/src/pages/policy/PolicySearch.jsx
@@ -1,7 +1,9 @@
-import { AutoComplete } from "antd";
+import { AutoComplete, Space } from "antd";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { copySearchParams, countryApiCall } from "../../api/call";
+import Button from "../../controls/Button";
+import { CheckOutlined } from "@ant-design/icons";
 
 export default function PolicySearch(props) {
   const { metadata, target, policy, width, onSelect } = props;
@@ -51,6 +53,7 @@ export default function PolicySearch(props) {
     }
   };
 
+  /*
   return (
     <AutoComplete
       options={policies || [{ value: defaultId, label: defaultLabel }]}
@@ -68,4 +71,69 @@ export default function PolicySearch(props) {
       value={value === defaultLabel ? null : value}
     />
   );
+  */
+
+
+  return (
+      <Space.Compact
+        style={{
+          // ...componentStyle,
+          width: width || "100%",
+        }}
+      >
+        <AutoComplete
+          options={policies || [{ value: defaultId, label: defaultLabel }]}
+          onSelect={(value) => {
+            let newSearch = copySearchParams(searchParams);
+            newSearch.set(target, value);
+            setSearchParams(newSearch);
+            if (onSelect) {
+              onSelect(value);
+            }
+          }}
+          onSearch={onSearch}
+          style={{ width: width || 200 }}
+          placeholder={defaultLabel}
+          value={value === defaultLabel ? null : value}
+        />
+        <Button
+          type="primary"
+          onClick={() => {}}
+          width={50}
+          style={{
+            padding: "unset"
+          }}
+          text={<CheckOutlined />}
+        />
+      </Space.Compact>
+  );
 }
+
+  /*
+    return (
+        {inputElement}
+        <Button
+          type={buttonStyle}
+          disabled={isDisabled}
+          onClick={(e) => onClick?.(e, inputValue)}
+          text={buttonText}
+          height={15}
+          width={100}
+        ></Button>
+      </Space.Compact>
+    );
+  const inputElement = (
+    <Input
+      style={boxStyle}
+      placeholder={placeholder}
+      disabled={isDisabled}
+      onChange={(e) => {
+        setInputValue(e.target.value);
+        onChange?.(e);
+      }}
+      status={error && "error"}
+      onPressEnter={(e) => onPressEnter?.(e, inputValue)}
+    />
+    
+  );
+*/

--- a/src/pages/policy/PolicySearch.jsx
+++ b/src/pages/policy/PolicySearch.jsx
@@ -47,7 +47,7 @@ export default function PolicySearch(props) {
   }
 
   async function handleStack() {
-    // Set some sort of loading?
+    // Set some sort of loading
     setIsStackerLoading(true);
 
     // Fetch policy to stack
@@ -130,22 +130,23 @@ export default function PolicySearch(props) {
         flexDirection: "column",
         justifyContent: "flex-start",
         alignItems: "flex-start",
-        gap: "10px"
+        gap: "10px",
       }}
     >
     <Space.Compact
       style={{
         width: width || "100%",
+        maxWidth: "100%",
       }}
     >
-    <AutoComplete
-      options={policies || [{ value: defaultId, label: defaultLabel }]}
-      onSelect={(value, option) => handleClickOnItem(value, option)}
-      onSearch={onSearch}
-      style={{ width: width || 200 }}
-      placeholder={defaultLabel}
-      value={value === defaultLabel ? null : value}
-    />
+      <AutoComplete
+        options={policies || [{ value: defaultId, label: defaultLabel }]}
+        onSelect={(value, option) => handleClickOnItem(value, option)}
+        onSearch={onSearch}
+        placeholder={defaultLabel}
+        value={value === defaultLabel ? null : value}
+        style={{overflow: "hidden", width: "100%"}}
+      />
         {displayStack && (
             <Tooltip
               title={isStackerLoading ? "Loading" : disableStack ? "" : "Add to current policy"}
@@ -153,10 +154,11 @@ export default function PolicySearch(props) {
               <Button
                 type={disableStack ? "disabled" : "secondary"}
                 onClick={handleStack}
-                width={50}
                 style={{
                   padding: "unset",
-                  borderWidth: "1px"
+                  borderWidth: "1px",
+                  minWidth: "32px",
+                  aspectRatio: "1"
                 }}
                 text={isStackerLoading
                   ? <LoadingOutlined />
@@ -172,9 +174,10 @@ export default function PolicySearch(props) {
           <Button
             type="primary"
             onClick={handleCheckmarkButton}
-            width={50}
             style={{
-              padding: "unset"
+              padding: "unset",
+              minWidth: "32px",
+              aspectRatio: "1"
             }}
             text={<CheckOutlined />}
           />

--- a/src/pages/policy/PolicySearch.jsx
+++ b/src/pages/policy/PolicySearch.jsx
@@ -6,7 +6,7 @@ import Button from "../../controls/Button";
 import { CheckOutlined, PlusOutlined } from "@ant-design/icons";
 
 export default function PolicySearch(props) {
-  const { metadata, target, policy, width, onSelect } = props;
+  const { metadata, target, policy, width, enableStack } = props;
   const [searchParams, setSearchParams] = useSearchParams();
   const defaultId = searchParams.get(target);
   let defaultLabel = policy[target].label || `Policy #${defaultId}`;
@@ -14,6 +14,7 @@ export default function PolicySearch(props) {
     defaultLabel = "Current law";
   }
   const [value, setValue] = useState(defaultLabel);
+  const [policyId, setPolicyId] = useState(searchParams.get(target));
 
   const [policies, setPolicies] = useState([]);
   const [lastRequestTime, setLastRequestTime] = useState(0);
@@ -23,8 +24,21 @@ export default function PolicySearch(props) {
     setValue(defaultLabel);
   }, [defaultLabel]);
 
-  // The search should query the API, but limited to one request every 1000ms.
+  // Handle when a user clicks an item in the list
+  function handleClickOnItem(value, option) {
+    setValue(option.label);
+    setPolicyId(value);
+  }
 
+  // Function to select a policy; this replaces any existing
+  // policy the user might have
+  function handleCheckmarkButton() {
+    let newSearch = copySearchParams(searchParams);
+    newSearch.set(target, policyId);
+    setSearchParams(newSearch);
+  }
+
+  // The search should query the API, but limited to one request every 1000ms.
   const onSearch = (searchText) => {
     setValue(searchText);
     const now = new Date().getTime();
@@ -39,11 +53,7 @@ export default function PolicySearch(props) {
             data.result.map((item) => {
               return {
                 value: item.id,
-                label: (
-                  <>
-                    #{item.id} {item.label}
-                  </>
-                ),
+                label: `#${item.id} ${item.label}`
               };
             }) || [],
           );
@@ -53,68 +63,43 @@ export default function PolicySearch(props) {
     }
   };
 
-  /*
   return (
+    <Space.Compact
+      style={{
+        width: width || "100%",
+      }}
+    >
     <AutoComplete
       options={policies || [{ value: defaultId, label: defaultLabel }]}
-      onSelect={(value) => {
-        let newSearch = copySearchParams(searchParams);
-        newSearch.set(target, value);
-        setSearchParams(newSearch);
-        if (onSelect) {
-          onSelect(value);
-        }
-      }}
+      onSelect={(value, option) => handleClickOnItem(value, option)}
       onSearch={onSearch}
       style={{ width: width || 200 }}
       placeholder={defaultLabel}
       value={value === defaultLabel ? null : value}
     />
-  );
-  */
-
-  return (
-      <Space.Compact
-        style={{
-          // ...componentStyle,
-          width: width || "100%",
-        }}
-      >
-        <AutoComplete
-          options={policies || [{ value: defaultId, label: defaultLabel }]}
-          onSelect={(value) => {
-            let newSearch = copySearchParams(searchParams);
-            newSearch.set(target, value);
-            setSearchParams(newSearch);
-            if (onSelect) {
-              onSelect(value);
-            }
-          }}
-          onSearch={onSearch}
-          style={{ width: width || 200 }}
-          placeholder={defaultLabel}
-          value={value === defaultLabel ? null : value}
-        />
-        <Tooltip
-          title="Add to current policy"
-        >
-          <Button
-            type="secondary"
-            onClick={() => {}}
-            width={50}
-            style={{
-              padding: "unset",
-              borderWidth: "1px"
-            }}
-            text={<PlusOutlined />}
-          />
-        </Tooltip>
+        {enableStack && (
+            <Tooltip
+              title="Add to current policy"
+            >
+              <Button
+                type="secondary"
+                onClick={() => {}}
+                width={50}
+                style={{
+                  padding: "unset",
+                  borderWidth: "1px"
+                }}
+                text={<PlusOutlined />}
+              />
+            </Tooltip>
+          )
+        }
         <Tooltip
           title="Use this policy; it will replace your current policy"
         >
           <Button
             type="primary"
-            onClick={() => {}}
+            onClick={handleCheckmarkButton}
             width={50}
             style={{
               padding: "unset"
@@ -122,78 +107,7 @@ export default function PolicySearch(props) {
             text={<CheckOutlined />}
           />
         </Tooltip>
-      </Space.Compact>
+    </Space.Compact>
   );
 
-  /*
-  return (
-    <>
-        <Tooltip
-          title="Add to current policy"
-          defaultOpen={true}
-        >
-          <Button
-            text="Test text"
-          />
-          <Button
-            type="secondary"
-            onClick={() => {}}
-            width={50}
-            style={{
-              padding: "unset",
-              borderWidth: "1px"
-            }}
-            text={<PlusOutlined />}
-          />
-        </Tooltip>
-        <Tooltip
-          title="Test AntButton"
-        >
-          <AntButton>Test text</AntButton>
-        </Tooltip>
-        <Tooltip
-          title="Use this policy; it will replace your current policy"
-        >
-          <Button
-            type="primary"
-            onClick={() => {}}
-            width={50}
-            style={{
-              padding: "unset"
-            }}
-            text={<CheckOutlined />}
-          />
-        </Tooltip>
-    </>
-  )
-  */
 }
-
-  /*
-    return (
-        {inputElement}
-        <Button
-          type={buttonStyle}
-          disabled={isDisabled}
-          onClick={(e) => onClick?.(e, inputValue)}
-          text={buttonText}
-          height={15}
-          width={100}
-        ></Button>
-      </Space.Compact>
-    );
-  const inputElement = (
-    <Input
-      style={boxStyle}
-      placeholder={placeholder}
-      disabled={isDisabled}
-      onChange={(e) => {
-        setInputValue(e.target.value);
-        onChange?.(e);
-      }}
-      status={error && "error"}
-      onPressEnter={(e) => onPressEnter?.(e, inputValue)}
-    />
-    
-  );
-*/


### PR DESCRIPTION
## Description

Fixes #1755.

## Changes

This PR allows a user to take a policy and "stack" another named policy upon it. Where conflicts occur, the "stacked" policy overwrites whatever settings the original policy holds.

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/14987227/5b1cdf30-65c8-43d3-9b7d-c24d8f01e0d4

## Tests

This adds a set of tests to ensure proper display and the creation of new policies.
