### PR TITLE
Use Authorization header instead of Authentication

### DIFF
--- a/src/__tests__/hooks/useAuthenticatedFetch.test.js
+++ b/src/__tests__/hooks/useAuthenticatedFetch.test.js
@@ -55,7 +55,7 @@ describe("useAuthenticatedFetch", () => {
         ...requestOptions,
         headers: {
           ...requestOptions.headers,
-          Authentication: "Bearer TEST_AUTH_TOKEN",
+          Authorization: "Bearer TEST_AUTH_TOKEN",
         },
       },
     ]);

--- a/src/hooks/useAuthenticatedFetch.js
+++ b/src/hooks/useAuthenticatedFetch.js
@@ -18,7 +18,7 @@ export function useAuthenticatedFetch() {
         try {
           //as per https://auth0.com/docs/quickstart/spa/react/02-calling-an-api
           const accessToken = await getAccessTokenSilently();
-          headers["Authentication"] = `Bearer ${accessToken}`;
+          headers["Authorization"] = `Bearer ${accessToken}`;
         } catch (error) {
           //IGNORE. If we can't get an access token we just call the API
           //without it.


### PR DESCRIPTION
partially addresses #2263
    
updated useAuthenticatedFetch to correctly set the "Authorization" header to the bearer token instead of
"Authentication"