### PR TITLE
Prevent PolicyImpactPopup showing for authed users who have already closed it before

### DIFF
--- a/src/modals/PolicyImpactPopup.jsx
+++ b/src/modals/PolicyImpactPopup.jsx
@@ -1,12 +1,23 @@
 import { Modal } from "antd";
 import { useState } from "react";
 import Button from "../controls/Button";
+import { useAuth0 } from "@auth0/auth0-react";
+import { getCookie, setCookie } from "../data/cookies";
 
 export default function PolicyImpactPopup(props) {
   const [needToOpenModal, setNeedToOpenModal] = useState(true);
   const { metadata, showPolicyImpactPopup } = props;
 
+  const { isAuthenticated } = useAuth0();
+
   function handleSubmit() {
+    // For authed users who accepted cookies, log cookie
+    // to prevent re-display
+    const consentCookie = getCookie("consent");
+    if (isAuthenticated && consentCookie === "granted") {
+      setCookie("policyImpactPopup", "disabled");
+    }
+
     // Destroy modal
     setNeedToOpenModal(false);
   }

--- a/src/modals/SignupModal.jsx
+++ b/src/modals/SignupModal.jsx
@@ -4,6 +4,7 @@ import Button from "../controls/Button";
 import { useAuth0 } from "@auth0/auth0-react";
 import { loginOptions } from "../auth/authUtils";
 import useCountryId from "../hooks/useCountryId";
+import { getCookie } from "../data/cookies";
 
 export default function SignupModal(props) {
   const { setShowPolicyImpactPopup } = props;
@@ -28,7 +29,11 @@ export default function SignupModal(props) {
   }
 
   if (isLoading || isAuthenticated) {
-    setShowPolicyImpactPopup(true);
+    if (getCookie("policyImpactPopup") === "disabled") {
+      setShowPolicyImpactPopup(false);
+    } else {
+      setShowPolicyImpactPopup(true);
+    }
     return null;
   }
 


### PR DESCRIPTION
## Description

Fixes #1898.

## Changes

For authenticated users with cookies enabled, this PR saves a cookie when these users close the `PolicyImpactPopup`, preventing its display in the future

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/14987227/11105c67-4c8b-4f23-bdfa-d72bd523957d

## Tests

N/A
