### PR TITLE
Point reproduce in Python segments to HuggingFace URLs

### DIFF
--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -58,7 +58,7 @@ export const STATUS_TEXT_COLORS = {
 // this only applies to the "enhanced_cps"
 // dataset selection
 export const DEFAULT_DATASETS = {
-  enhanced_cps: "enhanced_cps_2024",
+  enhanced_cps: "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5",
 };
 
 const DEFAULT_US_HOUSEHOLD = {

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -189,9 +189,9 @@ export function getImplementationCode(
   if (hasDatasetSpecified) {
     datasetText = DEFAULT_DATASETS[dataset];
   } else if (isState) {
-    datasetText = "pooled_3_year_cps_2023";
+    datasetText = "hf://policyengine/policyengine-us-data/pooled_3_year_cps_2023.h5";
   } else if (region === "enhanced_us") {
-    datasetText = "enhanced_cps_2024";
+    datasetText = "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5";
   }
 
   const datasetSpecifier = datasetText ? `dataset="${datasetText}"` : "";


### PR DESCRIPTION
Fixes #2315

## Description

Point dataset strings to URLs instead

## Changes

As above.

## Screenshots

<img width="764" alt="image" src="https://github.com/user-attachments/assets/d96e64d1-2151-4472-8cdb-bbffbf479698" />
## Tests

No tests added.
