### PR TITLE
Update CPS prompt date

### DIFF
--- a/src/pages/policy/output/promptContent.js
+++ b/src/pages/policy/output/promptContent.js
@@ -30,7 +30,7 @@ export const promptContent = (
     * Cite PolicyEngine ${metadata.countryId.toUpperCase()} v${selectedVersion} and the ${
       metadata.countryId === "uk"
         ? "PolicyEngine-enhanced 2019 Family Resources Survey"
-        : "2021 Current Population Survey March Supplement"
+        : "2022 Current Population Survey March Supplement"
     } microdata when describing policy impacts.
     * When describing poverty impacts, note that the poverty measure reported is ${
       metadata.countryId === "uk"


### PR DESCRIPTION
## Description

Fixes #1855.

## Changes

PR updates the CPS survey year from 2021 to 2022 in the AI prompt

## Screenshots

<img width="1440" alt="Screen Shot 2024-06-17 at 3 59 00 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/df0616cf-6619-43d9-a190-ba00812008b3">

## Tests

N/A
