### PR TITLE
Redirect enhanced_us region requests and remove deprecated `enhanced_us` code

### DIFF
--- a/src/PolicyEngine.jsx
+++ b/src/PolicyEngine.jsx
@@ -57,6 +57,7 @@ import MicrosimPage from "./pages/learn/MicrosimPage";
 import EducationPage from "./pages/learn/EducationPage";
 import OpenSourcePage from "./pages/learn/OpenSourcePage";
 import BenefitAccessPage from "./pages/learn/BenefitAccessPage";
+import { updateDeprecatedSearchParams } from "./routing/updateDeprecatedSearchParams";
 
 const PolicyPage = lazy(() => import("./pages/PolicyPage"));
 const HouseholdPage = lazy(() => import("./pages/HouseholdPage"));
@@ -77,6 +78,13 @@ export default function PolicyEngine() {
   const countryId = extractCountryId();
 
   const [searchParams, setSearchParams] = useSearchParams();
+
+  const updatedSearchParams = updateDeprecatedSearchParams(searchParams);
+  if (updatedSearchParams) {
+    // If we have updated search params, set them
+    setSearchParams(updatedSearchParams);
+  }
+
   const householdId = searchParams.get("household");
 
   let defaultBaselinePolicy = 1;

--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -1,0 +1,84 @@
+import { BrowserRouter, useSearchParams } from "react-router-dom";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import PolicyEngine from "../PolicyEngine";
+
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useSearchParams: jest.fn(),
+  };
+});
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve({}),
+    ok: true,
+  }),
+);
+
+afterEach(() => {
+  global.fetch.mockClear();
+});
+
+describe("PolicyEngine.jsx", () => {
+  test("Renders for US if proper data passed", () => {
+    useSearchParams.mockImplementation(() => [
+      new URLSearchParams(),
+      jest.fn(),
+    ]);
+
+    const { getByText } = render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
+
+    expect(
+      getByText("Computing Public Policy for Everyone"),
+    ).toBeInTheDocument();
+    expect(getByText("Trusted across the US")).toBeInTheDocument();
+  });
+  test("Converts deprecated 'region=enhanced_us' URL search param to 'region=us' and 'dataset=enhanced_cps'", () => {
+    const deprecatedEnhancedUsParams = new URLSearchParams({
+      region: "enhanced_us",
+      country_id: "us",
+    });
+
+    const updatedSearchParams = new URLSearchParams({
+      country_id: "us",
+      region: "us",
+      dataset: "enhanced_cps",
+    });
+
+    const mockSearchParams = {
+      get: jest.fn((key) => deprecatedEnhancedUsParams.get(key)),
+      has: jest.fn((key) => deprecatedEnhancedUsParams.has(key)),
+      delete: jest.fn((key) => deprecatedEnhancedUsParams.delete(key)),
+      set: jest.fn((key, value) => {
+        deprecatedEnhancedUsParams.set(key, value);
+      }),
+      [Symbol.iterator]: function () {
+        return deprecatedEnhancedUsParams[Symbol.iterator]();
+      },
+    };
+
+    const mockSetSearchParams = jest.fn();
+
+    useSearchParams.mockImplementation(() => [
+      mockSearchParams,
+      mockSetSearchParams,
+    ]);
+
+    render(
+      <BrowserRouter>
+        <PolicyEngine />
+      </BrowserRouter>,
+    );
+
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
+    expect(mockSetSearchParams).toHaveBeenCalledWith(updatedSearchParams);
+  });
+});

--- a/src/__tests__/pages/policy/PolicyRightSidebar.test.js
+++ b/src/__tests__/pages/policy/PolicyRightSidebar.test.js
@@ -124,32 +124,6 @@ describe("Enhanced CPS selector", () => {
       "ant-switch-disabled",
     );
   });
