### PR TITLE
Re-add Bottom Carousel to desktop app

### DIFF
--- a/src/layout/BottomCarousel.jsx
+++ b/src/layout/BottomCarousel.jsx
@@ -18,12 +18,13 @@ export default function BottomCarousel(props) {
         bottom: mobile ? "25vh" : 0,
         display: "flex",
         height: "min-content",
-        left: mobile ? 0 : "25%",
+        left: mobile ? 0 : "50%",
         width: mobile ? "100%" : "50%",
         alignItems: "center",
         backgroundColor: style.colors.WHITE,
         justifyContent: mobile ? "center" : "right",
-        borderTop: "1px solid black",
+        // borderTop: "1px solid black",
+        borderTop: `1px solid ${style.colors.MEDIUM_DARK_GRAY}`,
         padding: "10px 20px",
         gap: "10px",
       }}
@@ -48,7 +49,7 @@ export default function BottomCarousel(props) {
           gap: 20,
         }}
       >
-        {previous.label ? (
+        {mobile && previous.label ? (
           <SearchParamNavButton
             focus={previous.name}
             direction="left"
@@ -58,7 +59,7 @@ export default function BottomCarousel(props) {
           <div style={{ width: 50 }} />
         )}
         {}
-        {next.label ? (
+        {mobile && next.label ? (
           <SearchParamNavButton
             focus={next.name}
             direction="right"

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -1,6 +1,6 @@
 import style from "../../../style";
 import LoadingCentered from "../../../layout/LoadingCentered";
-import { policyOutputs } from "./tree";
+import { getPolicyOutputTree, policyOutputs } from "./tree";
 import ResultsPanel from "../../../layout/ResultsPanel";
 import PolicyImpactPopup from "../../../modals/PolicyImpactPopup";
 import { useScreenshot } from "use-react-screenshot";
@@ -16,6 +16,7 @@ import { useReactToPrint } from "react-to-print";
 import PolicyBreakdown from "./PolicyBreakdown";
 import { Helmet } from "react-helmet";
 import useCountryId from "../../../hooks/useCountryId";
+import BottomCarousel from "../../../layout/BottomCarousel";
 
 /**
  *
@@ -243,8 +244,10 @@ export function LowLevelDisplay(props) {
   }, [preparingForScreenshot, takeScreenShot]);
 
   const urlParams = new URLSearchParams(window.location.search);
+  const focus = urlParams.get("focus");
   const selectedVersion = urlParams.get("version") || metadata.version;
   const region = urlParams.get("region");
+  const policyOutputTree = getPolicyOutputTree(metadata.countryId);
   const url = encodeURIComponent(window.location.href);
   const encodedPolicyLabel = encodeURIComponent(getPolicyLabel(policy));
   const twitterLink = `https://twitter.com/intent/tweet?url=${url}&text=${encodedPolicyLabel}%2C%20on%20PolicyEngine`;
@@ -270,7 +273,7 @@ export function LowLevelDisplay(props) {
 
     if (region === "enhanced_us") {
       bottomText = bottomText.concat(
-        "These calculations utilize enhanced CPS data, an experimental feature. ",
+        "These calculations utilize enhanced CPS data, a beta feature. ",
       );
     }
   } else if (metadata.countryId === "uk") {
@@ -351,6 +354,13 @@ export function LowLevelDisplay(props) {
       <div ref={componentRef} id="downloadable-content">
         {children}
       </div>
+      {!mobile && !preparingForScreenshot && (
+        <BottomCarousel
+          selected={focus}
+          options={policyOutputTree[0].children}
+          bottomElements={bottomElements}
+        />
+      )}
     </ResultsPanel>
   );
 }


### PR DESCRIPTION
## Description

Fixes #1694.

## Changes

This re-adds the BottomCarousel component (except the old navigation buttons) that was removed in #1670.

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/14987227/c04bcbbd-a011-4e61-a680-2b85bd641d90

## Tests

N/A
