### PR TITLE
Fixed user profile page error

### DIFF
--- a/src/api/call.js
+++ b/src/api/call.js
@@ -4,7 +4,8 @@ import { buildVariableTree, getTreeLeavesInOrder } from "./variables";
 import { wrappedJsonStringify, wrappedResponseJson } from "../data/wrappedJson";
 import { useAuthenticatedFetch } from "../hooks/useAuthenticatedFetch";
 
-const POLICYENGINE_API = "https://api.policyengine.org";
+const POLICYENGINE_API =
+  process.env.REACT_APP_API_URL || "https://api.policyengine.org";
 
 /**
  * returns an api call function that can be used to make requests

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -318,7 +318,9 @@ function UserProfileSection(props) {
   } else if (dispState === STATES.EMPTY) {
     dispUserSince = "Loading";
   } else {
-    dispUserSince = dateFormatter.format(accessedUserProfile.user_since);
+    dispUserSince = dateFormatter.format(
+      new Date(parseInt(accessedUserProfile.user_since) * 1000),
+    );
   }
 
   let dispCountry = "";


### PR DESCRIPTION
## Description

Fixes #2589 

## Changes

- Updated the logic for loading the user profile page to prevent errors when a user profile does not exist yet.
- This fix is paired with the backend fix in [policyengine-api PR #2598](https://github.com/PolicyEngine/policyengine-api/pull/2598), which adds logic to automatically create a user profile during a GET /user-profile call if none exists.

