### PR TITLE
Update endpoints to use hyphens instead of underscores

### DIFF
--- a/src/PolicyEngine.jsx
+++ b/src/PolicyEngine.jsx
@@ -190,7 +190,7 @@ export default function PolicyEngine() {
   const { isAuthenticated, user } = useAuth0();
   useEffect(() => {
     async function fetchUserProfile() {
-      const USER_PROFILE_PATH = `/${countryId}/user_profile`;
+      const USER_PROFILE_PATH = `/${countryId}/user-profile`;
       // Determine if user already exists in user profile db
       try {
         const resGet = await apiCall(

--- a/src/api/userPolicies.js
+++ b/src/api/userPolicies.js
@@ -1,7 +1,7 @@
 import { wrappedResponseJson } from "../data/wrappedJson";
 import { apiCall } from "./call";
 
-const USER_POLICY_ENDPOINT = "/user_policy";
+const USER_POLICY_ENDPOINT = "/user-policy";
 
 export async function postUserPolicy(countryId, policyToAdd) {
   // Prevent creation of records where baseline and reform are the same;

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -85,7 +85,7 @@ export default function UserProfilePage(props) {
       if (metadata) {
         try {
           const data = await apiCall(
-            `/${countryId}/user_profile?user_id=${accessedUserId}`,
+            `/${countryId}/user-profile?user_id=${accessedUserId}`,
           );
           const dataJson = await data.json();
           if (data.status === 404 && dataJson.status === "ok") {
@@ -125,7 +125,7 @@ export default function UserProfilePage(props) {
       if (metadata) {
         try {
           const data = await apiCall(
-            `/${countryId}/user_policy/${accessedUserId}`,
+            `/${countryId}/user-policy/${accessedUserId}`,
           );
           const dataJson = await data.json();
           if (data.status < 200 || data.status >= 300) {
@@ -555,7 +555,7 @@ function UsernameDisplayAndEditor(props) {
   }
 
   async function handleSubmit() {
-    const USER_PROFILE_PATH = `/${countryId}/user_profile`;
+    const USER_PROFILE_PATH = `/${countryId}/user-profile`;
     const body = {
       user_id: accessedUserProfile.user_id,
       username: value,
@@ -566,7 +566,7 @@ function UsernameDisplayAndEditor(props) {
       const resJson = await wrappedResponseJson(res);
       if (resJson.status === "ok") {
         const data = await apiCall(
-          `/${countryId}/user_profile?user_id=${accessedUserProfile.user_id}`,
+          `/${countryId}/user-profile?user_id=${accessedUserProfile.user_id}`,
         );
         const dataJson = await data.json();
         if (data.status === 404 && dataJson.status === "ok") {


### PR DESCRIPTION
## Description

Fixes #2122 

## Changes

Updated endpoint names to use hyphens instead of underscores following similar changes in the API

## Depends on 

This requires [#1891 (update api endpoints to use hyphens)](https://github.com/PolicyEngine/policyengine-api/pull/1891) on the API to be merged. 


