### PR TITLE
Fixing spacing for Boolean Param inputs toggle in Abolitions

### DIFF
--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -151,7 +151,10 @@ export default function ParameterEditor(props) {
           </p>
           <div
             style={{
-              width: "100%",
+              width:
+                parameter.unit === "bool" || parameter.unit === "abolition"
+                  ? "50%"
+                  : "100%",
               display: "grid",
               gridTemplateColumns: gridColumns,
               gap: "10px",
@@ -711,7 +714,7 @@ function ValueSetter(props) {
 
   if (parameter.unit === "bool" || parameter.unit === "abolition") {
     return (
-      <div style={{ padding: 10 }}>
+      <div style={{ padding: 3 }}>
         <Switch
           key={"input for" + parameter.parameter}
           defaultChecked={startValue}


### PR DESCRIPTION
## Description
Fixes #2129 
This PR updates the layout of the PeriodSetter, ValueSetter, and SettingsPanel components to dynamically adjust their width based on the parameter type. 

## Changes
- Dynamically set width: 50% for bool and abolition parameter types in the container div.
- Retained width: 100% for all other parameter types.
- Reduced gap between PeriodSetter, ValueSetter, and SettingsPanel for a more compact layout.
- Additionally, the vertical alignment of the those elements has been fixed.

## Screenshots
<img width="1512" alt="Screenshot 2025-03-19 at 6 11 13 PM" src="https://github.com/user-attachments/assets/a0097b36-20eb-402d-89bd-3d31f73626dc" />
