### PR TITLE
Ensures uk parliament constituencies only show-up when explicitly enabled

### DIFF
--- a/src/pages/policy/output/tree.js
+++ b/src/pages/policy/output/tree.js
@@ -45,14 +45,7 @@ export const policyOutputs = {
 };
 
 export function getPolicyOutputTree(countryId, searchParams = {}) {
-  // Helper to safely check if a URL parameter exists
-  const hasParam = (param) => {
-    if (!searchParams) return false;
-    if (typeof searchParams.get === "function") {
-      return !!searchParams.get(param);
-    }
-    return !!searchParams[param];
-  };
+  // Checks if UK local areas is explicitly enabled in the URl Parameter
   const uk_local_areas_beta = searchParams.get("uk_local_areas_beta") === "true";
 
   const tree = [

--- a/src/pages/policy/output/tree.js
+++ b/src/pages/policy/output/tree.js
@@ -53,9 +53,7 @@ export function getPolicyOutputTree(countryId, searchParams = {}) {
     }
     return !!searchParams[param];
   };
-  const uk_local_areas_beta = hasParam("uk_local_areas_beta")
-    ? searchParams.get("uk_local_areas_beta")
-    : false;
+  const uk_local_areas_beta = searchParams.get("uk_local_areas_beta") === "true";
 
   const tree = [
     {

--- a/src/pages/policy/output/tree.js
+++ b/src/pages/policy/output/tree.js
@@ -47,7 +47,9 @@ export const policyOutputs = {
 export function getPolicyOutputTree(countryId, searchParams = {}) {
   // Checks if UK local areas is explicitly enabled in the URl Parameter
   const uk_local_areas_beta =
-    searchParams.get("uk_local_areas_beta") === "true";
+    searchParams && typeof searchParams.get === "function"
+      ? searchParams.get("uk_local_areas_beta") === "true"
+      : false;
 
   const tree = [
     {

--- a/src/pages/policy/output/tree.js
+++ b/src/pages/policy/output/tree.js
@@ -46,7 +46,8 @@ export const policyOutputs = {
 
 export function getPolicyOutputTree(countryId, searchParams = {}) {
   // Checks if UK local areas is explicitly enabled in the URl Parameter
-  const uk_local_areas_beta = searchParams.get("uk_local_areas_beta") === "true";
+  const uk_local_areas_beta =
+    searchParams.get("uk_local_areas_beta") === "true";
 
   const tree = [
     {


### PR DESCRIPTION
## Description
Fixes #2381 
 _**uk_local_areas_beta**_ was assigned a truthy/falsy value without explicitly checking for _**true**_.
It should be _**true**_ only if the query parameter explicitly says _**uk_local_areas_beta=true**_, ensuring the toggle correctly removes the feature

## Changes
**_uk_local_areas_beta_** was properly checked (_**=== "true"**_ instead of just being truthy) and that it removes the _**Parliamentary constituencies BETA**_ section if _**uk_local_areas_beta**_ is false.


## Screenshots
<img width="1512" alt="Screenshot 2025-02-28 at 4 55 12 PM" src="https://github.com/user-attachments/assets/3afbe982-f2dd-4ec4-81c2-d088847b0bd4" />

