### PR TITLE
Use UTC year for date inputs

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -4,7 +4,7 @@
 // allow for application into perpetuity, if that is desired behavior
 export const defaultForeverYear = "2100";
 
-export const defaultYear = new Date().getFullYear();
+export const defaultYear = new Date().getUTCFullYear();
 export const defaultStartDate = defaultYear.toString().concat("-01-01");
 export const defaultEndDate = defaultForeverYear.toString().concat("-12-31");
 

--- a/src/pages/policy/input/ParameterEditor.jsx
+++ b/src/pages/policy/input/ParameterEditor.jsx
@@ -300,7 +300,7 @@ function DefaultPeriodSetter(props) {
     parameterName,
   } = props;
 
-  const startYear = new Date(startDate).getFullYear();
+  const startYear = new Date(startDate).getUTCFullYear();
 
   const [value, setValue] = useState(startYear);
 


### PR DESCRIPTION
## Description

Fixes #2417.

## Changes

The `DefaultParameterEditor` component uses JavaScript's `Date` constructor to take an ISO date string `startDate` prop and convert it to a JS date-type. However, the standard constructor is time zone-sensitive and assumes date strings without a time zone are in UTC. Thus, when we passed `2025-01-01` to `DefaultParameterEditor`, this was converted for users in the Americas to `December 31, 2024, 7pm`. We then parsed the year off this value using the `getFullYear` method.

This PR replaces the use of `getFullYear` with `getUTCFullYear`, which corrects this problem by treating all `Date` instances as UTC.

## Screenshots
<img width="1440" alt="Screen Shot 2025-03-21 at 5 46 57 PM" src="https://github.com/user-attachments/assets/5b9c8344-4cec-4486-86f2-ca715bea13fb" />

## Tests

None have been added.
