### PR TITLE
Fix scroll bars

### DIFF
--- a/src/layout/StackedMenu.jsx
+++ b/src/layout/StackedMenu.jsx
@@ -3,7 +3,6 @@ import Menu from "./Menu";
 export default function StackedMenu(props) {
   const { firstTree, secondTree, selected, onSelect } = props;
 
-  // onOutput == focus=policyOutput.?
   const isOnOutput =
     window.location.search.includes("focus=policyOutput") ||
     window.location.search.includes("focus=householdOutput");
@@ -15,7 +14,7 @@ export default function StackedMenu(props) {
   }
 
   return (
-    <div style={{ overflow: "scroll", padding: 20, height: "100%" }}>
+    <div style={{ padding: 20, height: "100%" }}>
       {result}
     </div>
   );

--- a/src/layout/StackedMenu.jsx
+++ b/src/layout/StackedMenu.jsx
@@ -13,9 +13,5 @@ export default function StackedMenu(props) {
     result = <Menu tree={firstTree} selected={selected} onSelect={onSelect} />;
   }
 
-  return (
-    <div style={{ padding: 20, height: "100%" }}>
-      {result}
-    </div>
-  );
+  return <div style={{ padding: 20, height: "100%" }}>{result}</div>;
 }

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -379,7 +379,7 @@ function PolicyDisplay(props) {
       style={{
         paddingTop: 20,
         maxHeight: "20vh",
-        overflow: "scroll",
+        overflowY: "scroll",
       }}
     >
       <Carousel


### PR DESCRIPTION
## Description

Fixes #1480.

## Changes

This removes unnecessary scroll options so as to prevent the automatic display of scrollbars on browsers where their display is enabled. The only bar that couldn't be removed was on the policy calculator's reform carousel, where the `scroll-y` can't be removed.

## Screenshots

<img width="1440" alt="Screen Shot 2024-06-19 at 7 13 11 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/c2f082ef-3e88-4eae-ae45-0c6d62421a19">
<img width="1440" alt="Screen Shot 2024-06-19 at 7 13 20 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/249085a0-cad1-4a0f-93e9-b0ab9a419671">

## Tests

N/A
