### PR TITLE
Api url 2493

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_POLICYENGINE_API=https://api.policyengine.org

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ yarn-error.log*
 .idea
 
 venv/*
+.env

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ REACT_APP_DEBUG ?= false
 
 install:
 	npm ci
+	cp .env.example .env
 	pip3 install -U black
 
 build:

--- a/src/api/call.js
+++ b/src/api/call.js
@@ -4,8 +4,6 @@ import { buildVariableTree, getTreeLeavesInOrder } from "./variables";
 import { wrappedJsonStringify, wrappedResponseJson } from "../data/wrappedJson";
 import { useAuthenticatedFetch } from "../hooks/useAuthenticatedFetch";
 
-const POLICYENGINE_API = "https://api.policyengine.org";
-
 /**
  * returns an api call function that can be used to make requests
  * against the policyengine api endpoint.
@@ -47,7 +45,7 @@ export function apiCall(
   secondAttempt = false,
   fetchMethod = fetch,
 ) {
-  return fetchMethod(POLICYENGINE_API + path, {
+  return fetchMethod(process.env.REACT_APP_POLICYENGINE_API + path, {
     method: method || (body ? "POST" : "GET"),
     headers: {
       "Content-Type": "application/json",

--- a/src/api/call.js
+++ b/src/api/call.js
@@ -45,13 +45,17 @@ export function apiCall(
   secondAttempt = false,
   fetchMethod = fetch,
 ) {
-  return fetchMethod(process.env.REACT_APP_POLICYENGINE_API + path, {
-    method: method || (body ? "POST" : "GET"),
-    headers: {
-      "Content-Type": "application/json",
+  return fetchMethod(
+    process.env.REACT_APP_POLICYENGINE_API ||
+      "https://api.policyengine.org" + path,
+    {
+      method: method || (body ? "POST" : "GET"),
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: body ? wrappedJsonStringify(body) : null,
     },
-    body: body ? wrappedJsonStringify(body) : null,
-  }).then((response) => {
+  ).then((response) => {
     // If the response is a 500, try again once.
     if (response.status === 500 && !secondAttempt) {
       return apiCall(path, body, method, true);


### PR DESCRIPTION
# Environment Configuration and API Setup

## What Changed
- Created `.env.example` file as a template for environment configuration
- Added `.env` to `.gitignore` to prevent committing configuration
- Added a Makefile command to automatically copy `.env.example` to `.env`
- Modified the `apiCall` function to use environment variables with a fallback URL

## Why This Change
- Improves developer onboarding by providing a clear template for environment setup
- Simplifies local development setup with an automated environment configuration command
- Provides resilience with a fallback API URL when environment variables aren't set
- Makes the application more maintainable across different environments

## Technical Details
- Added `cp .env.example .env` command to Makefile for easy environment setup
- API endpoint configuration now follows: `process.env.REACT_APP_POLICYENGINE_API || "https://api.policyengine.org"`
- `.env` file is ignored in version control