### PR TITLE
fixed formatting of footnotes in markdowns

### DIFF
--- a/src/layout/MarkdownFormatter.jsx
+++ b/src/layout/MarkdownFormatter.jsx
@@ -264,6 +264,7 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict }) {
         li: ({ children }) => {
           // Check if li p a exists. If it does, get the ID of the a tag.
           let value = null;
+          let validValue = false;
           try {
             let footnoteLinkBack = children
               .find((child) => child?.props?.node.tagName === "p")
@@ -271,16 +272,12 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict }) {
                 (child) => child?.props?.node.tagName === "a",
               ).props.node.properties.href;
             value = footnoteLinkBack.split("-").pop();
+            validValue = /^-?\d+$/.test(value);
           } catch (e) {
             // Do nothing
           }
           return (
-            <li
-              style={{
-                marginLeft: 10,
-              }}
-              value={value}
-            >
+            <li style={{ marginLeft: 10 }} value={validValue ? value : null}>
               {children}
             </li>
           );


### PR DESCRIPTION
## Description
Fixes #1975
The issue with the value extraction logic has been addressed.
## Changes

Previously, the code split the link string at the "-" character and assigned the portion after it to the value. I have introduced additional validation to ensure that only numeric values are accepted for value in all relevant scenarios, as required by the original implementation.


![Screenshot 2024-09-01 at 09-48-05 PolicyEngine](https://github.com/user-attachments/assets/38a641e6-1838-406d-a03a-13bac89e0b84)
