### PR TITLE
Remove sub-box from US election banner

### DIFF
--- a/src/pages/home/HomeElectionBanner.jsx
+++ b/src/pages/home/HomeElectionBanner.jsx
@@ -23,8 +23,8 @@ const primaryArticles = [
   {
     title: "Trump Economic Agenda",
     shortTitle: "Trump Economic Agenda",
-    link: "/us/research/trump-2024"
-  }
+    link: "/us/research/trump-2024",
+  },
 ];
 
 const secondaryArticles = [

--- a/src/pages/home/HomeElectionBanner.jsx
+++ b/src/pages/home/HomeElectionBanner.jsx
@@ -23,8 +23,8 @@ const primaryArticles = [
   {
     title: "Trump Economic Agenda",
     shortTitle: "Trump Economic Agenda",
-    link: "/us/research/trump-2024",
-  },
+    link: "/us/research/trump-2024"
+  }
 ];
 
 const secondaryArticles = [
@@ -138,7 +138,6 @@ export default function HomeElectionBanner() {
             style={{
               minHeight: "fit-content",
               width: "100%",
-              backgroundColor: "rgba(44, 100, 150, 0.88)",
               display: "flex",
               flexDirection: "column",
               padding: "24px",
@@ -240,7 +239,6 @@ export default function HomeElectionBanner() {
               // instead of 100% since this behavior only desired at select
               // visual breakpoint (like 800px width)
               width: "min(600px, 92%)",
-              backgroundColor: "rgba(44, 100, 150, 0.88)",
               display: "flex",
               flexDirection: "column",
               padding: "48px",


### PR DESCRIPTION
## Description

Fixes #2176.

## Changes

Removes visual element of sub-box from US election banner. Technically, the box itself (the div) has to remain to allow for proper spacing and to allow us to handle the background image properly.

## Screenshots

[AwesomeScreenshot-10_31_2024,9_05_44PM.webm](https://github.com/user-attachments/assets/e48541cd-d339-4bb7-95a4-ed0b39085650)

## Tests

N/A
