### PR TITLE
Remove deprecated prop in antd Drawer

### DIFF
--- a/src/layout/MobileCalculatorPage.jsx
+++ b/src/layout/MobileCalculatorPage.jsx
@@ -534,13 +534,15 @@ function PolicyDrawerButton({ policy, metadata, buttonHeight }) {
         placement="bottom"
         title="Your policy"
         height="min(100vh, auto)"
+        styles={{
+          wrapper: {
+            maxHeight: "100vh",
+          },
+        }}
         style={{
           maxHeight: "100vh",
           overflow: "scroll",
           height: "unset",
-        }}
-        contentWrapperStyle={{
-          maxHeight: "100vh",
         }}
       >
         <PolicyRightSidebar


### PR DESCRIPTION
## Description

Fixes: #2102

## Changes

- Removed deprecated `contentWrapperStyle` prop, now using `styles.wrapper` . 


