### PR TITLE
Repair wrappedJsonStringify, modify reformDefinitionCode

### DIFF
--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -49,6 +49,13 @@ export function getHeaderCode(type, metadata, policy) {
     lines.push("from policyengine_core.reforms import Reform");
   }
 
+  // If either baseline or reform contains Infinity or -Infinity, 
+  // add the following Python imports
+  const allValues = getAllPolicyValues(policy);
+  if (allValues.some((value) => value === Infinity || value === -Infinity)) {
+    lines.push("import numpy as np");
+  }
+
   return lines;
 }
 
@@ -261,6 +268,30 @@ export function doesParamNameContainNumber(paramName) {
 }
 
 /**
+ * Given a standard "policy" object, get all individual
+ * values for both the baseline and reform policies
+ * @param {Object} policy 
+ * @returns {Array<Number | String >} An array of values
+ */
+export function getAllPolicyValues(policy) {
+  const { baseline, reform } = policy;
+
+  /** @type {Array<Object>} */
+  let valueSettings = [];
+
+  for (const policy of [baseline, reform]) {
+    const values = Object.values(policy.data);
+    valueSettings = valueSettings.concat(values);
+  }
+
+  const output = valueSettings.reduce((accu, item) => {
+    return accu.concat(...Object.values(item));
+  }, []);
+
+  return output;
+}
+
+/**
  * Utility function to sanitize a string and ensure that it's valid Python;
  * currently converts JS 'null', 'true', 'false', '"Infinity"', and '"-Infinity"' to Python
  * @param {String} string
@@ -271,6 +302,6 @@ export function sanitizeStringToPython(string) {
     .replace(/true/g, "True")
     .replace(/false/g, "False")
     .replace(/null/g, "None")
-    .replace(/"Infinity"/g, ".inf")
-    .replace(/"-Infinity"/g, "-.inf");
+    .replace(/"Infinity"/g, "np.inf")
+    .replace(/"-Infinity"/g, "-np.inf");
 }

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -49,7 +49,7 @@ export function getHeaderCode(type, metadata, policy) {
     lines.push("from policyengine_core.reforms import Reform");
   }
 
-  // If either baseline or reform contains Infinity or -Infinity, 
+  // If either baseline or reform contains Infinity or -Infinity,
   // add the following Python imports
   const allValues = getAllPolicyValues(policy);
   if (allValues.some((value) => value === Infinity || value === -Infinity)) {
@@ -270,7 +270,7 @@ export function doesParamNameContainNumber(paramName) {
 /**
  * Given a standard "policy" object, get all individual
  * values for both the baseline and reform policies
- * @param {Object} policy 
+ * @param {Object} policy
  * @returns {Array<Number | String >} An array of values
  */
 export function getAllPolicyValues(policy) {

--- a/src/data/wrappedJson.js
+++ b/src/data/wrappedJson.js
@@ -37,7 +37,15 @@ export function wrappedJsonParse() {
 }
 
 export function wrappedJsonStringify() {
-  return JSON.stringify(...arguments, JsonReplacer);
+  // json.stringify's second argument is a replacer function
+  // Because JS doesn't allow passing params by name (akin to Python),
+  // we need to specifically override the second arg to allow
+  // callers of wrappedJsonStringify to pass later args,
+  // such as JSON.stringify's 3rd arg, the space arg.
+
+  let modifiedArgs = [...arguments];
+  modifiedArgs[1] = JsonReplacer;
+  return JSON.stringify(...modifiedArgs);
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #2106.

## Changes

Previously, we improperly handled advanced features of `JSON.stringify()` within `wrappedJsonStringify`, causing the Reproduce in Python page to treat `Infinity` as `null`. Further, we had no means of importing `numpy` in the Reproduce in Python output. This PR changes `wrappedJsonStringify` to properly handle more than two arguments to `JSON.stringify()` and modifies `reformDefinitionCode` to check if any baseline or reform values are infinite, at which point it adds a line to import numpy.

## Screenshots

[AwesomeScreenshot-10_31_2024,9_15_43PM.webm](https://github.com/user-attachments/assets/a75786be-ffd5-4306-b4c3-e2c6e2558084)

## Tests

The code output was tested within a local run of `-us` and appears to work correctly.
