### PR TITLE
Properly size container div on PolicySearch

### DIFF
--- a/src/pages/policy/PolicySearch.jsx
+++ b/src/pages/policy/PolicySearch.jsx
@@ -118,21 +118,6 @@ export default function PolicySearch(props) {
       );
       setLastRequestTime(new Date().getTime());
       setLastSearch(searchText);
-
-      /*
-        .then((data) => {
-          setPolicies(
-            data.result.map((item) => {
-              return {
-                value: item.id,
-                label: `#${item.id} ${item.label}`
-              };
-            }) || [],
-          );
-          setLastRequestTime(new Date().getTime());
-          setLastSearch(searchText);
-        });
-      */
     }
   };
 
@@ -144,6 +129,7 @@ export default function PolicySearch(props) {
         justifyContent: "flex-start",
         alignItems: "flex-start",
         gap: "10px",
+        width: "100%",
       }}
     >
       <Space.Compact


### PR DESCRIPTION
## Description

Fixes #1890 

## Changes

Properly sizes the PolicySearch container div to ensure that the baseline PolicySearch component is the correct width

## Screenshots

<img width="360" alt="Screen Shot 2024-06-19 at 5 23 48 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/ca44391b-3148-4d89-a7b0-e2b8e1ff4a29">

## Tests

N/A
