### PR TITLE
Remove US and UK banners from homepages

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -9,12 +9,8 @@ import HomeTransparency from "./home/HomeTransparency";
 import Footer from "../layout/Footer";
 import HomeQuoteCarousel from "./home/HomeQuoteCarousel";
 import { Helmet } from "react-helmet";
-import UK2024AutumnBudgetBanner from "./home/banners/UK2024AutumnBudgetBanner";
-import US2024ElectionBanner from "./home/banners/US2024ElectionBanner.jsx";
-import useCountryId from "../hooks/useCountryId";
 
 export default function Home() {
-  const countryId = useCountryId();
   return (
     <>
       <Helmet>
@@ -22,9 +18,6 @@ export default function Home() {
       </Helmet>
       <div>
         <Header />
-        {countryId === "uk" && <UK2024AutumnBudgetBanner />}
-
-        {countryId === "us" && <US2024ElectionBanner />}
         <HomeLanding />
         <HomeUsedBy />
         <HomeBlogPreview />


### PR DESCRIPTION
## Description

Fixes #2288 

## Changes

Removes the US election and UK autumn budget banners from their sites, but keeps them as components.

## Screenshots

US site:
![PolicyEngine](https://github.com/user-attachments/assets/d7a68ad0-dcde-432b-9d95-f978580e1867)

UK site:
![PolicyEngine2](https://github.com/user-attachments/assets/63e4d54d-a9f2-408d-a11a-b5581cde82c0)

## Tests

N/A
