### PR TITLE
Enable state-level enhanced CPS runs

### DIFF
--- a/src/__tests__/data/reformDefinitionCode.test.js
+++ b/src/__tests__/data/reformDefinitionCode.test.js
@@ -255,7 +255,9 @@ describe("Test getImplementationCode", () => {
       "enhanced_cps",
     );
     expect(output).toBeInstanceOf(Array);
-    expect(output).toContain("baseline = Microsimulation(dataset='enhanced_cps_2024')");
+    expect(output).toContain(
+      "baseline = Microsimulation(dataset='enhanced_cps_2024')",
+    );
   });
 });
 

--- a/src/__tests__/data/reformDefinitionCode.test.js
+++ b/src/__tests__/data/reformDefinitionCode.test.js
@@ -27,6 +27,7 @@ describe("Test getReproducibilityCodeBlock", () => {
       reformPolicyUS,
       "us",
       2024,
+      null,
       householdUS,
     );
 
@@ -244,6 +245,17 @@ describe("Test getImplementationCode", () => {
     const output = getImplementationCode("policy", "uk", 2024, testPolicy);
     expect(output).toBeInstanceOf(Array);
     expect(output).toContain("baseline = Microsimulation(reform=baseline)");
+  });
+  test("If dataset provided, return lines with dataset", () => {
+    const output = getImplementationCode(
+      "policy",
+      "us",
+      2024,
+      baselinePolicyUS,
+      "enhanced_cps",
+    );
+    expect(output).toBeInstanceOf(Array);
+    expect(output).toContain("baseline = Microsimulation(dataset='enhanced_cps_2024')");
   });
 });
 

--- a/src/__tests__/pages/policy/PolicyRightSidebar.test.js
+++ b/src/__tests__/pages/policy/PolicyRightSidebar.test.js
@@ -175,32 +175,6 @@ describe("Enhanced CPS selector", () => {
       "ant-switch-disabled",
     );
   });
