### PR TITLE
Fix UK manifestos social card title

### DIFF
--- a/gcp/social_card_tags.py
+++ b/gcp/social_card_tags.py
@@ -2,6 +2,9 @@ import json
 from pathlib import Path
 from bs4 import BeautifulSoup
 
+CUSTOM_TITLES = {
+    "2024-manifestos": "UK 2024 Election Manifestos"
+}
 
 # Load src/posts/posts.json
 with open("src/posts/posts.json") as f:
@@ -26,7 +29,11 @@ def get_title(path: str, query_params: dict):
         main_text += f"Reform #{query_params['reform']} | "
 
     try:
-        page_name = path.split("/")[2].capitalize()
+        path_element = path.split("/")[2]
+        if CUSTOM_TITLES.get(path_element) is not None:
+            page_name = CUSTOM_TITLES.get(path_element)
+        else:
+            page_name = path_element.capitalize()
     except IndexError:
         page_name = "Home"
     main_text += f"{page_name} | "

--- a/gcp/social_card_tags.py
+++ b/gcp/social_card_tags.py
@@ -36,7 +36,7 @@ def get_title(path: str, query_params: dict):
         page_name = "Home"
     main_text += f"{page_name} | "
     main_text += f"PolicyEngine {country}"
-    return main_text
+    return main_text 
 
 
 def get_image(path: str, query_params: dict, social_cards: dict = {}):

--- a/gcp/social_card_tags.py
+++ b/gcp/social_card_tags.py
@@ -36,7 +36,7 @@ def get_title(path: str, query_params: dict):
         page_name = "Home"
     main_text += f"{page_name} | "
     main_text += f"PolicyEngine {country}"
-    return main_text 
+    return main_text
 
 
 def get_image(path: str, query_params: dict, social_cards: dict = {}):

--- a/gcp/social_card_tags.py
+++ b/gcp/social_card_tags.py
@@ -2,9 +2,7 @@ import json
 from pathlib import Path
 from bs4 import BeautifulSoup
 
-CUSTOM_TITLES = {
-    "2024-manifestos": "UK 2024 Election Manifestos"
-}
+CUSTOM_TITLES = {"2024-manifestos": "UK 2024 Election Manifestos"}
 
 # Load src/posts/posts.json
 with open("src/posts/posts.json") as f:


### PR DESCRIPTION
## Description

Fixes #1916

## Changes

Previously, all non-article pages of the app applied the same method of creating a social card title: the page's link would be capitalized. However, this does not work well for the UK manifestos app page. This PR adds a custom override dict that enables custom titling.

If desired, this could be redone to instead take URLs with hyphens (e.g., "2024-manifestos") and just replace the hyphens with spaces and capitalize where appropriate ("2024 Manifestos"). It would require less of an "escape hatch" than this PR, but didn't feel like enough of a solution.

## Screenshots

N/A

## Tests

I remain unsure how to test these changes. A future issue should create some method of testing the social card server.
