### PR TITLE
Reinstate Breadcrumbs

### DIFF
--- a/src/layout/MobileCalculatorPage.jsx
+++ b/src/layout/MobileCalculatorPage.jsx
@@ -354,16 +354,10 @@ function MobileTreeNavigationHolder(props) {
             margin: 0,
             fontWeight: i === breadcrumbs.length - 1 ? "normal" : "lighter",
           }}
-
           onClick={() => {
-            // eslint-disable-next-line no-console
-            console.log('type:', type);
-            // eslint-disable-next-line no-console
-            console.log('breakcrumb.name:', breadcrumb.name);              
-              let newSearch = new URLSearchParams(searchParams);
-              newSearch.set("focus", breadcrumb.name);
-              setSearchParams(newSearch);
-            
+            let newSearch = new URLSearchParams(searchParams);
+            newSearch.set("focus", breadcrumb.name);
+            setSearchParams(newSearch);
           }}
         >
           {breadcrumb.label}
@@ -426,13 +420,6 @@ export function MobileBottomNavButtons({ focus, type, metadata }) {
     previous =
       getPreviousValidFocus(options, currentIndex, validFocusValues) || {};
     next = getNextValidFocus(options, currentIndex, validFocusValues) || {};
-    // eslint-disable-next-line no-console
-    console.log('previous:', previous);
-    // eslint-disable-next-line no-console
-    console.log('next:', next);
-
-
-
   }
 
   return (

--- a/src/layout/MobileCalculatorPage.jsx
+++ b/src/layout/MobileCalculatorPage.jsx
@@ -426,6 +426,13 @@ export function MobileBottomNavButtons({ focus, type, metadata }) {
     previous =
       getPreviousValidFocus(options, currentIndex, validFocusValues) || {};
     next = getNextValidFocus(options, currentIndex, validFocusValues) || {};
+    // eslint-disable-next-line no-console
+    console.log('previous:', previous);
+    // eslint-disable-next-line no-console
+    console.log('next:', next);
+
+
+
   }
 
   return (

--- a/src/layout/MobileCalculatorPage.jsx
+++ b/src/layout/MobileCalculatorPage.jsx
@@ -276,7 +276,7 @@ function MobileBottomMenu(props) {
 function MobileTreeNavigationHolder(props) {
   const { metadata, type, buttonHeight } = props;
   // Try to find the current focus in the tree.
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const focus = searchParams.get("focus");
 
@@ -353,6 +353,17 @@ function MobileTreeNavigationHolder(props) {
             whiteSpace: "wrap",
             margin: 0,
             fontWeight: i === breadcrumbs.length - 1 ? "normal" : "lighter",
+          }}
+
+          onClick={() => {
+            // eslint-disable-next-line no-console
+            console.log('type:', type);
+            // eslint-disable-next-line no-console
+            console.log('breakcrumb.name:', breadcrumb.name);              
+              let newSearch = new URLSearchParams(searchParams);
+              newSearch.set("focus", breadcrumb.name);
+              setSearchParams(newSearch);
+            
           }}
         >
           {breadcrumb.label}

--- a/src/pages/PolicyPage.jsx
+++ b/src/pages/PolicyPage.jsx
@@ -148,18 +148,14 @@ export default function PolicyPage(props) {
         setPolicy={setPolicy}
       />
     );
-  } 
-
-  else if (Object.keys(metadata.parameters).includes(focus)) {
+  } else if (Object.keys(metadata.parameters).includes(focus)) {
     const node = findInTree({ children: [metadata.parameterTree] }, focus);
     middle = (
       <FolderPage label={node.label} metadata={metadata} inPolicySide>
         {node.children}
       </FolderPage>
     );
-  } 
-  
-  else if (isOutput) {
+  } else if (isOutput) {
     // eslint-disable-next-line no-console
     console.log("focus:" + focus);
     const POLICY_OUTPUT_TREE = getPolicyOutputTree(metadata.countryId);
@@ -169,10 +165,13 @@ export default function PolicyPage(props) {
     console.log("stripped_focus:" + stripped_focus);
     // eslint-disable-next-line no-console
     console.log("valid values:" + validFocusValues);
-  
+
     // Check if the current focus is within validFocusValues
-    if (focus === "policyOutput.policyBreakdown" ||
-      focus === "policyOutput.codeReproducibility" || validFocusValues.includes(stripped_focus)) {
+    if (
+      focus === "policyOutput.policyBreakdown" ||
+      focus === "policyOutput.codeReproducibility" ||
+      validFocusValues.includes(stripped_focus)
+    ) {
       middle = (
         <PolicyOutput
           metadata={metadata}
@@ -196,9 +195,9 @@ export default function PolicyPage(props) {
         }
         return null;
       };
-  
+
       const node = findNodeByName(POLICY_OUTPUT_TREE[0], focus);
-  
+
       // Render FolderPage with its children if the node is found
       if (node) {
         middle = (
@@ -212,7 +211,7 @@ export default function PolicyPage(props) {
         middle = <div>No matching node found.</div>;
       }
     }
-}
+  }
 
   // This code works
   // else if (isOutput && focus === "policyOutput") {

--- a/src/pages/PolicyPage.jsx
+++ b/src/pages/PolicyPage.jsx
@@ -19,6 +19,11 @@ import { Helmet } from "react-helmet";
 import SearchParamNavButton from "../controls/SearchParamNavButton";
 import style from "../style";
 import DeprecationModal from "../modals/DeprecationModal";
+import HOUSEHOLD_OUTPUT_TREE from "./household/output/tree";
+
+
+
+
 
 export function ParameterSearch(props) {
   const { metadata, callback } = props;
@@ -120,6 +125,12 @@ export default function PolicyPage(props) {
   }, [!!policy.reform.data]);
 
   let middle = null;
+  // eslint-disable-next-line no-console
+  console.log('metadata.parameters:', metadata.parameters);
+  // eslint-disable-next-line no-console
+  console.log('metadata.parameterTree:', metadata.parameterTree);
+  // eslint-disable-next-line no-console
+  console.log(Object.keys(metadata.parameters).includes(focus))
 
   if (!policy.reform.data) {
     middle = <LoadingCentered />;
@@ -147,14 +158,30 @@ export default function PolicyPage(props) {
         setPolicy={setPolicy}
       />
     );
-  } else if (Object.keys(metadata.parameters).includes(focus)) {
+  } 
+
+  else if (Object.keys(metadata.parameters).includes(focus)) {
     const node = findInTree({ children: [metadata.parameterTree] }, focus);
     middle = (
       <FolderPage label={node.label} metadata={metadata} inPolicySide>
         {node.children}
       </FolderPage>
     );
-  } else if (isOutput) {
+  } 
+  
+  else if (isOutput && focus === "policyOutput") {
+    const POLICY_OUTPUT_TREE = getPolicyOutputTree(metadata.countryId);
+    // eslint-disable-next-line no-console
+    console.log('POLICY_OUTPUT_TREE:', POLICY_OUTPUT_TREE);
+
+    middle = (
+      <FolderPage label="Policy output results" metadata={metadata}>
+        {POLICY_OUTPUT_TREE[0].children}
+      </FolderPage>
+    );
+  }
+
+  else if (isOutput && focus !== "polityOutput") {
     middle = (
       <>
         <PolicyOutput

--- a/src/pages/PolicyPage.jsx
+++ b/src/pages/PolicyPage.jsx
@@ -156,15 +156,9 @@ export default function PolicyPage(props) {
       </FolderPage>
     );
   } else if (isOutput) {
-    // eslint-disable-next-line no-console
-    console.log("focus:" + focus);
     const POLICY_OUTPUT_TREE = getPolicyOutputTree(metadata.countryId);
     const validFocusValues = impactKeys;
     const stripped_focus = focus.replace("policyOutput.", "");
-    // eslint-disable-next-line no-console
-    console.log("stripped_focus:" + stripped_focus);
-    // eslint-disable-next-line no-console
-    console.log("valid values:" + validFocusValues);
 
     // Check if the current focus is within validFocusValues
     if (
@@ -206,37 +200,10 @@ export default function PolicyPage(props) {
           </FolderPage>
         );
       } else {
-        // eslint-disable-next-line no-console
-        console.log("no node");
-        middle = <div>No matching node found.</div>;
+        middle = <div>Page cannot be found.</div>;
       }
     }
   }
-
-  // This code works
-  // else if (isOutput && focus === "policyOutput") {
-  //   const POLICY_OUTPUT_TREE = getPolicyOutputTree(metadata.countryId);
-  //   // eslint-disable-next-line no-console
-  //   console.log('POLICY_OUTPUT_TREE:', POLICY_OUTPUT_TREE);
-
-  //   middle = (
-  //     <FolderPage label="Policy output results" metadata={metadata}>
-  //       {POLICY_OUTPUT_TREE[0].children}
-  //     </FolderPage>
-  //   );
-  // }
-
-  // else if (isOutput && focus !== "policyOutput") {
-  //   middle = (
-  //     <>
-  //       <PolicyOutput
-  //         metadata={metadata}
-  //         policy={policy}
-  //         userProfile={userProfile}
-  //       />
-  //     </>
-  //   );
-  // }
 
   if (mobile) {
     return (

--- a/src/pages/PolicyPage.jsx
+++ b/src/pages/PolicyPage.jsx
@@ -19,11 +19,7 @@ import { Helmet } from "react-helmet";
 import SearchParamNavButton from "../controls/SearchParamNavButton";
 import style from "../style";
 import DeprecationModal from "../modals/DeprecationModal";
-import HOUSEHOLD_OUTPUT_TREE from "./household/output/tree";
-
-
-
-
+import { impactKeys } from "../pages/policy/output/ImpactTypes.jsx";
 
 export function ParameterSearch(props) {
   const { metadata, callback } = props;
@@ -125,12 +121,6 @@ export default function PolicyPage(props) {
   }, [!!policy.reform.data]);
 
   let middle = null;
-  // eslint-disable-next-line no-console
-  console.log('metadata.parameters:', metadata.parameters);
-  // eslint-disable-next-line no-console
-  console.log('metadata.parameterTree:', metadata.parameterTree);
-  // eslint-disable-next-line no-console
-  console.log(Object.keys(metadata.parameters).includes(focus))
 
   if (!policy.reform.data) {
     middle = <LoadingCentered />;
@@ -169,29 +159,85 @@ export default function PolicyPage(props) {
     );
   } 
   
-  else if (isOutput && focus === "policyOutput") {
-    const POLICY_OUTPUT_TREE = getPolicyOutputTree(metadata.countryId);
+  else if (isOutput) {
     // eslint-disable-next-line no-console
-    console.log('POLICY_OUTPUT_TREE:', POLICY_OUTPUT_TREE);
-
-    middle = (
-      <FolderPage label="Policy output results" metadata={metadata}>
-        {POLICY_OUTPUT_TREE[0].children}
-      </FolderPage>
-    );
-  }
-
-  else if (isOutput && focus !== "polityOutput") {
-    middle = (
-      <>
+    console.log("focus:" + focus);
+    const POLICY_OUTPUT_TREE = getPolicyOutputTree(metadata.countryId);
+    const validFocusValues = impactKeys;
+    const stripped_focus = focus.replace("policyOutput.", "");
+    // eslint-disable-next-line no-console
+    console.log("stripped_focus:" + stripped_focus);
+    // eslint-disable-next-line no-console
+    console.log("valid values:" + validFocusValues);
+  
+    // Check if the current focus is within validFocusValues
+    if (focus === "policyOutput.policyBreakdown" ||
+      focus === "policyOutput.codeReproducibility" || validFocusValues.includes(stripped_focus)) {
+      middle = (
         <PolicyOutput
           metadata={metadata}
           policy={policy}
           userProfile={userProfile}
         />
-      </>
-    );
-  }
+      );
+    } else {
+      // Find the node in the tree where the name matches the focus
+      const findNodeByName = (node, name) => {
+        if (node.name === name) {
+          return node;
+        }
+        if (node.children) {
+          for (let child of node.children) {
+            const result = findNodeByName(child, name);
+            if (result) {
+              return result;
+            }
+          }
+        }
+        return null;
+      };
+  
+      const node = findNodeByName(POLICY_OUTPUT_TREE[0], focus);
+  
+      // Render FolderPage with its children if the node is found
+      if (node) {
+        middle = (
+          <FolderPage label={node.label} metadata={metadata}>
+            {node.children}
+          </FolderPage>
+        );
+      } else {
+        // eslint-disable-next-line no-console
+        console.log("no node");
+        middle = <div>No matching node found.</div>;
+      }
+    }
+}
+
+  // This code works
+  // else if (isOutput && focus === "policyOutput") {
+  //   const POLICY_OUTPUT_TREE = getPolicyOutputTree(metadata.countryId);
+  //   // eslint-disable-next-line no-console
+  //   console.log('POLICY_OUTPUT_TREE:', POLICY_OUTPUT_TREE);
+
+  //   middle = (
+  //     <FolderPage label="Policy output results" metadata={metadata}>
+  //       {POLICY_OUTPUT_TREE[0].children}
+  //     </FolderPage>
+  //   );
+  // }
+
+  // else if (isOutput && focus !== "policyOutput") {
+  //   middle = (
+  //     <>
+  //       <PolicyOutput
+  //         metadata={metadata}
+  //         policy={policy}
+  //         userProfile={userProfile}
+  //       />
+  //     </>
+  //   );
+  // }
 
   if (mobile) {
     return (


### PR DESCRIPTION
Reinstates logic for clicking breadcrumbs in mobile to serve as navigation. 

Note that clicking breadcrumbs were disabled as part of #1947.

## Description

Fixes #2022 
1. Adds back in onClick logic
2. Adds logic to check if the focus has a page associated with it, or if it has children in the tree. If it has children in the tree, the folderpage with the children is returned. If it has a page, then the PolicyOutput page is returned. 

## Screenshots
https://www.loom.com/share/79ab325e6fa0402eb70b7bef0cff72f8?sid=cff59996-d6e2-40ad-a00e-a5e8b0c36868

## Tests

Tested locally (created new policy, clicked through each policy, compared to tree to ensure no pages are missing). 

Also ran  test suite. 8 are failing but not due to any of these changes. I compared to the master branch and all 8 were failing there too.
