### PR TITLE
Rounded 10-year budgetary impacts to 1dp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27932,7 +27932,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/yup/-/yup-1.6.1.tgz",
       "integrity": "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==",
-      "license": "MIT",
       "dependencies": {
         "property-expr": "^2.0.5",
         "tiny-case": "^1.0.3",

--- a/src/__tests__/pages/policy/output/budget/MultiYearBudgetaryImpact.test.js
+++ b/src/__tests__/pages/policy/output/budget/MultiYearBudgetaryImpact.test.js
@@ -78,8 +78,12 @@ describe("MultiYearBudgetaryImpact", () => {
 
       // Then
       expect(result).toEqual({
-        2020: (mockSingleYearResults[0].result.budget[budgetKey] / 1e9).toFixed(1),
-        2021: (mockSingleYearResults[1].result.budget[budgetKey] / 1e9).toFixed(1),
+        2020: (mockSingleYearResults[0].result.budget[budgetKey] / 1e9).toFixed(
+          1,
+        ),
+        2021: (mockSingleYearResults[1].result.budget[budgetKey] / 1e9).toFixed(
+          1,
+        ),
       });
     });
     test("getYearlyImpacts should correctly format yearly impacts with formula", () => {

--- a/src/__tests__/pages/policy/output/budget/MultiYearBudgetaryImpact.test.js
+++ b/src/__tests__/pages/policy/output/budget/MultiYearBudgetaryImpact.test.js
@@ -78,12 +78,8 @@ describe("MultiYearBudgetaryImpact", () => {
 
       // Then
       expect(result).toEqual({
-        2020: String(
-          mockSingleYearResults[0].result.budget[budgetKey] / 1e9,
-        ).toFixed(1),
-        2021: String(
-          mockSingleYearResults[1].result.budget[budgetKey] / 1e9,
-        ).toFixed(1),
+        2020: (mockSingleYearResults[0].result.budget[budgetKey] / 1e9).toFixed(1),
+        2021: (mockSingleYearResults[1].result.budget[budgetKey] / 1e9).toFixed(1),
       });
     });
     test("getYearlyImpacts should correctly format yearly impacts with formula", () => {
@@ -97,8 +93,8 @@ describe("MultiYearBudgetaryImpact", () => {
         formula(item.result.budget),
       );
       const expectedResult = {
-        2020: String(expectedImpact[0] / 1e9).toFixed(1),
-        2021: String(expectedImpact[1] / 1e9).toFixed(1),
+        2020: (expectedImpact[0] / 1e9).toFixed(1),
+        2021: (expectedImpact[1] / 1e9).toFixed(1),
       };
       // When
       const result = getYearlyImpacts(

--- a/src/__tests__/pages/policy/output/budget/MultiYearBudgetaryImpact.test.js
+++ b/src/__tests__/pages/policy/output/budget/MultiYearBudgetaryImpact.test.js
@@ -78,8 +78,8 @@ describe("MultiYearBudgetaryImpact", () => {
 
       // Then
       expect(result).toEqual({
-        2020: String(mockSingleYearResults[0].result.budget[budgetKey] / 1),
-        2021: String(mockSingleYearResults[1].result.budget[budgetKey] / 1),
+        2020: String(mockSingleYearResults[0].result.budget[budgetKey] / 1e9).toFixed(1),
+        2021: String(mockSingleYearResults[1].result.budget[budgetKey] / 1e9).toFixed(1),
       });
     });
     test("getYearlyImpacts should correctly format yearly impacts with formula", () => {
@@ -93,8 +93,8 @@ describe("MultiYearBudgetaryImpact", () => {
         formula(item.result.budget),
       );
       const expectedResult = {
-        2020: String(expectedImpact[0] / 1),
-        2021: String(expectedImpact[1] / 1),
+        2020: String(expectedImpact[0] / 1e9).toFixed(1),
+        2021: String(expectedImpact[1] / 1e9).toFixed(1),
       };
       // When
       const result = getYearlyImpacts(

--- a/src/__tests__/pages/policy/output/budget/MultiYearBudgetaryImpact.test.js
+++ b/src/__tests__/pages/policy/output/budget/MultiYearBudgetaryImpact.test.js
@@ -78,8 +78,8 @@ describe("MultiYearBudgetaryImpact", () => {
 
       // Then
       expect(result).toEqual({
-        2020: String(mockSingleYearResults[0].result.budget[budgetKey] / 1e9),
-        2021: String(mockSingleYearResults[1].result.budget[budgetKey] / 1e9),
+        2020: String(mockSingleYearResults[0].result.budget[budgetKey] / 1),
+        2021: String(mockSingleYearResults[1].result.budget[budgetKey] / 1),
       });
     });
     test("getYearlyImpacts should correctly format yearly impacts with formula", () => {
@@ -93,8 +93,8 @@ describe("MultiYearBudgetaryImpact", () => {
         formula(item.result.budget),
       );
       const expectedResult = {
-        2020: String(expectedImpact[0] / 1e9),
-        2021: String(expectedImpact[1] / 1e9),
+        2020: String(expectedImpact[0] / 1),
+        2021: String(expectedImpact[1] / 1),
       };
       // When
       const result = getYearlyImpacts(

--- a/src/__tests__/pages/policy/output/budget/MultiYearBudgetaryImpact.test.js
+++ b/src/__tests__/pages/policy/output/budget/MultiYearBudgetaryImpact.test.js
@@ -78,8 +78,12 @@ describe("MultiYearBudgetaryImpact", () => {
 
       // Then
       expect(result).toEqual({
-        2020: String(mockSingleYearResults[0].result.budget[budgetKey] / 1e9).toFixed(1),
-        2021: String(mockSingleYearResults[1].result.budget[budgetKey] / 1e9).toFixed(1),
+        2020: String(
+          mockSingleYearResults[0].result.budget[budgetKey] / 1e9,
+        ).toFixed(1),
+        2021: String(
+          mockSingleYearResults[1].result.budget[budgetKey] / 1e9,
+        ).toFixed(1),
       });
     });
     test("getYearlyImpacts should correctly format yearly impacts with formula", () => {

--- a/src/pages/policy/output/budget/MultiYearBudgetaryImpact.jsx
+++ b/src/pages/policy/output/budget/MultiYearBudgetaryImpact.jsx
@@ -57,7 +57,7 @@ const financialYearTypeByCountry = {
 const roundingPrecisionByCountry = {
   us: 1,
   uk: 1,
-  default: 0,
+  default: 1,
 };
 
 /**

--- a/src/pages/policy/output/budget/MultiYearBudgetaryImpact.jsx
+++ b/src/pages/policy/output/budget/MultiYearBudgetaryImpact.jsx
@@ -55,7 +55,7 @@ const financialYearTypeByCountry = {
 };
 
 const roundingPrecisionByCountry = {
-  us: 0,
+  us: 1,
   uk: 1,
   default: 0,
 };

--- a/src/pages/policy/output/budget/MultiYearBudgetaryImpact.jsx
+++ b/src/pages/policy/output/budget/MultiYearBudgetaryImpact.jsx
@@ -57,7 +57,7 @@ const financialYearTypeByCountry = {
 const roundingPrecisionByCountry = {
   us: 1,
   uk: 1,
-  default: 1,
+  default: 0,
 };
 
 /**


### PR DESCRIPTION
## Description

Fixes #2576 

## Changes

Modified the roundingPrecisionByCountry configuration to set the US rounding precision to 1 decimal.


