### PR TITLE
Add queue position to policy calculator

### DIFF
--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -56,7 +56,7 @@ export function DisplayError(props) {
  * @returns component for displaying a progress bar that fills up over time
  */
 export function DisplayWait(props) {
-  const { secondsElapsed, averageImpactTime } = props;
+  const { secondsElapsed, averageImpactTime, queueMsg } = props;
   return (
     <div style={{ textAlign: "center", paddingTop: 50 }}>
       <LoadingCentered message="Simulating the impact of your policy..." />
@@ -69,6 +69,7 @@ export function DisplayWait(props) {
         }
         strokeColor={style.colors.BLUE}
       />
+      <p style={{ paddingTop: "12px", marginBottom: "2px" }}>{queueMsg}</p>
       <p style={{ color: "grey" }}>
         This usually takes around {Math.round(averageImpactTime / 5) * 5}{" "}
         seconds, but may take longer.


### PR DESCRIPTION
## Description

Fixes #1853.

## Changes

This displays the current queue position when users receive a response from the `economy` endpoint that provides that information.

## Screenshots

This video is this long to demonstrate that the queue position updates as the responses the user receives do.
https://github.com/PolicyEngine/policyengine-app/assets/14987227/46ed8d96-d486-4df9-9e4d-2f0554c64d81

## Tests

N/A