-  test("Should not be enabled when region is a state", async () => {
-    const testSearchParams = {
-      focus: "gov",
-      region: "ar",
-    };
-
-    useSearchParams.mockImplementation(() => {
-      return [new URLSearchParams(testSearchParams), jest.fn()];
-    });
-
-    // Declare props
-    const props = {
-      metadata: {
-        ...metadataUS,
-        countryId: "us",
-      },
-      policy: standardPolicyUS,
-      defaultOpen: true,
-    };
-
-    const { getByTestId } = render(<PolicyRightSidebar {...props} />);
-
-    expect(getByTestId("enhanced_cps_switch").classList).toContain(
-      "ant-switch-disabled",
-    );
-  });
   test("Should change region when selected", () => {
     const testSearchParams = {
       focus: "gov",
@@ -209,7 +183,8 @@ describe("Enhanced CPS selector", () => {
 
     const expectedSearchParams = {
       focus: "gov",
-      region: "enhanced_us",
+      region: "us",
+      dataset: "enhanced_cps"
     };
 
     const mockSetSearchParams = jest.fn();

--- a/src/__tests__/pages/policy/PolicyRightSidebar.test.js
+++ b/src/__tests__/pages/policy/PolicyRightSidebar.test.js
@@ -184,7 +184,7 @@ describe("Enhanced CPS selector", () => {
     const expectedSearchParams = {
       focus: "gov",
       region: "us",
-      dataset: "enhanced_cps"
+      dataset: "enhanced_cps",
     };
 
     const mockSetSearchParams = jest.fn();

--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -53,12 +53,13 @@ export const STATUS_TEXT_COLORS = {
   Pending: colors.BLACK,
 };
 
-// Map region entries to default datasets;
-// at the moment, this only applies to the
-// "enhanced_us" region selection
+// Map dataset keywords to their equivalents
+// in the actual US package; at the moment, 
+// this only applies to the "enhanced_cps" 
+// dataset selection
 export const DEFAULT_DATASETS = {
-  enhanced_us: "enhanced_cps_2024",
-};
+  "enhanced_cps": "enhanced_cps_2024"
+}
 
 const DEFAULT_US_HOUSEHOLD = {
   families: {

--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -54,12 +54,12 @@ export const STATUS_TEXT_COLORS = {
 };
 
 // Map dataset keywords to their equivalents
-// in the actual US package; at the moment, 
-// this only applies to the "enhanced_cps" 
+// in the actual US package; at the moment,
+// this only applies to the "enhanced_cps"
 // dataset selection
 export const DEFAULT_DATASETS = {
-  "enhanced_cps": "enhanced_cps_2024"
-}
+  enhanced_cps: "enhanced_cps_2024",
+};
 
 const DEFAULT_US_HOUSEHOLD = {
   families: {

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -157,7 +157,13 @@ export function getSituationCode(
   return lines;
 }
 
-export function getImplementationCode(type, region, timePeriod, policy, dataset) {
+export function getImplementationCode(
+  type,
+  region,
+  timePeriod,
+  policy,
+  dataset,
+) {
   if (type !== "policy") {
     return [];
   }
@@ -167,8 +173,9 @@ export function getImplementationCode(type, region, timePeriod, policy, dataset)
 
   // Check if the region has a dataset specified; enhanced_us is legacy implemntation
   // whereby enhanced_us region correlated with enhanced_cps dataset
-  const hasDatasetSpecified = Object.keys(DEFAULT_DATASETS).includes(dataset) || region === "enhanced_us";
-  
+  const hasDatasetSpecified =
+    Object.keys(DEFAULT_DATASETS).includes(dataset) || region === "enhanced_us";
+
   let formattedDataset = null;
   if (region === "enhanced_us") {
     formattedDataset = "enhanced_cps_2024";

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -443,10 +443,16 @@ function UserProfileSection(props) {
 function PolicySimulationCard(props) {
   const { metadata, userPolicy, keyValue } = props;
 
+  console.log(userPolicy);
+
   const CURRENT_API_VERSION = metadata?.version;
   const geography =
     metadata.economy_options.region.filter(
       (region) => region.name === userPolicy.geography,
+    )[0]?.label || "Unknown";
+  const datasetName =
+    metadata.economy_options.datasets.filter(
+      (dataset) => dataset.name === userPolicy.dataset,
     )[0]?.label || "Unknown";
 
   const apiVersion = userPolicy.api_version;
@@ -480,7 +486,12 @@ function PolicySimulationCard(props) {
   return (
     <Link
       key={keyValue}
-      to={`/${userPolicy.country_id}/policy?focus=policyOutput.policyBreakdown&reform=${userPolicy.reform_id}&baseline=${userPolicy.baseline_id}&timePeriod=${userPolicy.year}&region=${userPolicy.geography}`}
+      to={
+        `/${userPolicy.country_id}/policy?focus=policyOutput.policyBreakdown` +
+        `&reform=${userPolicy.reform_id}&baseline=${userPolicy.baseline_id}` +
+        `&timePeriod=${userPolicy.year}&region=${userPolicy.geography}` +
+        `${userPolicy.dataset ? `&dataset=${userPolicy.dataset}` : ""}`
+      }
       style={{ height: "100%" }}
     >
       <Card
@@ -516,7 +527,12 @@ function PolicySimulationCard(props) {
           Simulated in{" "}
           <span style={{ fontWeight: 500 }}>{userPolicy.year}</span> over{" "}
           <span style={{ fontWeight: 500 }}>{geography}</span> against{" "}
-          <span style={{ fontWeight: 500 }}>{userPolicy.baseline_label}</span>.
+          <span style={{ fontWeight: 500 }}>{userPolicy.baseline_label}</span>
+          {userPolicy.dataset ? (
+            <span style={{ fontWeight: 500 }}> ({datasetName})</span>
+          ) : (
+            "."
+          )}
         </p>
         <p>
           <span style={{ fontWeight: 500 }}>

--- a/src/pages/household/output/HouseholdReproducibility.jsx
+++ b/src/pages/household/output/HouseholdReproducibility.jsx
@@ -12,6 +12,7 @@ export default function HouseholdReproducibility(props) {
   const [earningVariation, setEarningVariation] = useState(false);
   const [searchParams] = useSearchParams();
   const region = searchParams.get("region");
+  const dataset = searchParams.get("dataset");
   const mobile = useMobile();
 
   let lines = getReproducibilityCodeBlock(
@@ -20,6 +21,7 @@ export default function HouseholdReproducibility(props) {
     policy,
     region,
     year,
+    dataset,
     householdInput,
     earningVariation,
   );

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -541,8 +541,6 @@ export default function PolicyRightSidebar(props) {
     dataset = "enhanced_cps";
   }
 
-  console.log(dataset);
-
   const options = metadata.economy_options.region.map((stateAbbreviation) => {
     return { value: stateAbbreviation.name, label: stateAbbreviation.label };
   });

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -166,12 +166,9 @@ function DatasetSelector(props) {
     const sliderStartYear = 2024;
 
     // Return whether or not slider should be enabled
-    // Null timePeriod reflects no URL param setting yet - 
+    // Null timePeriod reflects no URL param setting yet -
     // this is actually default behavior
-    if (
-      !timePeriod ||
-      timePeriod >= sliderStartYear
-    ) {
+    if (!timePeriod || timePeriod >= sliderStartYear) {
       return true;
     }
 
@@ -225,10 +222,8 @@ function DatasetSelector(props) {
         style={{
           margin: 0,
           fontSize: displayCategory !== "mobile" && "0.95em",
-          color:
-            !shouldEnableSlider(timePeriod) && "rgba(0,0,0,0.5)",
-          cursor:
-            !shouldEnableSlider(timePeriod) && "not-allowed",
+          color: !shouldEnableSlider(timePeriod) && "rgba(0,0,0,0.5)",
+          cursor: !shouldEnableSlider(timePeriod) && "not-allowed",
         }}
       >
         Use Enhanced CPS (beta)
@@ -536,7 +531,7 @@ export default function PolicyRightSidebar(props) {
   const hasHousehold = searchParams.get("household") !== null;
 
   let dataset = searchParams.get("dataset");
-  // This allows backward compatibility with a past 
+  // This allows backward compatibility with a past
   // design where enhanced_cps was also a region value
   if (region === "enhanced_us" && !dataset) {
     dataset = "enhanced_cps";

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -27,8 +27,9 @@ function RegionSelector(props) {
     return { value: region.name, label: region.label };
   });
 
-  // These lines enable backward compatibility with a previous design whereby
-  // enhanced_cps was also a region value
+  // The below allows backward compatibility with a past design where enhanced_cps
+  // was also a region value
+  options = options.filter((option) => option.value !== "enhanced_us");
   let inputRegion = searchParams.get("region");
   if (inputRegion === "enhanced_us") {
     inputRegion = "us";

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -293,6 +293,7 @@ export function LowLevelDisplay(props) {
 
   const urlParams = new URLSearchParams(window.location.search);
   const focus = urlParams.get("focus");
+  const dataset = urlParams.get("dataset");
   const selectedVersion = urlParams.get("version") || metadata.version;
   const region = urlParams.get("region");
   const policyOutputTree = getPolicyOutputTree(metadata.countryId);
@@ -317,7 +318,7 @@ export function LowLevelDisplay(props) {
   if (metadata.countryId === "us") {
     bottomText = `PolicyEngine US v${selectedVersion} estimates reform impacts using microsimulation. `;
 
-    if (region === "enhanced_us") {
+    if (region === "enhanced_us" || dataset === "enhanced_cps") {
       bottomText = bottomText.concat(
         "These calculations utilize enhanced CPS data, a beta feature. ",
       );

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -34,6 +34,7 @@ export function FetchAndDisplayImpact(props) {
 
   const [searchParams, setSearchParams] = useSearchParams();
   const region = searchParams.get("region");
+  const dataset = searchParams.get("dataset");
   const timePeriod = searchParams.get("timePeriod");
   const reformPolicyId = searchParams.get("reform");
   const baselinePolicyId = searchParams.get("baseline");
@@ -85,7 +86,10 @@ export function FetchAndDisplayImpact(props) {
       const maxHouseholdString = maxHouseholds
         ? `&max_households=${maxHouseholds}`
         : "";
-      const url = `/${metadata.countryId}/economy/${reformPolicyId}/over/${baselinePolicyId}?region=${region}&time_period=${timePeriod}&version=${selectedVersion}${maxHouseholdString}`;
+      const datasetString = dataset ? `&dataset=${dataset}` : "";
+      const url = `/${metadata.countryId}/economy/${reformPolicyId}/over/` + 
+        `${baselinePolicyId}?region=${region}&time_period=${timePeriod}` + 
+        `&version=${selectedVersion}${maxHouseholdString}${datasetString}`;
       setImpact(null);
       setError(null);
       // start counting (but stop when the API call finishes)
@@ -162,7 +166,7 @@ export function FetchAndDisplayImpact(props) {
     }
     policyRef.current = policy;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [region, timePeriod, reformPolicyId, baselinePolicyId, maxHouseholds]);
+  }, [region, dataset, timePeriod, reformPolicyId, baselinePolicyId, maxHouseholds]);
 
   useEffect(() => {
     if (!impact || !userPolicyId || !countryId) return;

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -87,8 +87,9 @@ export function FetchAndDisplayImpact(props) {
         ? `&max_households=${maxHouseholds}`
         : "";
       const datasetString = dataset ? `&dataset=${dataset}` : "";
-      const url = `/${metadata.countryId}/economy/${reformPolicyId}/over/` + 
-        `${baselinePolicyId}?region=${region}&time_period=${timePeriod}` + 
+      const url =
+        `/${metadata.countryId}/economy/${reformPolicyId}/over/` +
+        `${baselinePolicyId}?region=${region}&time_period=${timePeriod}` +
         `&version=${selectedVersion}${maxHouseholdString}${datasetString}`;
       setImpact(null);
       setError(null);
@@ -166,7 +167,14 @@ export function FetchAndDisplayImpact(props) {
     }
     policyRef.current = policy;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [region, dataset, timePeriod, reformPolicyId, baselinePolicyId, maxHouseholds]);
+  }, [
+    region,
+    dataset,
+    timePeriod,
+    reformPolicyId,
+    baselinePolicyId,
+    maxHouseholds,
+  ]);
 
   useEffect(() => {
     if (!impact || !userPolicyId || !countryId) return;

--- a/src/pages/policy/output/FetchAndDisplayImpact.jsx
+++ b/src/pages/policy/output/FetchAndDisplayImpact.jsx
@@ -226,6 +226,7 @@ export function FetchAndDisplayCliffImpact(props) {
   const timePeriod = searchParams.get("timePeriod");
   const reformPolicyId = searchParams.get("reform");
   const baselinePolicyId = searchParams.get("baseline");
+  const dataset = searchParams.get("dataset");
 
   // Remove the following eslint ignore when cliff impacts are restored
   // eslint-disable-next-line no-unused-vars
@@ -237,7 +238,7 @@ export function FetchAndDisplayCliffImpact(props) {
   } = props;
   useEffect(() => {
     if (!!region && !!timePeriod && !!reformPolicyId && !!baselinePolicyId) {
-      const url = `/${metadata.countryId}/economy/${reformPolicyId}/over/${baselinePolicyId}?region=${region}&time_period=${timePeriod}&target=cliff`;
+      const url = `/${metadata.countryId}/economy/${reformPolicyId}/over/${baselinePolicyId}?region=${region}&time_period=${timePeriod}&target=cliff&dataset=${dataset}`;
       setImpact(null);
       setError(null);
       asyncApiCall(url, null, 5_000)
@@ -281,7 +282,7 @@ export function FetchAndDisplayCliffImpact(props) {
       setSearchParams(newSearch);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [region, timePeriod, reformPolicyId, baselinePolicyId]);
+  }, [region, timePeriod, reformPolicyId, baselinePolicyId, dataset]);
 
   if (error) {
     return <DisplayError error={error} />;

--- a/src/pages/policy/output/PolicyOutput.jsx
+++ b/src/pages/policy/output/PolicyOutput.jsx
@@ -29,6 +29,7 @@ export default function PolicyOutput(props) {
   const reformPolicyId = urlParams.get("reform");
   const geography = urlParams.get("region");
   const timePeriod = urlParams.get("timePeriod");
+  const dataset = urlParams.get("dataset");
 
   useEffect(() => {
     function addPolicyToLocalStorage(policyToAdd) {
@@ -56,6 +57,7 @@ export default function PolicyOutput(props) {
         baseline_label: policy.baseline.label,
         baseline_id: policy.baseline.id,
         geography: geography,
+        dataset: dataset,
         year: timePeriod,
         api_version: metadata.version,
         number_of_provisions: countProvisions(policy),
@@ -99,6 +101,7 @@ export default function PolicyOutput(props) {
   }, [
     countryId,
     geography,
+    dataset,
     isAuthenticated,
     metadata,
     policy,

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -16,7 +16,7 @@ export default function PolicyReproducibility(props) {
     policy,
     region,
     timePeriod,
-    dataset
+    dataset,
   );
 
   const colabLink =

--- a/src/pages/policy/output/PolicyReproducibility.jsx
+++ b/src/pages/policy/output/PolicyReproducibility.jsx
@@ -8,6 +8,7 @@ export default function PolicyReproducibility(props) {
   const [searchParams] = useSearchParams();
   const timePeriod = searchParams.get("timePeriod");
   const region = searchParams.get("region");
+  const dataset = searchParams.get("dataset");
 
   let codeLines = getReproducibilityCodeBlock(
     "policy",
@@ -15,6 +16,7 @@ export default function PolicyReproducibility(props) {
     policy,
     region,
     timePeriod,
+    dataset
   );
 
   const colabLink =


### PR DESCRIPTION
## Description

Fixes #2216 

Before this can be merged, https://github.com/PolicyEngine/policyengine-api/pull/2009 must be approved. A minor change must be made to the production database, then that PR must be merged. After that, this PR can be merged.

## Changes

This PR makes various changes in order to support the application of a dataset to any given region. In conjunction with the API-side PR, this creates a new "dataset" URL parameter for society-wide simulation runs, but also maintains backward compatibility with our previous pattern of using the `enhanced_us` region to denote a US-wide sim run with the enhanced CPS dataset. It also denotes datasets on user profile cards.

## Screenshots

[AwesomeScreenshot-11_23_2024,1_02_06AM.webm](https://github.com/user-attachments/assets/31871f99-4269-4d8c-8905-3d6ff5d51529)
