### PR TITLE
Use more broadly supported CSS for collapsibles

### DIFF
--- a/src/layout/CollapsedPanel.jsx
+++ b/src/layout/CollapsedPanel.jsx
@@ -18,9 +18,10 @@ export default function CollapsedPanel(props) {
     >
       <p
         style={{
-          writingMode: "sideways-lr",
+          writingMode: "tb",
+          transform: "rotate(180deg)",
           margin: "0",
-          paddingTop: "30px",
+          paddingBottom: "30px",
           fontSize: "12px",
           color: style.colors.DARK_GRAY,
         }}


### PR DESCRIPTION
## Description

Fixes #1882.

## Changes

This utilizes more broadly supported CSS options to ensure the collapsible titles display properly.

## Screenshots

The below is taken from Chrome, but functions similarly on Safari.
<img width="1440" alt="Screen Shot 2024-06-19 at 1 50 46 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/0398eb18-5434-4069-abcd-cede22e9c08d">

## Tests

N/A
