### PR TITLE
Add newline between charts and text on LSR pages

### DIFF
--- a/src/layout/HoverCard.jsx
+++ b/src/layout/HoverCard.jsx
@@ -103,7 +103,7 @@ const MemoizedChildren = memo(function MemoizedChildren(props) {
             height: "100%",
             display: "flex",
             flexDirection: "column",
-            gap: "12px"
+            gap: "12px",
           }}
         >
           {children}

--- a/src/layout/HoverCard.jsx
+++ b/src/layout/HoverCard.jsx
@@ -92,7 +92,6 @@ const MemoizedChildren = memo(function MemoizedChildren(props) {
     <HoverCardContext.Provider value={setContent}>
       <ChartWidthContext.Provider value={chartWidth}>
         <div
-          className="test"
           onMouseEnter={() => {
             setEnabled(true);
           }}
@@ -103,6 +102,8 @@ const MemoizedChildren = memo(function MemoizedChildren(props) {
           style={{
             height: "100%",
             display: "flex",
+            flexDirection: "column",
+            gap: "12px"
           }}
         >
           {children}


### PR DESCRIPTION
## Description

Fixes #1884

## Changes

Adds spacing between charts and text on LSR pages

## Screenshots

<img width="1440" alt="Screen Shot 2024-06-19 at 2 05 18 AM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/40a7eb96-9f07-4528-a354-6e11c92c3ba2">

## Tests

N/A
