### PR TITLE
Auth now specifies api as audience.

### DIFF
--- a/src/__tests__/hooks/useAuthenticatedFetch.test.js
+++ b/src/__tests__/hooks/useAuthenticatedFetch.test.js
@@ -34,6 +34,7 @@ describe("useAuthenticatedFetch", () => {
       },
     });
   }
+
   test("given the user is logged in then it adds the bearer token", async () => {
     givenTheUserIsLoggedIn("TEST_AUTH_TOKEN");
     const requestOptions = {
@@ -60,6 +61,7 @@ describe("useAuthenticatedFetch", () => {
       },
     ]);
   });
+
   test("given the user is not logged in then it adds nothing", async () => {
     const { result } = renderHook(() => useAuthenticatedFetch());
 

--- a/src/auth/Auth0ProviderWithNavigate.jsx
+++ b/src/auth/Auth0ProviderWithNavigate.jsx
@@ -26,6 +26,7 @@ export default function Auth0ProviderWithNavigate({ children }) {
       clientId={clientId}
       authorizationParams={{
         redirect_uri: redirectUri,
+        audience: "https://api.policyengine.org/",
       }}
       onRedirectCallback={onRedirectCallback}
       useRefreshTokens={true}

--- a/src/hooks/useAuthenticatedFetch.js
+++ b/src/hooks/useAuthenticatedFetch.js
@@ -17,7 +17,9 @@ export function useAuthenticatedFetch() {
       if (isAuthenticated) {
         try {
           //as per https://auth0.com/docs/quickstart/spa/react/02-calling-an-api
-          const accessToken = await getAccessTokenSilently();
+          const accessToken = await getAccessTokenSilently({
+            audience: "https://api.policyengine.org/",
+          });
           headers["Authorization"] = `Bearer ${accessToken}`;
         } catch (error) {
           //IGNORE. If we can't get an access token we just call the API


### PR DESCRIPTION
partially fixes #2263

In the baseline implementation of the app the auth token request did not specify an audience (the target API for the JWT). After defining the policyengine API in auth0, I have now updated both the provider and the fetch with auth to specify issuer.

Immediately this will actually stop existing, logged in users from submitting a bearer token until they have to re-log in.

Since the bearer token is yet used this change will not impact the user experience.
