### PR TITLE
Revert sorting code

### DIFF
--- a/src/pages/PolicyPage.jsx
+++ b/src/pages/PolicyPage.jsx
@@ -57,31 +57,6 @@ function PolicyLeftSidebar(props) {
   const POLICY_OUTPUT_TREE = getPolicyOutputTree(metadata.countryId);
   const selected = searchParams.get("focus") || "";
 
-  function recursiveAlphaSort(tree) {
-    if (!tree) {
-      return [];
-    }
-
-    let sorted = tree.sort((a, b) => {
-      // JS sorts by ASCII value - Z comes before a
-      if (a.label.toLowerCase() < b.label.toLowerCase()) {
-        return -1;
-      }
-      if (a.label.toLowerCase() > b.label.toLowerCase()) {
-        return 1;
-      }
-      return 0;
-    });
-
-    for (let i = 0; i < sorted.length; i++) {
-      sorted[i].children = recursiveAlphaSort(sorted[i].children);
-    }
-
-    return sorted;
-  }
-
-  const firstTree = recursiveAlphaSort(metadata.parameterTree.children);
-
   const onSelect = (name) => {
     let newSearch = copySearchParams(searchParams);
     newSearch.set("focus", name);
@@ -101,8 +76,7 @@ function PolicyLeftSidebar(props) {
         </div>
       )}
       <StackedMenu
-        // firstTree={metadata.parameterTree.children}
-        firstTree={firstTree}
+        firstTree={metadata.parameterTree.children}
         selected={selected}
         onSelect={onSelect}
         secondTree={POLICY_OUTPUT_TREE[0].children}


### PR DESCRIPTION
## Description

Fixes #2348 
Reopens #2342 

## Changes

This code reverts the sorting code introduced as a fix to #2342. Unfortunately, this code made parameters (as opposed to parameter nodes) unclickable in the application.

In my opinion, part of the problem with the prior fix is that it assumed an implementation within `Menu` and `StackedMenu` (two components used to generate the parameter list) that was not present. `StackedMenu` and `Menu` contain display logic that is, in my opinion, too tightly intertwined with the metadata structure itself, such that even merely sorting the metadata alphabetically causes bugs. An ideal implementation here would probably make both components more stylistic only, implementing a separate metadata parsing logic to enable easier modification where necessary.

## Screenshots

N/A

## Tests

N/A
