### PR TITLE
fix undefined logos and add organization info

### DIFF
--- a/src/data/organisations.js
+++ b/src/data/organisations.js
@@ -8,10 +8,10 @@ import UKEU from "../images/logos/orgs/ukeu.svg";
 import ASI from "../images/logos/orgs/asi.webp";
 import CEC from "../images/logos/orgs/cec.svg";
 import CGO from "../images/logos/orgs/cgo.jpg";
-/*import EPMT from "../images/logos/orgs/epmt.jpg";*/
+import EPMT from "../images/logos/orgs/epmt.jpg";
 import NISKANENCenter from "../images/logos/orgs/niskanen-center.png";
 import F4GI from "../images/logos/orgs/f4gi.jpg";
-// import GCV from "../images/logos/orgs/gary-community-ventures.png";
+import GCV from "../images/logos/orgs/gary-community-ventures.png";
 import MFB from "../images/logos/orgs/myfriendben.png";
 import MCA from "../images/logos/orgs/mca.jpg";
 import UBICenter from "../images/logos/orgs/ubicenter.png";
@@ -87,6 +87,16 @@ export const orgData = {
       name: "Maryland Child Alliance",
       logo: MCA,
       link: "https://www.marylandchildalliance.org/revenue-raisers",
+    },
+    epmt: {
+      name: "End Poverty Make Trillions",
+      logo: EPMT,
+      link: "https://endpovertymaketrillions.com/",
+    },
+    gcv: {
+      name: "Gary Community Ventures",
+      logo: GCV,
+      link: "https://garycommunity.org/",
     },
     mfb: {
       name: "MyFriendBen",


### PR DESCRIPTION
Fixes #1984 

- fixes the undefined logos on the testimonials. 

## Changes
- Readded the two missing logos and their organizational info
@MaxGhenis  you removed Gary Community Ventures in #1979, should it be readded as I have done?


## Screenshots

### Before
![before-testimonial](https://github.com/user-attachments/assets/e74277ea-eade-4d6a-b4fc-0d2ca5565421)
![before-2](https://github.com/user-attachments/assets/cd2509b2-b4ba-4c35-bf2d-dbf0fe6c22c9)



### After
![testimonial-logos](https://github.com/user-attachments/assets/dafb7024-e20c-4c60-ad25-d3dfcf4f12f4)
![after-2](https://github.com/user-attachments/assets/f4635a44-e007-4bf7-b2b1-76105c684652)


## Tests

No tests
