### PR TITLE
Revert to navigator language for country ID selection

### DIFF
--- a/src/routing/RedirectToCountry.jsx
+++ b/src/routing/RedirectToCountry.jsx
@@ -23,7 +23,7 @@ export function findCountryId() {
 
   const browserLanguage = navigator.language;
 
-  if (COUNTRY_CODES.includes(browserLanguage)) {
+  if (Object.keys(COUNTRY_CODES).includes(browserLanguage)) {
     return COUNTRY_CODES[browserLanguage];
   } else {
     return "us";

--- a/src/routing/RedirectToCountry.jsx
+++ b/src/routing/RedirectToCountry.jsx
@@ -1,5 +1,4 @@
 import { Navigate } from "react-router-dom";
-import { COUNTRY_CODES } from "../data/countries";
 
 export default function RedirectToCountry() {
   // Find country ID
@@ -14,14 +13,18 @@ export default function RedirectToCountry() {
  * @returns {String}
  */
 export function findCountryId() {
-  const locale = Intl.DateTimeFormat().resolvedOptions().locale;
-  let localeCountry = undefined;
-  if (locale.includes("-")) {
-    localeCountry = locale.split("-")[1].toLowerCase();
-  }
+  const COUNTRY_CODES = {
+    "en-US": "us",
+    "en-GB": "uk",
+    "en-CA": "ca",
+    "en-NG": "ng",
+    "en-IL": "il",
+  };
 
-  if (COUNTRY_CODES.includes(localeCountry)) {
-    return localeCountry;
+  const browserLanguage = navigator.language;
+
+  if (COUNTRY_CODES.includes(browserLanguage)) {
+    return COUNTRY_CODES[browserLanguage];
   } else {
     return "us";
   }


### PR DESCRIPTION
## Description

Fixes #1901.

## Changes

PR reverts to using `navigator.language` to select a user's default country, as opposed to `Intl.DateTimeFormat().resolvedOptions().locale`. This may risk issues with subsets of users whose primary browser language is not English, but may also resolve problems UK-based users appear to have.

## Screenshots

https://github.com/PolicyEngine/policyengine-app/assets/14987227/abfbbd0d-1b10-457a-aa6e-5175ffc038b1

## Tests

N/A
