### PR TITLE
Hot-fix remove of invalid deciles in charts

### DIFF
--- a/src/pages/policy/output/decile/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/decile/AverageImpactByDecile.jsx
@@ -135,6 +135,14 @@ export function ImpactPlot(props) {
 export default function averageImpactByDecile(props) {
   const { impact, policyLabel, metadata, mobile, useHoverCard = false } = props;
   const decileAverage = impact.decile.average;
+
+  // Hot fix to be removed to avoid deciles outside of 1-10
+  Object.keys(decileAverage).map((key) => {
+    if (key > 10 || key < 1) {
+      delete decileAverage[key];
+    }
+  });
+
   const averageChange =
     -impact.budget.budgetary_impact / impact.budget.households;
   const chart = (

--- a/src/pages/policy/output/decile/AverageImpactByDecile.jsx
+++ b/src/pages/policy/output/decile/AverageImpactByDecile.jsx
@@ -137,7 +137,7 @@ export default function averageImpactByDecile(props) {
   const decileAverage = impact.decile.average;
 
   // Hot fix to be removed to avoid deciles outside of 1-10
-  Object.keys(decileAverage).map((key) => {
+  Object.keys(decileAverage).forEach((key) => {
     if (key > 10 || key < 1) {
       delete decileAverage[key];
     }

--- a/src/pages/policy/output/decile/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/decile/RelativeImpactByDecile.jsx
@@ -128,7 +128,7 @@ export default function relativeImpactByDecile(props) {
   const decileRelative = impact.decile.relative;
 
   // Hot fix to be removed to avoid deciles outside of 1-10
-  Object.keys(decileRelative).map((key) => {
+  Object.keys(decileRelative).forEach((key) => {
     if (key > 10 || key < 1) {
       delete decileRelative[key];
     }

--- a/src/pages/policy/output/decile/RelativeImpactByDecile.jsx
+++ b/src/pages/policy/output/decile/RelativeImpactByDecile.jsx
@@ -126,6 +126,14 @@ export function ImpactPlot(props) {
 export default function relativeImpactByDecile(props) {
   const { impact, policyLabel, metadata, mobile, useHoverCard = false } = props;
   const decileRelative = impact.decile.relative;
+
+  // Hot fix to be removed to avoid deciles outside of 1-10
+  Object.keys(decileRelative).map((key) => {
+    if (key > 10 || key < 1) {
+      delete decileRelative[key];
+    }
+  });
+
   const relativeChange =
     -impact.budget.budgetary_impact / impact.budget.baseline_net_income;
   const chart = (


### PR DESCRIPTION
## Description

Fixes #2136.

## Changes

Temporarily drops any invalid deciles from the calculated data object when plotting as a chart on the front end.

## Screenshots

This is taken when running these changes http://localhost:3000/us/policy?reform=68397&focus=policyOutput.laborSupplyImpact.earnings.byDecile.relative.substitution&region=enhanced_us&timePeriod=2026&baseline=2, the original reproduction from #2101.
<img width="648" alt="Screen Shot 2024-10-25 at 6 51 50 PM" src="https://github.com/user-attachments/assets/6c833833-cdf0-4c03-b8f5-888e87c549c1">

## Tests

N/A
