### PR TITLE
Change PolicyRightSidebar buttons to blue

### DIFF
--- a/src/controls/Button.jsx
+++ b/src/controls/Button.jsx
@@ -15,6 +15,18 @@ export const buttonStyles = {
       color: colors.WHITE,
     },
   },
+  primaryBlue: {
+    standard: {
+      backgroundColor: colors.BLUE_PRIMARY,
+      borderColor: colors.BLUE_PRIMARY,
+      color: colors.WHITE,
+    },
+    hover: {
+      backgroundColor: colors.BLUE_PRESSED,
+      borderColor: colors.BLUE_PRESSED,
+      color: colors.WHITE,
+    },
+  },
   secondary: {
     standard: {
       backgroundColor: "transparent",

--- a/src/pages/policy/PolicySearch.jsx
+++ b/src/pages/policy/PolicySearch.jsx
@@ -172,7 +172,7 @@ export default function PolicySearch(props) {
         )}
         <Tooltip title="Use this policy; it will replace your current policy">
           <Button
-            type="primary"
+            type="primaryBlue"
             onClick={handleCheckmarkButton}
             style={{
               padding: "unset",


### PR DESCRIPTION
## Description
Curious to hear if this is an improvement stylistically.

Fixes #2112 

## Changes

Changes the `Button` component to have a new `primaryBlue` setting, then uses that to change button color on PolicyRightSidebar

## Screenshots

[AwesomeScreenshot-10_28_2024,10_38_19PM.webm](https://github.com/user-attachments/assets/565c72f7-d24d-4cc8-af19-45447d7d7b1a)

## Tests

N/A
