### PR TITLE
Improve front end display of Anthropic-side AI errors

### DIFF
--- a/src/pages/policy/output/Analysis.jsx
+++ b/src/pages/policy/output/Analysis.jsx
@@ -1,5 +1,5 @@
 import { useSearchParams } from "react-router-dom";
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState } from "react";
 import Spinner from "../../../layout/Spinner";
 import Button from "../../../controls/Button";
 import CodeBlock from "../../../layout/CodeBlock";

--- a/src/pages/policy/output/Analysis.jsx
+++ b/src/pages/policy/output/Analysis.jsx
@@ -1,5 +1,5 @@
 import { useSearchParams } from "react-router-dom";
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import Spinner from "../../../layout/Spinner";
 import Button from "../../../controls/Button";
 import CodeBlock from "../../../layout/CodeBlock";
@@ -124,7 +124,7 @@ export function GenerateAnalysisButton(props) {
     );
 
   function resetAnalysis() {
-    setAnalysisError(false);
+    setAnalysisError(null);
     setAnalysis(""); // Reset analysis content
     setAnalysisLoading(false);
   }
@@ -178,7 +178,11 @@ export function GenerateAnalysisButton(props) {
         for (const chunk of chunks) {
           if (chunk) {
             const data = JSON.parse(chunk);
-            if (data.stream) {
+            console.log(data);
+            if (data.type === "error") {
+              setAnalysisError(data.stream);
+              break;
+            } else if (data.type === "text" && data.stream) {
               setAnalysis((prevAnalysis) => prevAnalysis + data.stream);
             }
           }
@@ -259,7 +263,7 @@ export default function Analysis(props) {
   // Stateful vars for analysis output
   const [audience, setAudience] = useState("Normal");
   const [analysis, setAnalysis] = useState("");
-  const [analysisError, setAnalysisError] = useState(false);
+  const [analysisError, setAnalysisError] = useState(null);
 
   // Stateful vars for generating prompt itself
   const [prompt, setPrompt] = useState("");
@@ -368,7 +372,7 @@ export default function Analysis(props) {
           </div>
         ) : null}
         {analysisError ? (
-          <ErrorComponent message="There was an error generating the analysis." />
+          <ErrorComponent message={analysisError} />
         ) : (
           analysis && <MarkdownFormatter markdown={analysis} dict={chartDict} />
         )}

--- a/src/pages/policy/output/Analysis.jsx
+++ b/src/pages/policy/output/Analysis.jsx
@@ -181,8 +181,7 @@ export function GenerateAnalysisButton(props) {
             if (data.type === "error") {
               setAnalysisError(data.stream);
               break;
-            }
-            else if (data.type === "text" && data.stream) {
+            } else if (data.type === "text" && data.stream) {
               setAnalysis((prevAnalysis) => prevAnalysis + data.stream);
             }
           }

--- a/src/pages/policy/output/Analysis.jsx
+++ b/src/pages/policy/output/Analysis.jsx
@@ -115,6 +115,14 @@ export function GenerateAnalysisButton(props) {
     aiOutputStream,
   } = props;
 
+  const errorMessages = {
+    overloaded_error:
+      "Claude, our partner service, is currently overloaded. Please try again later.",
+    api_error:
+      "Claude, our partner service, is currently experiencing an error. Please try again later.",
+    default: "The AI service has experienced an error.",
+  };
+
   const [analysisLoading, setAnalysisLoading] = useState(false);
 
   const displayCharts = (markdown) =>
@@ -179,7 +187,9 @@ export function GenerateAnalysisButton(props) {
           if (chunk) {
             const data = JSON.parse(chunk);
             if (data.type === "error") {
-              setAnalysisError(data.stream);
+              const errorMessage =
+                errorMessages[data.error] || errorMessages["default"];
+              setAnalysisError(errorMessage);
               break;
             } else if (data.type === "text" && data.stream) {
               setAnalysis((prevAnalysis) => prevAnalysis + data.stream);

--- a/src/pages/policy/output/Analysis.jsx
+++ b/src/pages/policy/output/Analysis.jsx
@@ -178,11 +178,11 @@ export function GenerateAnalysisButton(props) {
         for (const chunk of chunks) {
           if (chunk) {
             const data = JSON.parse(chunk);
-            console.log(data);
             if (data.type === "error") {
               setAnalysisError(data.stream);
               break;
-            } else if (data.type === "text" && data.stream) {
+            }
+            else if (data.type === "text" && data.stream) {
               setAnalysis((prevAnalysis) => prevAnalysis + data.stream);
             }
           }


### PR DESCRIPTION
## Description

Fixes #2382

## Changes

Displays error messages corresponding with Anthropic-side errors

https://github.com/PolicyEngine/policyengine-api/pull/2225 must be merged before this

## Screenshots

Image of the display with a (mock) Claude overloaded error:
<img width="1440" alt="Screen Shot 2025-02-28 at 12 14 00 AM" src="https://github.com/user-attachments/assets/80620d4a-c255-4112-bc9f-5c0b24eaef26" />

## Tests

None added; relevant tests added to API
