### PR TITLE
fix(icon)-replaced pluscircle icon with >

### DIFF
--- a/src/pages/household/output/NetIncomeBreakdown.jsx
+++ b/src/pages/household/output/NetIncomeBreakdown.jsx
@@ -1,7 +1,7 @@
 import {
   CaretDownFilled,
   CaretUpFilled,
-  PlusCircleOutlined,
+  CaretRightOutlined,
   InfoCircleOutlined,
 } from "@ant-design/icons";
 import { Tooltip, Button } from "antd";
@@ -125,8 +125,7 @@ function VariableArithmetic(props) {
           </span>
         </>
       ) : (
-        `Your ${variable.label} ${
-          variable.label.endsWith("s") ? "don't" : "doesn't"
+        `Your ${variable.label} ${variable.label.endsWith("s") ? "don't" : "doesn't"
         } change`
       );
     shouldShowVariable = (variableName) => {
@@ -153,9 +152,8 @@ function VariableArithmetic(props) {
   } else {
     valueStr = (
       <>
-        {`Your ${variable.label} ${
-          variable.label.endsWith("s") ? "are" : "is"
-        }`}
+        {`Your ${variable.label} ${variable.label.endsWith("s") ? "are" : "is"
+          }`}
         &nbsp;
         {nodeArrow(nodeSign)}&nbsp;
         <span
@@ -300,12 +298,12 @@ function VariableArithmetic(props) {
           </Tooltip>
 
           {expandable && (
-            <PlusCircleOutlined
+            <CaretRightOutlined
               style={{
                 fontSize: 14,
                 marginLeft: 10,
                 color: style.colors.DARK_GRAY,
-                transform: expanded ? "rotate(45deg)" : "rotate(0deg)",
+                transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
                 transition: "transform 0.2s",
               }}
             />


### PR DESCRIPTION
fixes #2418 
### **Description**
Replaced the `PlusCircleOutlined` icon with the `>` icon in the `NetIncomeBreakdown.jsx` file for better visual clarity and consistency with the design guidelines.  

###  **Changes**
- Removed the `PlusCircleOutlined` icon.  
- Added the `>` icon using `CaretRightOutlined` from `@ant-design/icons`.  
- Applied a rotation effect to the icon based on the expanded state.  

## Screenshots
![image](https://github.com/user-attachments/assets/6f386e79-a573-4809-9a52-ae39d86f1c1b)

###  **Tests**
- Manually tested the UI interaction:  
    - The icon changes orientation (rotates) based on the expanded state.  
    - The visual appearance aligns with the expected design.  
- Verified the component rendering and icon transition animations.  
