### PR TITLE
Prevent tables from causing articles to overflow

### DIFF
--- a/src/layout/MarkdownFormatter.jsx
+++ b/src/layout/MarkdownFormatter.jsx
@@ -408,9 +408,7 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict }) {
             style={{
               marginTop: 30,
               marginBottom: 30,
-              // evenly distribute the table header cells
               display: "table",
-              // tableLayout: "fixed",
               width: "100%",
             }}
           >
@@ -431,7 +429,6 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict }) {
               textAlign: "center",
               verticalAlign: "middle",
               color: "white",
-              // width: "100%",
             }}
           >
             {children}

--- a/src/layout/MarkdownFormatter.jsx
+++ b/src/layout/MarkdownFormatter.jsx
@@ -410,7 +410,7 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict }) {
               marginBottom: 30,
               // evenly distribute the table header cells
               display: "table",
-              tableLayout: "fixed",
+              // tableLayout: "fixed",
               width: "100%",
             }}
           >
@@ -431,7 +431,7 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict }) {
               textAlign: "center",
               verticalAlign: "middle",
               color: "white",
-              width: "100%",
+              // width: "100%",
             }}
           >
             {children}

--- a/src/pages/BlogPage.jsx
+++ b/src/pages/BlogPage.jsx
@@ -307,7 +307,7 @@ function PostBodySection({ post, markdown, notebook }) {
             <LeftContents markdown={markdown} notebook={notebook} />
           </div>
         </div>
-        <div style={{ flex: 4 }}>
+        <div style={{ flex: 4, minWidth: 0 }}>
           {bodyContent}
           <AuthorSection post={post} />
         </div>


### PR DESCRIPTION
## Description

Fixes #1908.

## Changes

This PR makes various changes to table formatting to prevent situations where tables of a particular width cause the central column of the article to overflow its intended width.

Note that these changes no longer allow tables with columns of equal widths. If this is a deal-breaker, a different fix to the problem will be required.

## Screenshots

<img width="1440" alt="Screen Shot 2024-07-01 at 6 21 12 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/7ebaea66-c641-409e-bad1-341cf400918b">

## Tests

N/A
