### PR TITLE
Stop "Reproduce in Python" from reseting/reloading simulation

### DIFF
--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -8,6 +8,7 @@ import { getImpactReps } from "./ImpactTypes";
 import { Progress, message } from "antd";
 import { useEffect, useRef, useState } from "react";
 import Analysis from "./Analysis";
+import PolicyReproducibility from "./PolicyReproducibility";
 import useMobile from "layout/Responsive";
 import ErrorPage from "layout/ErrorPage";
 import ResultActions from "layout/ResultActions";
@@ -153,6 +154,8 @@ export function DisplayImpact(props) {
         region={region}
       />
     );
+  } else if (impactType === "codeReproducibility") {
+    pane = <PolicyReproducibility metadata={metadata} policy={policy} />;
   }
   // Remove the below else-if block when labor supply impacts are expanded
   // back to all countries

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { DisplayEmpty, LowLevelDisplay } from "./Display";
-import PolicyReproducibility from "./PolicyReproducibility";
+
+import { DisplayEmpty } from "./Display";
 import {
   FetchAndDisplayCliffImpact,
   FetchAndDisplayImpact,
@@ -114,16 +114,7 @@ export default function PolicyOutput(props) {
   if (!reformPolicyId) {
     return <DisplayEmpty />;
   }
-  if (impactType === "codeReproducibility") {
-    return (
-      <>
-        <SignupModal setShowPolicyImpactPopup={setShowPolicyImpactPopup} />
-        <LowLevelDisplay {...props} showPolicyImpactPopup={false}>
-          <PolicyReproducibility metadata={metadata} policy={policy} />
-        </LowLevelDisplay>
-      </>
-    );
-  } else if (impactType === "cliffImpact") {
+  if (impactType === "cliffImpact") {
     return (
       <>
         <SignupModal setShowPolicyImpactPopup={setShowPolicyImpactPopup} />


### PR DESCRIPTION
## Fixes #1732 

## Changes

- moved the `PolicyReproducibility` component from `PolicyOutput` to `Display`, so it does not cause a rerender of the entire output when it mounts/unmounts. 

## Screenshots

### Before


https://github.com/user-attachments/assets/c11093a5-8770-431d-a7a7-e9b702611145

### After

https://github.com/user-attachments/assets/2c4574be-7503-444b-98fa-3fb41f95bde8

## Tests

- Ran `make test`
- Manual testing
