### PR TITLE
solves undefined variable employment_income error in Marginal tax Rates

### DIFF
--- a/src/api/variables.js
+++ b/src/api/variables.js
@@ -356,7 +356,7 @@ export function getValueFromHousehold(
   }
   if (!timePeriodValues) {
     console.error("Error getting variable value", variable);
-    return null;
+    return 0;
   }
   if (!timePeriod) {
     const possibleTimePeriods = Object.keys(timePeriodValues);

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -51,6 +51,7 @@ export default function MarginalTaxRates(props) {
     householdInput,
     metadata,
   );
+
   const currentMtr = getValueFromHousehold(
     "marginal_tax_rate",
     year,
@@ -61,7 +62,11 @@ export default function MarginalTaxRates(props) {
 
   useEffect(() => {
     let householdData = JSON.parse(JSON.stringify(householdInput));
+    // Ensure 'employment_income' exists for the current user and initialize if necessary
+    householdData.people.you.employment_income =
+      householdData.people.you.employment_income ?? {};
     householdData.people.you.employment_income[year] = null;
+
     householdData.axes = [
       [
         {

--- a/src/pages/household/output/MarginalTaxRates.jsx
+++ b/src/pages/household/output/MarginalTaxRates.jsx
@@ -63,8 +63,9 @@ export default function MarginalTaxRates(props) {
   useEffect(() => {
     let householdData = JSON.parse(JSON.stringify(householdInput));
     // Ensure 'employment_income' exists for the current user and initialize if necessary
+    householdData.people.you = householdData.people.you || {};
     householdData.people.you.employment_income =
-      householdData.people.you.employment_income ?? {};
+      householdData.people.you.employment_income || {};
     householdData.people.you.employment_income[year] = null;
 
     householdData.axes = [


### PR DESCRIPTION
Fixes #2039

solution enables existing code to work as expected even if parts of the object are missing