### PR TITLE
Americanize country agnostic code

### DIFF
--- a/src/pages/policy/output/ImpactTypes.jsx
+++ b/src/pages/policy/output/ImpactTypes.jsx
@@ -13,19 +13,19 @@ import povertyImpactByGender from "./poverty/PovertyImpactByGender";
 import povertyImpactByRace from "./poverty/PovertyImpactByRace";
 import relativeImpactByDecile from "./decile/RelativeImpactByDecile";
 import relativeImpactByWealthDecile from "./decile/RelativeImpactByWealthDecile";
-import LaborSupplyResponseAbsolute from "./labourSupply/LaborSupplyResponseAbsolute";
-import LaborSupplyResponseRelative from "./labourSupply/LaborSupplyResponseRelative";
-import lsrHoursImpact from "./labourSupply/LaborSupplyHoursImpact";
+import LaborSupplyResponseAbsolute from "./laborSupply/LaborSupplyResponseAbsolute";
+import LaborSupplyResponseRelative from "./laborSupply/LaborSupplyResponseRelative";
+import lsrHoursImpact from "./laborSupply/LaborSupplyHoursImpact";
 import {
-  LabourSupplyDecileAbsoluteImpactIncome,
-  LabourSupplyDecileAbsoluteImpactSubstitution,
-  LabourSupplyDecileAbsoluteImpactTotal,
-} from "./labourSupply/LabourSupplyDecileAbsoluteImpacts";
+  LaborSupplyDecileAbsoluteImpactIncome,
+  LaborSupplyDecileAbsoluteImpactSubstitution,
+  LaborSupplyDecileAbsoluteImpactTotal,
+} from "./laborSupply/LaborSupplyDecileAbsoluteImpacts";
 import {
-  LabourSupplyDecileRelativeImpactIncome,
-  LabourSupplyDecileRelativeImpactSubstitution,
-  LabourSupplyDecileRelativeImpactTotal,
-} from "./labourSupply/LabourSupplyDecileRelativeImpacts";
+  LaborSupplyDecileRelativeImpactIncome,
+  LaborSupplyDecileRelativeImpactSubstitution,
+  LaborSupplyDecileRelativeImpactTotal,
+} from "./laborSupply/LaborSupplyDecileRelativeImpacts";
 import Analysis from "./Analysis";
 
 const map = {
@@ -47,17 +47,17 @@ const map = {
   "laborSupplyImpact.earnings.overall.absolute": LaborSupplyResponseAbsolute,
   "laborSupplyImpact.earnings.overall.relative": LaborSupplyResponseRelative,
   "laborSupplyImpact.earnings.byDecile.relative.total":
-    LabourSupplyDecileRelativeImpactTotal,
+    LaborSupplyDecileRelativeImpactTotal,
   "laborSupplyImpact.earnings.byDecile.relative.income":
-    LabourSupplyDecileRelativeImpactIncome,
+    LaborSupplyDecileRelativeImpactIncome,
   "laborSupplyImpact.earnings.byDecile.relative.substitution":
-    LabourSupplyDecileRelativeImpactSubstitution,
+    LaborSupplyDecileRelativeImpactSubstitution,
   "laborSupplyImpact.earnings.byDecile.absolute.total":
-    LabourSupplyDecileAbsoluteImpactTotal,
+    LaborSupplyDecileAbsoluteImpactTotal,
   "laborSupplyImpact.earnings.byDecile.absolute.income":
-    LabourSupplyDecileAbsoluteImpactIncome,
+    LaborSupplyDecileAbsoluteImpactIncome,
   "laborSupplyImpact.earnings.byDecile.absolute.substitution":
-    LabourSupplyDecileAbsoluteImpactSubstitution,
+    LaborSupplyDecileAbsoluteImpactSubstitution,
   "laborSupplyImpact.hours": lsrHoursImpact,
   analysis: Analysis,
 };

--- a/src/pages/policy/output/laborSupply/LaborSupplyDecileAbsoluteImpacts.jsx
+++ b/src/pages/policy/output/laborSupply/LaborSupplyDecileAbsoluteImpacts.jsx
@@ -1,20 +1,20 @@
 import { formatCurrencyAbbr } from "../../../../lang/format";
 import {
-  LabourSupplyDecileIncome,
-  LabourSupplyDecileSubstitution,
-  LabourSupplyDecileTotal,
-} from "./LabourSupplyDecileCharts";
+  LaborSupplyDecileIncome,
+  LaborSupplyDecileSubstitution,
+  LaborSupplyDecileTotal,
+} from "./LaborSupplyDecileCharts";
 
