### PR TITLE
Fix Typo In Biden 2025 Budget

### DIFF
--- a/src/posts/articles/biden-budget-2025.md
+++ b/src/posts/articles/biden-budget-2025.md
@@ -64,7 +64,7 @@ Finally, the President proposed increasing both the top Medicare tax rate and to
 
 ### Provisions not modeled
 
-The Budget introduces three additional individual income tax reforms that PolicyEngine does not yet model:
+The Budget introduces four additional individual income tax reforms that PolicyEngine does not yet model:
 
 1. Applying the NIIT to pass-through business income of taxpayers with income above $400,000
 


### PR DESCRIPTION
Fixes #2308

## Fixes Typo in Bide 2025 Budget Article

changed the word "three" to "four" as the list had four items