### PR TITLE
Added the github account on Ben gross in authors.json

### DIFF
--- a/src/posts/authors.json
+++ b/src/posts/authors.json
@@ -95,6 +95,7 @@
     "linkedin": "https://www.linkedin.com/in/ben-gross-146330178/",
     "twitter": "twitter.com/bengrossbg",
     "headshot": "ben-gross.png",
-    "title": "Communications Intern at PolicyEngine"
+    "title": "Communications Intern at PolicyEngine",
+    "github": "https://github.com/BenGross"
   }
 }


### PR DESCRIPTION
## Description

Add full info on Ben Gross to authors.json #1927.

## Changes

Added the github account to complete the ben gross info in authors.json.

