### PR TITLE
Update CPS article link

### DIFF
--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -270,12 +270,10 @@ export function LowLevelDisplay(props) {
   });
 
   let bottomText = "";
-  let bottomLink = "";
+  let bottomLink = null;
 
   if (metadata.countryId === "us") {
     bottomText = `PolicyEngine US v${selectedVersion} estimates reform impacts using microsimulation. `;
-    bottomLink =
-      "/us/research/enhancing-the-current-population-survey-for-policy-analysis";
 
     if (region === "enhanced_us") {
       bottomText = bottomText.concat(
@@ -285,8 +283,6 @@ export function LowLevelDisplay(props) {
     }
   } else if (metadata.countryId === "uk") {
     bottomText = `PolicyEngine UK v${selectedVersion} estimates reform impacts using microsimulation. `;
-    bottomLink =
-      "/uk/research/how-machine-learning-tools-make-policyengine-more-accurate";
   }
 
   const embed = new URLSearchParams(window.location.search).get("embed");
@@ -300,9 +296,11 @@ export function LowLevelDisplay(props) {
         }}
       >
         {bottomText}
-        <a href={bottomLink} target="_blank" rel="noreferrer">
-          Learn more
-        </a>
+        {bottomLink && (
+          <a href={bottomLink} target="_blank" rel="noreferrer">
+            Learn more
+          </a>
+        )}
       </p>
     );
 

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -281,6 +281,7 @@ export function LowLevelDisplay(props) {
       bottomText = bottomText.concat(
         "These calculations utilize enhanced CPS data, a beta feature. ",
       );
+      bottomLink = "/us/research/enhanced-cps-beta";
     }
   } else if (metadata.countryId === "uk") {
     bottomText = `PolicyEngine UK v${selectedVersion} estimates reform impacts using microsimulation. `;


### PR DESCRIPTION
## Description

Fixes #1877.

## Changes

This PR displays the enhanced CPS article link on the bottom of the page for simulation runs utilizing enhanced CPS, while keeping it the previous default for all other US runs.

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/14987227/f9ab8e7d-b06c-465e-ab61-3d205e9f36b5

## Tests

N/A
