### PR TITLE
Allow custom baseline with current law for enqueuing output

### DIFF
--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -731,7 +731,9 @@ export default function PolicyRightSidebar(props) {
         {!hideButtons && focus && !focus.startsWith("policyOutput") && (
           <SearchParamNavButton
             type={
-              Object.keys(policy.reform.data).length === 0
+              // Disable output if both baseline and reform are current law
+              Object.keys(policy.reform.data).length === 0 &&
+              Object.keys(policy.baseline.data).length === 0
                 ? "disabled"
                 : "primary"
             }


### PR DESCRIPTION
## Description

Fixes #1859 

## Changes

PR allows app to calculate policies with custom baseline compared against current law, while still preventing a current law baseline/current law reform from being calculated

## Screenshots

https://github.com/user-attachments/assets/642500a3-75d8-47c7-9d8f-412f62bc5292

## Tests

N/A
