### PR TITLE
Remove UK election banner

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -9,12 +9,8 @@ import HomeTransparency from "./home/HomeTransparency";
 import Footer from "../layout/Footer";
 import HomeQuoteCarousel from "./home/HomeQuoteCarousel";
 import { Helmet } from "react-helmet";
-import useCountryId from "../hooks/useCountryId";
-import HomeElectionBanner from "./home/HomeElectionBanner";
 
 export default function Home() {
-  const countryId = useCountryId();
-
   return (
     <>
       <Helmet>
@@ -23,7 +19,6 @@ export default function Home() {
       <div>
         <Header />
         <HomeLanding />
-        {countryId === "uk" && <HomeElectionBanner />}
         <HomeUsedBy />
         <HomeBlogPreview />
         <HomeSubscribe />

--- a/src/pages/home/HomeElectionBanner.jsx
+++ b/src/pages/home/HomeElectionBanner.jsx
@@ -4,6 +4,12 @@ import westminster from "../../images/home/westminster.jpg";
 import useDisplayCategory from "../../hooks/useDisplayCategory";
 import { useWindowWidth } from "../../hooks/useWindow";
 
+/**
+ * UK 2024 general election banner from home page. If used again,
+ * at breakpoints around 900px, the text content should push upward
+ * on the banner instead of overflowing.
+ * @returns {JSX.Element}
+ */
 export default function HomeElectionBanner() {
   const dC = useDisplayCategory();
   const windowWidth = useWindowWidth();


### PR DESCRIPTION
## Description

Fixes #2120.

## Changes

Removes UK election banner, but leaves its component (with recommendation for change) for any similar future events.

## Screenshots

N/A

## Tests

N/A
