### PR TITLE
Change Lib Dems name on election banner button

### DIFF
--- a/src/pages/home/HomeElectionBanner.jsx
+++ b/src/pages/home/HomeElectionBanner.jsx
@@ -136,7 +136,7 @@ export default function HomeElectionBanner() {
             />
             <LinkButton
               type="primary"
-              text={windowWidth > 650 ? "Liberal Democrat" : "Lib"}
+              text={windowWidth > 650 ? "Liberal Democrats" : "Lib"}
               backgroundColor="#fad496"
               borderColor="#fad496"
               activeBackgroundColor="#faa61a"
@@ -280,7 +280,7 @@ export default function HomeElectionBanner() {
         />
         <LinkButton
           type="primary"
-          text="Liberal Democratic"
+          text="Liberal Democrats"
           backgroundColor="#fad496"
           borderColor="#fad496"
           activeBackgroundColor="#faa61a"


### PR DESCRIPTION
## Description

Fixes #1917.

## Changes

Changes wording on UK election banner desktop-breakpoint button from "Liberal Democratic" to "Liberal Democrats"

## Screenshots

<img width="1440" alt="Screen Shot 2024-07-01 at 3 49 22 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/642c9754-a891-4c57-81e5-ba4b88195a86">

## Tests

N/A