-  test("Should be enabled when region is 'enhanced_us'", async () => {
-    const testSearchParams = {
-      focus: "gov",
-      region: "enhanced_us",
-    };
-
-    useSearchParams.mockImplementation(() => {
-      return [new URLSearchParams(testSearchParams), jest.fn()];
-    });
-
-    // Declare props
-    const props = {
-      metadata: {
-        ...metadataUS,
-        countryId: "us",
-      },
-      policy: standardPolicyUS,
-      defaultOpen: true,
-    };
-
-    const { getByTestId } = render(<PolicyRightSidebar {...props} />);
-
-    expect(getByTestId("enhanced_cps_switch").classList).not.toContain(
-      "ant-switch-disabled",
-    );
-  });
   test("Should be enabled when region is 'null'", async () => {
     const testSearchParams = {
       focus: "gov",

--- a/src/__tests__/routing/updateDeprecatedSearchParams.test.js
+++ b/src/__tests__/routing/updateDeprecatedSearchParams.test.js
@@ -1,0 +1,39 @@
+import { updateDeprecatedSearchParams } from "../../routing/updateDeprecatedSearchParams";
+
+describe("updateDeprecatedSearchParams", () => {
+  const validCountryId = "us";
+  const validDataset = "enhanced_cps";
+  const validRegion = "us";
+  const deprecatedRegion = "enhanced_us";
+
+  test("should return null if no updates are needed", () => {
+    const searchParams = new URLSearchParams({
+      region: validRegion,
+      country_id: validCountryId,
+      dataset: validDataset,
+    });
+    const result = updateDeprecatedSearchParams(searchParams);
+    expect(result).toBeNull();
+  });
+  test("should return new URLSearchParams object with updated params, updating relevant params", () => {
+    const searchParams = new URLSearchParams({
+      region: deprecatedRegion,
+      country_id: validCountryId,
+      dataset: validDataset,
+    });
+    const result = updateDeprecatedSearchParams(searchParams);
+    expect(result).not.toBeNull();
+    expect(result.get("region")).toBe(validRegion);
+    expect(result.get("dataset")).toBe(validDataset);
+  });
+  test("should return new URLSearchParams object with updated params, adding relevant new params", () => {
+    const searchParams = new URLSearchParams({
+      region: deprecatedRegion,
+      country_id: validCountryId,
+    });
+    const result = updateDeprecatedSearchParams(searchParams);
+    expect(result).not.toBeNull();
+    expect(result.get("region")).toBe(validRegion);
+    expect(result.get("dataset")).toBe(validDataset);
+  });
+});

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -177,7 +177,7 @@ export function getImplementationCode(
   // Check if the region has a dataset specified
   const hasDatasetSpecified = Object.keys(DEFAULT_DATASETS).includes(dataset);
 
-  const isState = countryId === "us" && region != "us";
+  const isState = countryId === "us" && region !== "us";
 
   let datasetText = "";
 

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -177,22 +177,15 @@ export function getImplementationCode(
   // Check if the region has a dataset specified
   const hasDatasetSpecified = Object.keys(DEFAULT_DATASETS).includes(dataset);
 
-  const COUNTRY_LEVEL_US_REGIONS = ["us", "enhanced_us"];
-
-  const isState =
-    countryId === "us" && !COUNTRY_LEVEL_US_REGIONS.includes(region);
+  const isState = countryId === "us" && region != "us";
 
   let datasetText = "";
 
-  // enhanced_us is legacy implemntation
-  // whereby enhanced_us region correlated with enhanced_cps dataset
   if (hasDatasetSpecified) {
     datasetText = DEFAULT_DATASETS[dataset];
   } else if (isState) {
     datasetText =
       "hf://policyengine/policyengine-us-data/pooled_3_year_cps_2023.h5";
-  } else if (region === "enhanced_us") {
-    datasetText = "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5";
   }
 
   const datasetSpecifier = datasetText ? `dataset="${datasetText}"` : "";

--- a/src/pages/Simulations.jsx
+++ b/src/pages/Simulations.jsx
@@ -28,7 +28,7 @@ export default function SimulationsPage() {
       "reform_impact_id": 1,
       "reform_impact_json": "{json object}",
       "reform_policy_id": 6, 
-      "region": "enhanced_us", 
+      "region": "us", 
       "start_time": "2024-09-25 09:58:14.133369", 
       "end_time": "2024-09-25 09:58:14.133369",
       "status": "ok", 

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -34,13 +34,10 @@ function RegionSelector(props) {
     return { value: region.name, label: region.label };
   });
 
-  // The below allows backward compatibility with a past design where enhanced_cps
-  // was also a region value
+  // The enhanced_us region is deprecated and should be removed from the API by June 1, 2025;
+  // remove this filter after removing API code
   options = options.filter((option) => option.value !== "enhanced_us");
   let inputRegion = searchParams.get("region");
-  if (inputRegion === "enhanced_us") {
-    inputRegion = "us";
-  }
   if (!(searchParams.get("uk_local_areas_beta") === "true")) {
     options = options.filter(
       (option) => !option.value.includes("constituency/"),
@@ -504,11 +501,6 @@ function DatasetSelector(props) {
     // Set params accordingly
     if (isChecked) {
       newSearch.delete("dataset");
-      // Allows for backwards compatibility with a past design
-      // where enhanced_cps was also a region value
-      if (searchParams.get("region") === "enhanced_us") {
-        newSearch.set("region", "us");
-      }
       setIsChecked(false);
     } else {
       newSearch.set("dataset", "enhanced_cps");
@@ -847,11 +839,6 @@ export default function PolicyRightSidebar(props) {
   const hasHousehold = searchParams.get("household") !== null;
 
   let dataset = searchParams.get("dataset");
-  // This allows backward compatibility with a past
-  // design where enhanced_cps was also a region value
-  if (region === "enhanced_us" && !dataset) {
-    dataset = "enhanced_cps";
-  }
 
   const options = metadata.economy_options.region.map((stateAbbreviation) => {
     return { value: stateAbbreviation.name, label: stateAbbreviation.label };

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -318,7 +318,7 @@ export function LowLevelDisplay(props) {
   if (metadata.countryId === "us") {
     bottomText = `PolicyEngine US v${selectedVersion} estimates reform impacts using microsimulation. `;
 
-    if (region === "enhanced_us" || dataset === "enhanced_cps") {
+    if (dataset === "enhanced_cps") {
       bottomText = bottomText.concat(
         "These calculations utilize enhanced CPS data, a beta feature. ",
       );

--- a/src/pages/policy/output/Display.jsx
+++ b/src/pages/policy/output/Display.jsx
@@ -295,7 +295,6 @@ export function LowLevelDisplay(props) {
   const focus = urlParams.get("focus");
   const dataset = urlParams.get("dataset");
   const selectedVersion = urlParams.get("version") || metadata.version;
-  const region = urlParams.get("region");
   const policyOutputTree = getPolicyOutputTree(metadata.countryId, urlParams);
   const url = encodeURIComponent(window.location.href);
   const encodedPolicyLabel = encodeURIComponent(getPolicyLabel(policy));

--- a/src/pages/policy/output/ImpactChart.jsx
+++ b/src/pages/policy/output/ImpactChart.jsx
@@ -122,7 +122,7 @@ export function absoluteChangeMessage(
  * and it is not us or uk
  */
 export function regionName(metadata) {
-  const ignoreList = ["us", "uk", "enhanced_us"];
+  const ignoreList = ["us", "uk"];
   const urlParams = new URLSearchParams(window.location.search);
   const region = urlParams.get("region");
   if (ignoreList.includes(region)) return;

--- a/src/pages/policy/output/PolicyBreakdown.jsx
+++ b/src/pages/policy/output/PolicyBreakdown.jsx
@@ -18,12 +18,7 @@ export default function PolicyBreakdown(props) {
     setSearchParams(newSearch);
   };
   let regionLabel;
-  // This is a workaround for enhanced_us that should be changed
-  // if and when it is treated as something other than a "region"
-  // by the back end
-  if (regionObj?.name === "enhanced_us") {
-    regionLabel = "the US";
-  } else if (regionObj) {
+  if (regionObj) {
     regionLabel = regionObj.label;
   } else {
     regionLabel = "undefined region";

--- a/src/routing/updateDeprecatedSearchParams.js
+++ b/src/routing/updateDeprecatedSearchParams.js
@@ -1,0 +1,61 @@
+import * as yup from "yup";
+import { copySearchParams } from "../api/call";
+
+export const DeprecatedSearchParam = yup.object({
+  oldKey: yup.string().required(),
+  oldValue: yup.string().required(),
+  newKeysAndValues: yup
+    .array()
+    .of(
+      yup.object({
+        key: yup.string().required(),
+        value: yup.string().required(),
+      }),
+    )
+    .required(),
+});
+
+export const deprecatedSearchParams = [
+  DeprecatedSearchParam.validateSync({
+    oldKey: "region",
+    oldValue: "enhanced_us",
+    newKeysAndValues: [
+      { key: "region", value: "us" },
+      { key: "dataset", value: "enhanced_cps" },
+    ],
+  }),
+];
+
+export const deprecatedSearchParamKeys = deprecatedSearchParams.map(
+  (param) => param.oldKey,
+);
+
+/**
+ * Given a URLSearchParams object, return null if no updates are needed,
+ * otherwise return new URLSearchParams object, replacing deprecated params
+ * @param {URLSearchParams} searchParams
+ * @returns {URLSearchParams|null} Null if no updates needed, otherwise new URLSearchParams object
+ */
+export function updateDeprecatedSearchParams(searchParams) {
+  // Check if any deprecated params are present
+  const hasDeprecatedParams = deprecatedSearchParams.some(
+    (param) =>
+      searchParams.has(param.oldKey) &&
+      searchParams.get(param.oldKey) === param.oldValue,
+  );
+  if (!hasDeprecatedParams) {
+    return null;
+  }
+
+  let newSearchParams = copySearchParams(searchParams);
+  deprecatedSearchParams.forEach((param) => {
+    if (searchParams.get(param.oldKey) === param.oldValue) {
+      newSearchParams.delete(param.oldKey);
+      param.newKeysAndValues.forEach((newParam) => {
+        newSearchParams.set(newParam.key, newParam.value);
+      });
+    }
+  });
+
+  return newSearchParams;
+}

--- a/src/routing/updateDeprecatedSearchParams.js
+++ b/src/routing/updateDeprecatedSearchParams.js
@@ -15,7 +15,7 @@ export const DeprecatedSearchParam = yup.object({
     .required(),
 });
 
-export const deprecatedSearchParams = [
+export const DEPRECATED_SEARCH_PARAMS = [
   DeprecatedSearchParam.validateSync({
     oldKey: "region",
     oldValue: "enhanced_us",
@@ -26,10 +26,6 @@ export const deprecatedSearchParams = [
   }),
 ];
 
-export const deprecatedSearchParamKeys = deprecatedSearchParams.map(
-  (param) => param.oldKey,
-);
-
 /**
  * Given a URLSearchParams object, return null if no updates are needed,
  * otherwise return new URLSearchParams object, replacing deprecated params
@@ -38,7 +34,7 @@ export const deprecatedSearchParamKeys = deprecatedSearchParams.map(
  */
 export function updateDeprecatedSearchParams(searchParams) {
   // Check if any deprecated params are present
-  const hasDeprecatedParams = deprecatedSearchParams.some(
+  const hasDeprecatedParams = DEPRECATED_SEARCH_PARAMS.some(
     (param) =>
       searchParams.has(param.oldKey) &&
       searchParams.get(param.oldKey) === param.oldValue,
@@ -48,7 +44,7 @@ export function updateDeprecatedSearchParams(searchParams) {
   }
 
   let newSearchParams = copySearchParams(searchParams);
-  deprecatedSearchParams.forEach((param) => {
+  DEPRECATED_SEARCH_PARAMS.forEach((param) => {
     if (searchParams.get(param.oldKey) === param.oldValue) {
       newSearchParams.delete(param.oldKey);
       param.newKeysAndValues.forEach((newParam) => {


### PR DESCRIPTION
## Description

Fixes #2549

## Changes

* Redirects all inbound requests containing the deprecated URL parameter `region=enhanced_us` to `region=us&dataset=enhanced_cps`
* Removes all code referencing the `region=enhanced_us` setting, except the code filtering the `enhanced_us` region out of the API's regions list; this will be addressed after removing the option from the API

## Screenshots

N/A

## Tests

Added tests for new function to update deprecated URL parameters and to ensure that `PolicyEngine.jsx` properly modifies said deprecated parameters when rendering.
