### PR TITLE
Fix: Make Table of Contents scroll to relevant section of Blog posts

### DIFF
--- a/src/layout/MarkdownFormatter.jsx
+++ b/src/layout/MarkdownFormatter.jsx
@@ -2,7 +2,7 @@ import Markdown from "react-markdown";
 import { TwitterTweetEmbed } from "react-twitter-embed";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
-import { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import style from "../style";
 import useDisplayCategory from "../hooks/useDisplayCategory";
 import Plot from "react-plotly.js";
@@ -370,17 +370,17 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict }) {
           }
         },
         h2: ({ children }) => {
-          let headerText = children[0];
+          let headerText = React.Children.toArray(children).join("");
           if (!headerText.split) {
             headerText = "";
           }
           // Remove slashes and commas, and replace spaces with dashes to create a
           // unique ID for each header.
           const slug = headerText
-            .split(" ")
-            .join("-")
-            .replace("/", "")
-            .replace(/,/g, "");
+            .toLowerCase()
+            .replace(/[/,]/g, "")
+            .replace(/\s+/g, "-");
+
           return (
             <h2 id={slug} style={{ marginBottom: 20 }}>
               {children}
@@ -388,20 +388,22 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict }) {
           );
         },
         h3: ({ children }) => {
-          const headerText = children[0];
-          return (
-            <h3 id={headerText.split(" ").join("-").replace(/,/g, "")}>
-              {children}
-            </h3>
-          );
+          const headerText = React.Children.toArray(children).join("");
+          const slug = headerText
+            .toLowerCase()
+            .replace(/[/,]/g, "")
+            .replace(/\s+/g, "-");
+
+          return <h3 id={slug}>{children}</h3>;
         },
         h4: ({ children }) => {
-          const headerText = children[0];
-          return (
-            <h4 id={headerText.split(" ").join("-").replace(/,/g, "")}>
-              {children}
-            </h4>
-          );
+          const headerText = React.Children.toArray(children).join("");
+          const slug = headerText
+            .toLowerCase()
+            .replace(/[/,]/g, "")
+            .replace(/\s+/g, "-");
+
+          return <h4 id={slug}>{children}</h4>;
         },
         table: ({ children }) => (
           <table

--- a/src/layout/MarkdownFormatter.jsx
+++ b/src/layout/MarkdownFormatter.jsx
@@ -336,14 +336,15 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict }) {
             </a>
           );
         },
-        h1: ({ children }) => {
-          const headerText = children[0];
+        h1: ({ children: headerText }) => {
+          const slug = headerText
+            .toLowerCase()
+            .replace(/[/,]/g, "")
+            .replace(/\s+/g, "-");
+
           return (
-            <h1
-              id={headerText.split(" ").join("-").replace(/,/g, "")}
-              style={{ marginBottom: 20 }}
-            >
-              {children}
+            <h1 id={slug} style={{ marginBottom: 20 }}>
+              {headerText}
             </h1>
           );
         },
@@ -369,8 +370,7 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict }) {
             return <section>{children}</section>;
           }
         },
-        h2: ({ children }) => {
-          let headerText = React.Children.toArray(children).join("");
+        h2: ({ children: headerText }) => {
           if (!headerText.split) {
             headerText = "";
           }
@@ -383,27 +383,25 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict }) {
 
           return (
             <h2 id={slug} style={{ marginBottom: 20 }}>
-              {children}
+              {headerText}
             </h2>
           );
         },
-        h3: ({ children }) => {
-          const headerText = React.Children.toArray(children).join("");
+        h3: ({ children: headerText }) => {
           const slug = headerText
             .toLowerCase()
             .replace(/[/,]/g, "")
             .replace(/\s+/g, "-");
 
-          return <h3 id={slug}>{children}</h3>;
+          return <h3 id={slug}>{headerText}</h3>;
         },
-        h4: ({ children }) => {
-          const headerText = React.Children.toArray(children).join("");
+        h4: ({ children: headerText }) => {
           const slug = headerText
             .toLowerCase()
             .replace(/[/,]/g, "")
             .replace(/\s+/g, "-");
 
-          return <h4 id={slug}>{children}</h4>;
+          return <h4 id={slug}>{headerText}</h4>;
         },
         table: ({ children }) => (
           <table

--- a/src/pages/BlogPage.jsx
+++ b/src/pages/BlogPage.jsx
@@ -697,14 +697,7 @@ function LeftContents(props) {
     return text;
   });
   const headerSlugs = headers.map((header) =>
-    header
-      .split(" ")
-      .slice(1)
-      .join(" ")
-      .split(" ")
-      .join("-")
-      .replace("\\", "")
-      .replace(/,/g, ""),
+    header.replace(/[#,/]/g, "").trim().replace(/\s+/g, "-").toLowerCase(),
   );
 
   let contents = [];
@@ -712,6 +705,7 @@ function LeftContents(props) {
     const headerLevel = headerLevels[i];
     const headerText = headerTexts[i];
     const headerSlug = headerSlugs[i];
+
     contents.push(
       <div
         style={{ display: "flex", alignItems: "center", marginBottom: 5 }}


### PR DESCRIPTION
Fixes #1990 

## Changes

- fix `markdown-formatter` to assign unique and correct heading ids 
- scroll to relevant section of blog post from table of contents
