### PR TITLE
Image removed and code added for good look

### DIFF
--- a/src/components/CodeBlock.jsx
+++ b/src/components/CodeBlock.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import CodeEditor from "@uiw/react-textarea-code-editor";
+
+export default function CodeBlock({ code, language = "json" }) {
+  return (
+    <CodeEditor
+      value={code}
+      language={language}
+      padding={15}
+      style={{
+        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+        fontSize: 14,
+        backgroundColor: "#f5f5f5",
+        borderRadius: 8,
+        marginTop: 12,
+      }}
+      readOnly
+    />
+  );
+}

--- a/src/layout/ShowcaseItem.jsx
+++ b/src/layout/ShowcaseItem.jsx
@@ -46,6 +46,7 @@ export default function ShowcaseItem({
         <p>{description}</p>
         <EmphasisedLink url={link} text={linkTitle} />
       </div>
+
       {imageIsMissing ? (
         <div
           style={{
@@ -66,7 +67,7 @@ export default function ShowcaseItem({
             }}
           />
         </div>
-      ) : (
+      ) : typeof image === "string" ? (
         <img
           src={image}
           width={displayCategory === "desktop" ? 400 : "100%"}
@@ -76,7 +77,17 @@ export default function ShowcaseItem({
           }}
           alt={altText}
         />
+      ) : (
+        <div
+          style={{
+            width: displayCategory === "desktop" ? 400 : "100%",
+            marginTop: displayCategory === "desktop" ? 0 : 20,
+          }}
+        >
+          {image}
+        </div>
       )}
+
     </div>
   );
 }

--- a/src/pages/home/HomeTransparency.jsx
+++ b/src/pages/home/HomeTransparency.jsx
@@ -1,6 +1,6 @@
 import style from "../../style";
 import Section from "../../layout/Section";
-import apiScreenshot from "../../images/home/api_screenshot.png";
+import CodeBlock from "../../components/CodeBlock";
 import githubScreenshot from "../../images/home/github_screenshot.png";
 import testingScreenshot from "../../images/home/testing_screenshot.png";
 import ShowcaseItem from "../../layout/ShowcaseItem";
@@ -20,23 +20,33 @@ export default function HomeTransparency() {
         borderColor={style.colors.BLACK}
       />
       <ShowcaseItem
-        title="Our models are tested extensively"
-        description="PolicyEngine's software undergoes thousands of automated tests every day to ensure our simulations produce accurate results."
-        linkTitle="Explore the documentation"
-        link={`https://policyengine.github.io/policyengine-${countryId}`}
-        image={testingScreenshot}
-        altText="Screenshot of PolicyEngine's test coverage"
-        borderColor={style.colors.BLACK}
-      />
-      <ShowcaseItem
         title="PolicyEngine's API computes policy impacts"
         description="Instantly compute taxes and benefits for any household under current or reformed policy rules, using the PolicyEngine REST API, reproducing any result in the web app."
         linkTitle="Explore the documentation"
         link={`/${countryId}/api`}
-        image={apiScreenshot}
-        altText="Screenshot of PolicyEngine's API documentation"
+        image={
+          <CodeBlock
+            code={`{
+          "income_tax": {
+            "2023": 3486
+          },
+          "income_tax_pre_charges": {
+            "2023": 3486
+          },
+          "is_CTC_child_limit_exempt": {
+            "2023": true
+          },
+          "is_QYP": {
+            "2023": false
+          }
+        }`}
+          />
+        }
+        altText="JSON response from API"
         borderColor={style.colors.BLACK}
       />
+
+
     </Section>
   );
 }


### PR DESCRIPTION
Issue: #2534

## Changes
Removed this Image block and replaced with a codeblock
![image](https://github.com/user-attachments/assets/ed3e3cf8-fc75-4774-9c92-2224f9fa9368)


Replace image with code block in API showcase

- Modified `src/pages/home/HomeTransparency.jsx`: removed static image import and added <CodeBlock> with JSON response
- Updated `src/components/ShowcaseItem.tsx` to handle inline code block as child instead of image

## After new changes applied
![image](https://github.com/user-attachments/assets/6253c1f7-bf74-49c8-9455-15f3097cf307)