-export function LabourSupplyDecileAbsoluteImpactIncome(props) {
+export function LaborSupplyDecileAbsoluteImpactIncome(props) {
   const { policyLabel, impact, countryId } = props;
 
-  const decileImpact = impact.labour_supply_response;
+  const decileImpact = impact.labor_supply_response;
 
   const data = decileImpact.decile.average;
 
   const incomeChanges = Object.values(data.income).slice(0, 10);
 
-  const title = `${policyLabel}'s income effect-driven absolute labor supply impact by decile`;
+  const title = `${policyLabel}'s income effect-driven absolute ${countryId === "us" ? "labor" : "labour"} supply impact by decile`;
   const description =
     "This chart shows the estimated income effect-driven absolute " +
     `change in earnings (in ${countryId === "uk" ? "pounds" : "dollars"}) ` +
@@ -31,7 +31,7 @@ export function LabourSupplyDecileAbsoluteImpactIncome(props) {
   };
 
   const chart = (
-    <LabourSupplyDecileIncome
+    <LaborSupplyDecileIncome
       title={title}
       incomeChanges={incomeChanges}
       countryId={countryId}
@@ -45,16 +45,16 @@ export function LabourSupplyDecileAbsoluteImpactIncome(props) {
   return { chart: chart, csv: () => {} };
 }
 
-export function LabourSupplyDecileAbsoluteImpactSubstitution(props) {
+export function LaborSupplyDecileAbsoluteImpactSubstitution(props) {
   const { policyLabel, impact, countryId } = props;
 
-  const decileImpact = impact.labour_supply_response;
+  const decileImpact = impact.labor_supply_response;
 
   const data = decileImpact.decile.average;
 
   let substitutionChanges = Object.values(data.substitution).slice(0, 10);
 
-  const title = `${policyLabel}'s substitution effect-driven absolute labor supply impact by decile`;
+  const title = `${policyLabel}'s substitution effect-driven absolute ${countryId === "us" ? "labor" : "labour"} supply impact by decile`;
   const description =
     "This chart shows the estimated substitution effect-driven " +
     `absolute change in earnings (in ${countryId === "uk" ? "pounds" : "dollars"}) ` +
@@ -70,7 +70,7 @@ export function LabourSupplyDecileAbsoluteImpactSubstitution(props) {
     );
   };
   const chart = (
-    <LabourSupplyDecileSubstitution
+    <LaborSupplyDecileSubstitution
       title={title}
       substitutionChanges={substitutionChanges}
       countryId={countryId}
@@ -84,10 +84,10 @@ export function LabourSupplyDecileAbsoluteImpactSubstitution(props) {
   return { chart: chart, csv: () => {} };
 }
 
-export function LabourSupplyDecileAbsoluteImpactTotal(props) {
+export function LaborSupplyDecileAbsoluteImpactTotal(props) {
   const { policyLabel, impact, countryId } = props;
 
-  const decileImpact = impact.labour_supply_response;
+  const decileImpact = impact.labor_supply_response;
 
   const data = decileImpact.decile.average;
 
@@ -98,7 +98,7 @@ export function LabourSupplyDecileAbsoluteImpactTotal(props) {
     overallChange.push(incomeChanges[i] + substitutionChanges[i]);
   }
 
-  const title = `${policyLabel}'s absolute labor supply impact by decile`;
+  const title = `${policyLabel}'s absolute ${countryId === "us" ? "labor" : "labour"} supply impact by decile`;
   const description =
     "This chart shows the estimated total absolute change in earnings (in " +
     `${countryId === "uk" ? " pounds" : " dollars"}) for each disposable ` +
@@ -115,7 +115,7 @@ export function LabourSupplyDecileAbsoluteImpactTotal(props) {
   };
 
   const chart = (
-    <LabourSupplyDecileTotal
+    <LaborSupplyDecileTotal
       title={title}
       overallChange={overallChange}
       countryId={countryId}

--- a/src/pages/policy/output/laborSupply/LaborSupplyDecileCharts.jsx
+++ b/src/pages/policy/output/laborSupply/LaborSupplyDecileCharts.jsx
@@ -5,7 +5,7 @@ import { localeCode } from "../../../../lang/format";
 import { ChartLogo } from "../../../../api/charts";
 import { plotLayoutFont } from "../utils";
 
-export function LabourSupplyDecileIncome(props) {
+export function LaborSupplyDecileIncome(props) {
   const {
     title,
     incomeChanges,
@@ -72,7 +72,7 @@ export function LabourSupplyDecileIncome(props) {
   );
 }
 
-export function LabourSupplyDecileSubstitution(props) {
+export function LaborSupplyDecileSubstitution(props) {
   const {
     title,
     substitutionChanges,
@@ -139,7 +139,7 @@ export function LabourSupplyDecileSubstitution(props) {
   );
 }
 
-export function LabourSupplyDecileTotal(props) {
+export function LaborSupplyDecileTotal(props) {
   const {
     title,
     yAxisTitle,

--- a/src/pages/policy/output/laborSupply/LaborSupplyDecileRelativeImpacts.jsx
+++ b/src/pages/policy/output/laborSupply/LaborSupplyDecileRelativeImpacts.jsx
@@ -1,20 +1,20 @@
 import { formatPercent } from "../../../../lang/format";
 import {
-  LabourSupplyDecileIncome,
-  LabourSupplyDecileSubstitution,
-  LabourSupplyDecileTotal,
-} from "./LabourSupplyDecileCharts";
+  LaborSupplyDecileIncome,
+  LaborSupplyDecileSubstitution,
+  LaborSupplyDecileTotal,
+} from "./LaborSupplyDecileCharts";
 
-export function LabourSupplyDecileRelativeImpactIncome(props) {
+export function LaborSupplyDecileRelativeImpactIncome(props) {
   const { policyLabel, impact, countryId } = props;
 
-  const decileImpact = impact.labour_supply_response;
+  const decileImpact = impact.labor_supply_response;
 
   const data = decileImpact.decile.relative;
 
   const incomeChanges = Object.values(data.income).slice(0, 10);
 
-  const title = `${policyLabel}'s income effect-driven relative labor supply impact by decile`;
+  const title = `${policyLabel}'s income effect-driven relative ${countryId === "us" ? "labor" : "labour"} supply impact by decile`;
   const description =
     "This chart shows only the income effect-driven portion of " +
     "the estimated relative change in earnings (as a percentage " +
@@ -32,7 +32,7 @@ export function LabourSupplyDecileRelativeImpactIncome(props) {
   };
 
   const chart = (
-    <LabourSupplyDecileIncome
+    <LaborSupplyDecileIncome
       title={title}
       incomeChanges={incomeChanges}
       countryId={countryId}
@@ -46,15 +46,15 @@ export function LabourSupplyDecileRelativeImpactIncome(props) {
   return { chart: chart, csv: () => {} };
 }
 
-export function LabourSupplyDecileRelativeImpactSubstitution(props) {
+export function LaborSupplyDecileRelativeImpactSubstitution(props) {
   const { policyLabel, impact, countryId } = props;
 
-  const decileImpact = impact.labour_supply_response;
+  const decileImpact = impact.labor_supply_response;
 
   const data = decileImpact.decile.relative;
 
   let substitutionChanges = Object.values(data.substitution).slice(0, 10);
-  const title = `${policyLabel}'s substitution effect-driven relative labor supply impact by decile`;
+  const title = `${policyLabel}'s substitution effect-driven relative ${countryId === "us" ? "labor" : "labour"} supply impact by decile`;
   const description =
     "This chart shows only the substitution effect-driven portion of " +
     "the estimated relative change in earnings (as a percentage " +
@@ -71,7 +71,7 @@ export function LabourSupplyDecileRelativeImpactSubstitution(props) {
   };
 
   const chart = (
-    <LabourSupplyDecileSubstitution
+    <LaborSupplyDecileSubstitution
       title={title}
       substitutionChanges={substitutionChanges}
       countryId={countryId}
@@ -85,10 +85,10 @@ export function LabourSupplyDecileRelativeImpactSubstitution(props) {
   return { chart: chart, csv: () => {} };
 }
 
-export function LabourSupplyDecileRelativeImpactTotal(props) {
+export function LaborSupplyDecileRelativeImpactTotal(props) {
   const { policyLabel, impact, countryId } = props;
 
-  const decileImpact = impact.labour_supply_response;
+  const decileImpact = impact.labor_supply_response;
 
   const data = decileImpact.decile.relative;
 
@@ -99,7 +99,7 @@ export function LabourSupplyDecileRelativeImpactTotal(props) {
     overallChange.push(incomeChanges[i] + substitutionChanges[i]);
   }
 
-  const title = `${policyLabel}'s relative labor supply impact by decile`;
+  const title = `${policyLabel}'s relative ${countryId === "us" ? "labor" : "labour"} supply impact by decile`;
   const description =
     "This chart shows the estimated relative change in earnings (as a " +
     "percentage of total earnings) for each disposable income decile.";
@@ -115,7 +115,7 @@ export function LabourSupplyDecileRelativeImpactTotal(props) {
   };
 
   const chart = (
-    <LabourSupplyDecileTotal
+    <LaborSupplyDecileTotal
       title={title}
       overallChange={overallChange}
       countryId={countryId}

--- a/src/pages/policy/output/laborSupply/LaborSupplyResponseAbsolute.jsx
+++ b/src/pages/policy/output/laborSupply/LaborSupplyResponseAbsolute.jsx
@@ -106,8 +106,8 @@ function title(policyLabel, change, metadata) {
 
 export default function lsrImpactAbsolute(props) {
   const { impact, policyLabel, metadata, mobile } = props;
-  const incomeEffect = impact.labour_supply_response.income_lsr;
-  const substitutionEffect = impact.labour_supply_response.substitution_lsr;
+  const incomeEffect = impact.labor_supply_response.income_lsr;
+  const substitutionEffect = impact.labor_supply_response.substitution_lsr;
 
   const labels = ["Income effect", "Substitution effect", "Net change"];
   const values = [


### PR DESCRIPTION
## Description

Fixes #2148 

## Changes

- Changed all country-agnostic instances of 'labour" to 'labor'
- renamed functions/modules to use 'labor'
- checking `country_id` to return appropriate spelling in titles

## Tests

Automated tests: `make test` passed

## Depends on

This requires [#1906 (Americanize country agnostic code)](https://github.com/PolicyEngine/policyengine-api/pull/1906) in the API to be merged.