### PR TITLE
Add isNoReform function and check for falsy values

### DIFF
--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -495,6 +495,26 @@ export default function PolicyRightSidebar(props) {
     (option) => option.value === stateAbbreviation,
   )?.value;
 
+  const baselineData = policy.baseline.data;
+  const reformData = policy.reform.data;
+
+  // Convenience function for determining if baseline and reform
+  // are both current law, and thus, there is no reform
+  function isNoReform(baselineData, reformData) {
+    if (!baselineData || !reformData) {
+      return true;
+    }
+
+    if (
+      Object.keys(baselineData).length === 0 &&
+      Object.keys(reformData).length === 0
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
   const confirmEconomicImpact = () => {
     let message = "";
     if (validatedStateAbbreviation && stateAbbreviation !== region) {
@@ -782,10 +802,7 @@ export default function PolicyRightSidebar(props) {
           <SearchParamNavButton
             type={
               // Disable output if both baseline and reform are current law
-              Object.keys(policy.reform.data).length === 0 &&
-              Object.keys(policy.baseline.data).length === 0
-                ? "disabled"
-                : "primary"
+              isNoReform(baselineData, reformData) ? "disabled" : "primary"
             }
             text="Calculate economic impact"
             onClick={confirmEconomicImpact}


### PR DESCRIPTION
## Description

Fixes #1983.

## Changes

#1983 occurs when a user clicks the policy calculator before both the default baseline and reform policies are able to fully load. Though the policies' IDs are present in the app (as part of the `policy` JS object), one (typically baseline) will not have a fully instantiated empty object for its `data` key, instead possessing `null`. 

Previously, `PolicyRightSidebar` used both the baseline and reform policies' `data` key to determine whether the two policies were both current law. This required object methods that would fail on the `null` `policy.baseline.data` key, as object methods cannot be applied to `null` in JS.

These changes add type checking to ensure that `policy.baseline.data` and `policy.reform.data` are fully loaded before running an object method.

## Screenshots

It is difficult to succinctly test this issue visually, as one must prove that an inconsistent error no longer occurs. However, the below video attempts to demonstrate the workflow that causes the bug, first run on the app running locally post-changes, then on the deployed app, hitting the bug on deployed after only two refreshes of the app.

https://github.com/user-attachments/assets/649e01a5-b271-4a5f-9e08-651915da1cdf

## Tests

Only visual tests have been provided. 
