### PR TITLE
Re-enable cliff impacts

### DIFF
--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -165,7 +165,7 @@ function description(metadata) {
   return (
     <p style={{ marginTop: "10px" }}>
       The cliff rate is the share of households whose net income falls if each
-      adult earned an additional {metadata.currency}2,000. The cliff gap is the
+      adult earned an additional {metadata.currency}1,000. The cliff gap is the
       sum of the losses incurred by all households on a cliff if their income
       rose in this way.{" "}
       <a href="https://policyengine.org/us/research/how-would-reforms-affect-cliffs">

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -1,13 +1,7 @@
 import { useEffect, useRef, useState } from "react";
-import {
-  DisplayError,
-  DisplayImpact,
-  DisplayWait,
-  LowLevelDisplay,
-} from "./Display";
+import { DisplayError, DisplayImpact, DisplayWait } from "./Display";
 import { useSearchParams } from "react-router-dom";
 import { asyncApiCall, copySearchParams, apiCall } from "../../../api/call";
-import ErrorPage from "layout/ErrorPage";
 import { defaultYear } from "data/constants";
 import { areObjectsSame } from "../../../data/areObjectsSame";
 import { updateUserPolicy } from "../../../api/userPolicies";
@@ -225,10 +219,7 @@ export function FetchAndDisplayCliffImpact(props) {
 
   const [impact, setImpact] = useState(null);
   const [error, setError] = useState(null);
-  const {
-    metadata,
-    policy,
-  } = props;
+  const { metadata, policy } = props;
   useEffect(() => {
     if (!!region && !!timePeriod && !!reformPolicyId && !!baselinePolicyId) {
       const url = `/${metadata.countryId}/economy/${reformPolicyId}/over/${baselinePolicyId}?region=${region}&time_period=${timePeriod}&target=cliff`;
@@ -294,11 +285,5 @@ export function FetchAndDisplayCliffImpact(props) {
     return <LoadingCentered message="Computing the cliff impact..." />;
   }
 
-  return (
-    <DisplayImpact
-      impact={impact}
-      policy={policy}
-      metadata={metadata}
-    />
-  );
+  return <DisplayImpact impact={impact} policy={policy} metadata={metadata} />;
 }

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -52,11 +52,6 @@ export function FetchAndDisplayImpact(props) {
   function computingCallback(data) {
     // Position in queue message only occurs with average_time
     // in the response object; if this is present, enable message
-    /*
-    if (data.average_time && data.message) {
-      setQueueMsg(data.message);
-    }
-    */
     if (data.queue_position) {
       setQueuePos(data.queue_position);
     }
@@ -271,15 +266,6 @@ export function FetchAndDisplayCliffImpact(props) {
   if (error) {
     return <DisplayError error={error} />;
   }
-
-  // Remove the below commented block when cliff impacts are reinstated
-  /*
-  return (
-    <LowLevelDisplay {...props}>
-      <ErrorPage message="This service is temporarily unavailable. Please try again later." />
-    </LowLevelDisplay>
-  );
-  */
 
   if (!impact) {
     return <LoadingCentered message="Computing the cliff impact..." />;

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -13,7 +13,7 @@ import { areObjectsSame } from "../../../data/areObjectsSame";
 import { updateUserPolicy } from "../../../api/userPolicies";
 import useCountryId from "../../../hooks/useCountryId";
 import { wrappedResponseJson } from "../../../data/wrappedJson";
-// import LoadingCentered from "layout/LoadingCentered";
+import LoadingCentered from "layout/LoadingCentered";
 
 /**
  *
@@ -223,13 +223,11 @@ export function FetchAndDisplayCliffImpact(props) {
   const reformPolicyId = searchParams.get("reform");
   const baselinePolicyId = searchParams.get("baseline");
 
-  // Remove the following eslint ignore when cliff impacts are restored
-  // eslint-disable-next-line no-unused-vars
   const [impact, setImpact] = useState(null);
   const [error, setError] = useState(null);
   const {
     metadata,
-    // policy,
+    policy,
   } = props;
   useEffect(() => {
     if (!!region && !!timePeriod && !!reformPolicyId && !!baselinePolicyId) {
@@ -283,14 +281,15 @@ export function FetchAndDisplayCliffImpact(props) {
     return <DisplayError error={error} />;
   }
 
-  // Remove the below block when cliff impacts are reinstated
+  // Remove the below commented block when cliff impacts are reinstated
+  /*
   return (
     <LowLevelDisplay {...props}>
       <ErrorPage message="This service is temporarily unavailable. Please try again later." />
     </LowLevelDisplay>
   );
+  */
 
-  /*
   if (!impact) {
     return <LoadingCentered message="Computing the cliff impact..." />;
   }
@@ -302,5 +301,4 @@ export function FetchAndDisplayCliffImpact(props) {
       metadata={metadata}
     />
   );
-  */
 }

--- a/src/pages/policy/output/ImpactTypes.jsx
+++ b/src/pages/policy/output/ImpactTypes.jsx
@@ -1,7 +1,7 @@
 import averageImpactByDecile from "./decile/AverageImpactByDecile";
 import averageImpactByWealthDecile from "./decile/AverageImpactByWealthDecile";
 import budgetaryImpact from "./budget/BudgetaryImpact";
-// import cliffImpact from "./CliffImpact";
+import cliffImpact from "./CliffImpact";
 import deepPovertyImpact from "./poverty/DeepPovertyImpact";
 import deepPovertyImpactByGender from "./poverty/DeepPovertyImpactByGender";
 import detailedBudgetaryImpact from "./budget/DetailedBudgetaryImpact";
@@ -43,7 +43,7 @@ const map = {
   "povertyImpact.deep.byGender": deepPovertyImpactByGender,
   "povertyImpact.regular.byRace": povertyImpactByRace,
   inequalityImpact: inequalityImpact,
-  // cliffImpact: cliffImpact,
+  cliffImpact: cliffImpact,
   "laborSupplyImpact.earnings.overall.absolute": LaborSupplyResponseAbsolute,
   "laborSupplyImpact.earnings.overall.relative": LaborSupplyResponseRelative,
   "laborSupplyImpact.earnings.byDecile.relative.total":

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -122,7 +122,6 @@ export default function PolicyOutput(props) {
           {...props}
           showPolicyImpactPopup={showPolicyImpactPopup}
         />
-        ;
       </>
     );
   }

--- a/src/pages/policy/output/tree.js
+++ b/src/pages/policy/output/tree.js
@@ -14,7 +14,7 @@ export const policyOutputs = {
   genderDeepPovertyImpact: "Deep poverty impact by sex",
   racialPovertyImpact: "Poverty impact by race and ethnicity",
   inequalityImpact: "Income inequality impact",
-  // cliffImpact: "Cliff impact",
+  cliffImpact: "Cliff impact",
   "laborSupplyImpact.byDecile.relative.total":
     "Labor supply impact by decile (relative)",
   "laborSupplyImpact.byDecile.relative.income":
@@ -157,6 +157,10 @@ export function getPolicyOutputTree(countryId) {
         {
           name: "policyOutput.inequalityImpact",
           label: "Inequality impact",
+        },
+        {
+          name: "policyOutput.cliffImpact",
+          label: "Cliff impact",
         },
         {
           name: "policyOutput.laborSupplyImpact",


### PR DESCRIPTION
## Description

Fixes #1843. To not crash, this requires the merging of https://github.com/PolicyEngine/policyengine-api/pull/1982; to correctly calculate UK results, https://github.com/PolicyEngine/policyengine-uk/pull/997 must also be merged. This PR will remain in draft until the merging of the relevant API changes and until I can capture some screenshots.

## Changes

Re-enables cliff impacts. Also removes a hanging semicolon that created a floating semicolon on the cliff impacts output page. Most of this code merely un-comments code that was previously commented out as a result of https://github.com/PolicyEngine/policyengine-app/pull/1099.

## Screenshots

<img width="1440" alt="Screen Shot 2024-11-19 at 1 09 56 AM" src="https://github.com/user-attachments/assets/dfc9d5b2-d3de-44df-a0cf-2861022cf2fc">
<img width="1440" alt="Screen Shot 2024-11-19 at 1 11 49 AM" src="https://github.com/user-attachments/assets/6f220909-e708-48c0-ab50-d883da0aeb3c">


## Tests

N/A
