### PR TITLE
Removed Carousel From Mobile View

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "jest-when": "^3.6.0",
         "lint-staged": "^15.2.5",
         "node-fetch": "^3.3.2",
-        "prettier": "^3.2.5",
+        "prettier": "^3.3.3",
         "resize-observer-polyfill": "^1.5.1",
         "typescript": "^5.4.5",
         "whatwg-fetch": "^3.6.20"
@@ -10187,6 +10187,7 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -20662,10 +20663,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "jest-when": "^3.6.0",
     "lint-staged": "^15.2.5",
     "node-fetch": "^3.3.2",
-    "prettier": "^3.2.5",
+    "prettier": "^3.3.3",
     "resize-observer-polyfill": "^1.5.1",
     "typescript": "^5.4.5",
     "whatwg-fetch": "^3.6.20"

--- a/src/layout/BottomCarousel.jsx
+++ b/src/layout/BottomCarousel.jsx
@@ -1,3 +1,5 @@
+// Was originally named "BottomCarousel" because the mobile view had a carousel but this was later removed.
+
 import SearchParamNavButton from "../controls/SearchParamNavButton";
 import style from "../style";
 import useMobile from "./Responsive";
@@ -18,15 +20,15 @@ export default function BottomCarousel(props) {
     <div
       style={{
         position: "fixed",
-        bottom: mobile ? "25vh" : 0,
+        bottom: 0,
         display: "flex",
         height: "min-content",
         minHeight: COLLAPSE_BUTTON_HEIGHT,
         right: 0,
-        width: mobile ? "100%" : paneWidth,
+        width: paneWidth,
         alignItems: "center",
         backgroundColor: style.colors.WHITE,
-        justifyContent: mobile ? "center" : "left",
+        justifyContent: "left",
         borderImage: `linear-gradient(to right, 
           ${style.colors.LIGHT_GRAY} 0px, 
           ${style.colors.LIGHT_GRAY} 12px, 
@@ -51,36 +53,6 @@ export default function BottomCarousel(props) {
           }}
         >
           {bottomElements}
-        </div>
-      )}
-      {mobile && (
-        <div
-          style={{
-            flex: 1,
-            display: "flex",
-            justifyContent: mobile ? "center" : "right",
-            alignItems: "flex-start",
-            gap: 20,
-          }}
-        >
-          {previous.label ? (
-            <SearchParamNavButton
-              focus={previous.name}
-              direction="left"
-              style={{ width: 50, fontSize: 16 }}
-            />
-          ) : (
-            <div style={{ width: 50 }} />
-          )}
-          {mobile && next.label ? (
-            <SearchParamNavButton
-              focus={next.name}
-              direction="right"
-              style={{ width: 50, fontSize: 16 }}
-            />
-          ) : (
-            <div style={{ width: 60 }} />
-          )}
         </div>
       )}
     </div>

--- a/src/layout/BottomImpactDescription.jsx
+++ b/src/layout/BottomImpactDescription.jsx
@@ -1,17 +1,13 @@
 // This file was originally named "BottomCarousel" because the mobile view had a carousel but this was later removed.
 
-import SearchParamNavButton from "../controls/SearchParamNavButton";
 import style from "../style";
 import useMobile from "./Responsive";
 import { COLLAPSE_BUTTON_HEIGHT, PaneWidthContext } from "./ThreeColumnPage";
 import { useContext } from "react";
 
 export default function BottomImpactDescription(props) {
-  const { selected, options, bottomElements } = props;
+  const { bottomElements } = props;
   const mobile = useMobile();
-  const currentIndex = options.map((option) => option.name).indexOf(selected);
-  const previous = options[currentIndex - 1] || {};
-  const next = options[currentIndex + 1] || {};
   const paneWidth = useContext(PaneWidthContext);
 
   // Show the previous to the left, the current in the middle, and the next to the right

--- a/src/layout/BottomImpactDescription.jsx
+++ b/src/layout/BottomImpactDescription.jsx
@@ -1,4 +1,4 @@
-// Was originally named "BottomCarousel" because the mobile view had a carousel but this was later removed.
+// This file was originally named "BottomCarousel" because the mobile view had a carousel but this was later removed.
 
 import SearchParamNavButton from "../controls/SearchParamNavButton";
 import style from "../style";
@@ -6,7 +6,7 @@ import useMobile from "./Responsive";
 import { COLLAPSE_BUTTON_HEIGHT, PaneWidthContext } from "./ThreeColumnPage";
 import { useContext } from "react";
 
-export default function BottomCarousel(props) {
+export default function BottomImpactDescription(props) {
   const { selected, options, bottomElements } = props;
   const mobile = useMobile();
   const currentIndex = options.map((option) => option.name).indexOf(selected);

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -367,11 +367,14 @@ export function LowLevelDisplay(props) {
       <div ref={componentRef} id="downloadable-content">
         {children}
       </div>
-      <BottomCarousel
-        selected={focus}
-        options={policyOutputTree[0].children}
-        bottomElements={bottomElements}
+      {!mobile && (
+        <BottomCarousel
+          selected={focus}
+          options={policyOutputTree[0].children}
+          bottomElements={bottomElements}
       />
+      )}
+      
     </ResultsPanel>
   );
 }

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -372,9 +372,8 @@ export function LowLevelDisplay(props) {
           selected={focus}
           options={policyOutputTree[0].children}
           bottomElements={bottomElements}
-      />
+        />
       )}
-      
     </ResultsPanel>
   );
 }

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -16,7 +16,7 @@ import { useReactToPrint } from "react-to-print";
 import PolicyBreakdown from "./PolicyBreakdown";
 import { Helmet } from "react-helmet";
 import useCountryId from "../../../hooks/useCountryId";
-import BottomCarousel from "../../../layout/BottomCarousel";
+import BottomImpactDescription from "../../../layout/BottomImpactDescription";
 
 /**
  *
@@ -368,7 +368,7 @@ export function LowLevelDisplay(props) {
         {children}
       </div>
       {!mobile && (
-        <BottomCarousel
+        <BottomImpactDescription
           selected={focus}
           options={policyOutputTree[0].children}
           bottomElements={bottomElements}

--- a/src/posts/README.md
+++ b/src/posts/README.md
@@ -23,4 +23,5 @@
 8. Replace superscript footnotes with Markdown footnotes.
 
 [^1]: This way, Medium does all the image optimisation and we can use their server space to host the images.
+
 [^2]: A 'slug' is a code-friendly version of the post title. For example, the slug for "How to write a blog post" is `how-to-write-a-blog-post`.

--- a/src/posts/articles/analysis-of-the-spring-budget-2023.md
+++ b/src/posts/articles/analysis-of-the-spring-budget-2023.md
@@ -39,4 +39,5 @@ In terms of inequality, the Gini coefficient decreases slightly from 0.336 to 0.
 The Spring Budget 2023’s policy changes regarding energy and fuel have a budgetary impact of £7.3 billion, with nearly all people (98%) gaining from these reforms. The policies have a larger relative impact on lower-income households, contribute to a reduction in poverty rates and inequality under several different metrics.
 
 [^1]: To estimate the impact of the fuel duty freeze, we compare it against a counterfactual scenario in which the fuel duty rate was raised to 65p.
+
 [^2]: See the policy costing document [here](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1142824/Costing_Document_-_Spring_Budget_2023.pdf#page=9).

--- a/src/posts/articles/labour-2024-manifesto.md
+++ b/src/posts/articles/labour-2024-manifesto.md
@@ -89,5 +89,7 @@ The Labour manifesto redistributes £4.2bn and raises £3.3bn surplus revenue pr
 ## Notes
 
 [^1]: Where a policy is clearly a tax on corporations or consumption, we distribute the burden according to imputed corporate wealth and consumption, respectively. For public service budget changes we apply the ONS’ estimates of public service consumption by income decile. Where a policy is clearly only incident on high incomes, we model it as a progressive tax after an appropriate income level.
+
 [^2]: See our open-source model addition [here](https://github.com/PolicyEngine/policyengine-uk/pull/880/files). We do not model the business rate increase.
+
 [^3]: [Advani et al](https://warwick.ac.uk/fac/soc/economics/research/centres/cage/manage/publications/bn36.2022.pdf) found that only 0.3% of people who have ever been non-doms earn less than £100,000, and non-dom status becomes more prevalent at higher incomes.

--- a/src/posts/articles/policyengine-launches-in-new-york-state.md
+++ b/src/posts/articles/policyengine-launches-in-new-york-state.md
@@ -13,5 +13,7 @@ From Governor Hochul to think tanks to families trying to better understand thei
 ![](https://cdn-images-1.medium.com/max/5868/1*TUzMiSu3Z9ktiA5_9syB-Q.png)
 
 [^1]: PolicyEngine results may not constitute exact tax liabilities or benefit entitlements.
+
 [^2]: PolicyEngine estimates New York-wide impacts using the Current Population Survey, which undercaptures income and benefits, especially among low- and high-income households.
+
 [^3]: Nikhil Woodruff and Aleida Baumgartner modeled PolicyEngine’s New York tax model.

--- a/src/posts/articles/restoring-arpa-eitc.md
+++ b/src/posts/articles/restoring-arpa-eitc.md
@@ -39,6 +39,7 @@ In 2021, ARPA made the following changes to the EITC for childless workers:
 1. Allowed separate filers in the same household to be eligible for the EITC
 
 [^1]: The value of $600 mentioned in the previous section is the inflation-adjusted figure for 2023.
+
 [^2]: Today’s inflation-adjusted value is $9,800.
 
 ## Limitations of PolicyEngine’s EITC model


### PR DESCRIPTION
Added logic to does not display BottomCarousel component for mobile. Removed irrelevant code for mobile in the BottomCarousel Component.

## Description

Fixes #1945. Added logic to does not display BottomCarousel component for mobile. Removed irrelevant code for mobile in the BottomCarousel Component.

## Changes

Added logic to does not display BottomCarousel component for mobile. Removed irrelevant code for mobile in the BottomCarousel Component. Changed component name to BottomImpactDescription since it is no longer a carousel.

## Screenshots

https://www.loom.com/share/2b4e66f64dcd47a7a2b6fabf00dc8a1c

## Tests

I don't think Jest tests are too relevant so I went through full UI for type = 'household' and type = 'policy' for both US and UK versions of the app. Ran npm tests and no new tests fail (outside of the 8 that were failing prior to the change).
