### PR TITLE
Fix issue with author filtering when at bottom of Research page

### DIFF
--- a/src/pages/Research.jsx
+++ b/src/pages/Research.jsx
@@ -17,7 +17,7 @@ import authors from "../posts/authors.json";
 import { MediumBlogPreview } from "./home/HomeBlogPreview";
 import Fuse from "fuse.js";
 import { useSearchParams } from "react-router-dom";
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import FontIcon from "../layout/FontIcon";
 import { Helmet } from "react-helmet";
@@ -102,14 +102,28 @@ function ResearchExplorer() {
     />
   );
 
+  const resultsRef = useRef(null);
   const postResults = (
-    <>
+    <div ref={resultsRef}>
       <h2 style={{ marginBottom: 30 }}>
         {filteredPosts.length} result{filteredPosts.length === 1 ? "" : "s"}
       </h2>
       <BlogPostResults posts={filteredPosts} />
-    </>
+    </div>
   );
+
+  useEffect(() => {
+    if (resultsRef.current) {
+      const rect = resultsRef.current.getBoundingClientRect();
+      const isFullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+      if (!isFullyVisible) {
+        resultsRef.current.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
+      }
+    }
+  }, [filteredPosts]);
 
   function onSearch(search) {
     setSearchParams(search ? { search } : {});


### PR DESCRIPTION
Fixes #1555
## Description

This PR introduces changes to the `ResearchExplorer` component to properly handle scrolling behavior when displaying filtered results. The main change involves using the `useRef` hook to reference the container of filtered results (`resultsRef`) and ensuring that the div scrolls into view smoothly when filtered posts are updated and the div is not fully visible in the viewport.

## Changes

- **Refactored Scrolling Logic:**
  - Add a `ref={resultsRef}` to the div wrapping the filtered post results.
  - Add a `useEffect` that checks if the results div is fully visible in the viewport. If not, it scrolls the div into view with a smooth scroll effect when `filteredPosts` changes.

## Screenshots

https://github.com/user-attachments/assets/be98de51-7790-4c29-b311-74ef12782e22

## Tests

Make file command `make test` was not working so I directly executed the script command `npm run test` some tests failed but these were not related to the files or code I contributed. 
![research js test result](https://github.com/user-attachments/assets/cc7ee7b5-7def-4018-a666-c92f79154a88)
![test results](https://github.com/user-attachments/assets/b2f55e20-c0bc-44b8-b698-344279fe1331)