### PR TITLE
Properly display queue message

### DIFF
--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -57,7 +57,15 @@ export function DisplayError(props) {
  * @returns component for displaying a progress bar that fills up over time
  */
 export function DisplayWait(props) {
-  const { secondsElapsed, averageImpactTime, queueMsg } = props;
+  const { secondsElapsed, averageImpactTime, queuePos } = props;
+
+  let queueMsg = "";
+  if (Number(queuePos) === 0) {
+    queueMsg = "We are currently running your simulation.";
+  } else {
+    queueMsg = `Your position in the queue is ${queuePos}.`;
+  }
+
   return (
     <div style={{ textAlign: "center", paddingTop: 50 }}>
       <LoadingCentered message="Simulating the impact of your policy..." />

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -42,7 +42,7 @@ export function FetchAndDisplayImpact(props) {
   const [error, setError] = useState(null);
   const [averageImpactTime, setAverageImpactTime] = useState(20);
   const [secondsElapsed, setSecondsElapsed] = useState(0);
-  const [queueMsg, setQueueMsg] = useState("");
+  const [queuePos, setQueuePos] = useState("");
 
   const policyRef = useRef(null);
   const countryId = useCountryId();
@@ -56,8 +56,13 @@ export function FetchAndDisplayImpact(props) {
   function computingCallback(data) {
     // Position in queue message only occurs with average_time
     // in the response object; if this is present, enable message
+    /*
     if (data.average_time && data.message) {
       setQueueMsg(data.message);
+    }
+    */
+    if (data.queue_position) {
+      setQueuePos(data.queue_position);
     }
   }
 
@@ -178,7 +183,7 @@ export function FetchAndDisplayImpact(props) {
       <DisplayWait
         averageImpactTime={averageImpactTime}
         secondsElapsed={secondsElapsed}
-        queueMsg={queueMsg}
+        queuePos={queuePos}
       />
     );
   }


### PR DESCRIPTION
## Description

Fixes #1883. Requires merging of https://github.com/PolicyEngine/policyengine-api/pull/1579.

## Changes

Consumes the changes made to the API in the above linked PR to make it easier to customize the queue message by pulling only the queue position from each server response, then creating a statement using it.

## Screenshots

The below is when a user's policy is currently being calculated. The message displayed when an item is in the queue remains the same: "Your position in the queue is X".
<img width="1440" alt="Screen Shot 2024-06-19 at 8 39 05 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/102e8636-37b8-451f-ada0-8bad1fe4a893">

## Tests

N/A
