### PR TITLE
Removed debug() calls from Jest tests

### DIFF
--- a/src/__tests__/pages/Research.test.js
+++ b/src/__tests__/pages/Research.test.js
@@ -177,7 +177,7 @@ describe("MediumBlogPreview Component", () => {
         </BrowserRouter>,
       );
 
-      screen.debug();
+      // screen.debug();
 
       const titleElement = screen.getByRole("heading", {
         name: mockPost.title,

--- a/src/__tests__/pages/Research.test.js
+++ b/src/__tests__/pages/Research.test.js
@@ -177,8 +177,6 @@ describe("MediumBlogPreview Component", () => {
         </BrowserRouter>,
       );
 
-      // screen.debug();
-
       const titleElement = screen.getByRole("heading", {
         name: mockPost.title,
       });


### PR DESCRIPTION
## Description
Fixes #2210.

## Changes
Removed the 'screen.debug()' statement from 'Research.test.js' test file.

