### PR TITLE
Move election banner downward on UK site

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -22,8 +22,8 @@ export default function Home() {
       </Helmet>
       <div>
         <Header />
-        {countryId === "uk" && <HomeElectionBanner />}
         <HomeLanding />
+        {countryId === "uk" && <HomeElectionBanner />}
         <HomeUsedBy />
         <HomeBlogPreview />
         <HomeSubscribe />


### PR DESCRIPTION
## Description

Fixes #1921 

## Changes

Moves the election banner downward on the UK site, considering the finalization of the UK election on July 4

## Screenshots

<img width="1440" alt="Screen Shot 2024-07-09 at 2 14 15 PM" src="https://github.com/PolicyEngine/policyengine-app/assets/14987227/f3d07575-4930-48a7-9791-f9cc4891422c">

## Tests

N/A
