### PR TITLE
Switch to ipinfo.io-based country detection fixing Issue 2448

### DIFF
--- a/src/__tests__/PolicyEngine.test.js
+++ b/src/__tests__/PolicyEngine.test.js
@@ -24,23 +24,25 @@ afterEach(() => {
 });
 
 describe("PolicyEngine.jsx", () => {
-  test("Renders for US if proper data passed", () => {
+  test("Renders for US if proper data passed", async () => {
     useSearchParams.mockImplementation(() => [
       new URLSearchParams(),
       jest.fn(),
     ]);
 
-    const { getByText } = render(
+    const { findByText } = render(
       <BrowserRouter>
         <PolicyEngine />
       </BrowserRouter>,
     );
 
     expect(
-      getByText("Computing Public Policy for Everyone"),
+      await findByText("Computing Public Policy for Everyone"),
     ).toBeInTheDocument();
-    expect(getByText("Trusted across the US")).toBeInTheDocument();
+
+    expect(await findByText("Trusted across the US")).toBeInTheDocument();
   });
+
   test("Converts deprecated 'region=enhanced_us' URL search param to 'region=us' and 'dataset=enhanced_cps'", () => {
     const deprecatedEnhancedUsParams = new URLSearchParams({
       region: "enhanced_us",

--- a/src/posts/articles/farage-speech-may-2025.ipynb
+++ b/src/posts/articles/farage-speech-may-2025.ipynb
@@ -109,7 +109,7 @@
     "        \"gov.hmrc.income_tax.rates.uk[1].threshold\": 50_000,\n",
     "        \"gov.hmrc.income_tax.allowances.marriage_allowance.max\": 0.25,\n",
     "        \"gov.dwp.universal_credit.elements.child.limit.child_count\": 90,\n",
-    "    }\n",
+    "    },\n",
     ")"
    ]
   },
@@ -163,7 +163,7 @@
     "fig = px.bar(\n",
     "    y=result.decile.relative,\n",
     "    text=[f\"{x:.1%}\" for x in result.decile.relative.values()],\n",
-    "    color_discrete_sequence=[BLUE]\n",
+    "    color_discrete_sequence=[BLUE],\n",
     ").update_layout(\n",
     "    title=\"Impact of Reform UK tax-benefit policies by income decile\",\n",
     "    xaxis_title=\"Income decile\",\n",
@@ -172,8 +172,7 @@
     "    yaxis_tickformat=\".0%\",\n",
     ")\n",
     "\n",
-    "print(format_fig(fig).update_layout(\n",
-    ").to_json())"
+    "print(format_fig(fig).update_layout().to_json())"
    ]
   },
   {
@@ -323,11 +322,14 @@
     "    print(reform, policy_reform_names[i])\n",
     "\n",
     "    for year in tqdm(range(2025, 2030)):\n",
-    "        debt_impact = sim.reform_simulation.calculate(\"gov_balance\", year).sum()/1e9 - sim.baseline_simulation.calculate(\"gov_balance\", year).sum()/1e9\n",
+    "        debt_impact = (\n",
+    "            sim.reform_simulation.calculate(\"gov_balance\", year).sum() / 1e9\n",
+    "            - sim.baseline_simulation.calculate(\"gov_balance\", year).sum()\n",
+    "            / 1e9\n",
+    "        )\n",
     "        years.append(year)\n",
     "        debt_impacts.append(debt_impact)\n",
-    "        policies.append(policy_reform_names[i])\n",
-    "\n"
+    "        policies.append(policy_reform_names[i])"
    ]
   },
   {
@@ -339,13 +341,17 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "df = pd.DataFrame({\n",
-    "    \"Year\": years,\n",
-    "    \"Debt impact (£ billions)\": debt_impacts,\n",
-    "    \"Policy\": policies,\n",
-    "})\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"Year\": years,\n",
+    "        \"Debt impact (£ billions)\": debt_impacts,\n",
+    "        \"Policy\": policies,\n",
+    "    }\n",
+    ")\n",
     "\n",
-    "df = df.pivot(columns=\"Year\", index=\"Policy\", values=\"Debt impact (£ billions)\")\n",
+    "df = df.pivot(\n",
+    "    columns=\"Year\", index=\"Policy\", values=\"Debt impact (£ billions)\"\n",
+    ")\n",
     "df = df.iloc[[2, 1, 3, 0]]"
    ]
   },

--- a/src/routing/RedirectToCountry.jsx
+++ b/src/routing/RedirectToCountry.jsx
@@ -1,31 +1,24 @@
+import { useState, useEffect } from "react";
 import { Navigate } from "react-router-dom";
-
-export default function RedirectToCountry() {
-  // Find country ID
-  const countryId = findCountryId();
-
-  return <Navigate to={`/${countryId}`} replace />;
-}
+import { getCountryId } from "../utils/ipinfoCountry.js";
 
 /**
- * Based on the URL and user's browser, determine country ID;
- * if not possible, return "us" as country ID
- * @returns {String}
+ * Redirects the user to their country-specific route based on their IP address.
  */
-export function findCountryId() {
-  const COUNTRY_CODES = {
-    "en-US": "us",
-    "en-GB": "uk",
-    "en-CA": "ca",
-    "en-NG": "ng",
-    "en-IL": "il",
-  };
+export default function RedirectToCountry() {
+  const [countryId, setCountryId] = useState(null);
 
-  const browserLanguage = navigator.language;
+  useEffect(() => {
+    let cancelled = false;
+    getCountryId().then((id) => {
+      if (!cancelled) setCountryId(id);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-  if (Object.keys(COUNTRY_CODES).includes(browserLanguage)) {
-    return COUNTRY_CODES[browserLanguage];
-  } else {
-    return "us";
-  }
+  if (countryId === null) return null;
+
+  return <Navigate to={`/${countryId}`} replace />;
 }

--- a/src/utils/ipinfoCountry.js
+++ b/src/utils/ipinfoCountry.js
@@ -1,0 +1,42 @@
+/**
+ * Returns a PolicyEngine country-id ("uk", "us", …) chosen in this order:
+ *   1. ipinfo.io Lite endpoint
+ *   2. fallback to navigator.language mapping
+ *   3. final default "us"
+ */
+export async function getCountryId() {
+  // IP lookup
+  try {
+    const token = process.env.REACT_APP_IPINFO_TOKEN;
+    const resp = await fetch(`https://api.ipinfo.io/lite/me?token=${token}`);
+    //const resp    = await fetch(`https://ipinfo.io/json?token=${token}`); //in case we ignore ipinfo token
+    if (resp.ok) {
+      //const { country: iso2 = "" } = await resp.json(); //in case we ignore ipinfo token
+      const { country_code: iso2 = "" } = await resp.json();
+      const ISO2 = iso2.toUpperCase();
+
+      // Return the country-id based on the ISO2 code
+      if (["GB", "IM", "JE", "GG"].includes(ISO2)) return "uk";
+      if (ISO2 === "US") return "us";
+      if (ISO2 === "CA") return "ca";
+      if (ISO2 === "NG") return "ng";
+      if (ISO2 === "IL") return "il";
+    }
+  } catch (err) {
+    console.error("ipinfo lookup failed:", err);
+  }
+
+  // language fallback
+  const LANGUAGE_MAP = {
+    "en-GB": "uk",
+    "en-US": "us",
+    "en-CA": "ca",
+    "en-NG": "ng",
+    "en-IL": "il",
+  };
+  const lang = navigator.language;
+  if (LANGUAGE_MAP[lang]) return LANGUAGE_MAP[lang];
+
+  // default
+  return "us";
+}


### PR DESCRIPTION
Fixes #2448 

## Description

Replaces the browser-language–based country detection with an IP-based lookup using ipinfo.io, eliminating frequent mis-localisations 

## Changes

Removed the “guess the visitor’s country from their browser-language”  and replaced it with the IP lookup from ipinfo.io. On the very first page load the app  pings https://api.ipinfo.io/json with a custon token (which could be changed) reads the two-letter country code, translates that into the country  IDs we use internally (“uk”, “us”, “ca”, etc.), and redirects from the root (/) to /{countryId}. If the IP call fails—for example the user is offline or a tracker-blocker gets in the way—  fall back to the old language mapping and finally default to “us”.
