### PR TITLE
Update cliff impacts to use new schema

### DIFF
--- a/src/pages/policy/output/CliffImpact.jsx
+++ b/src/pages/policy/output/CliffImpact.jsx
@@ -39,10 +39,12 @@ function ImpactPlot(props) {
   const hoverMessage = (x) => {
     const baseline =
       x === "Cliff rate"
-        ? impact.baseline.cliff_share
-        : impact.baseline.cliff_gap;
+        ? impact.cliff_impact.baseline.cliff_share
+        : impact.cliff_impact.baseline.cliff_gap;
     const reform =
-      x === "Cliff rate" ? impact.reform.cliff_share : impact.reform.cliff_gap;
+      x === "Cliff rate"
+        ? impact.cliff_impact.reform.cliff_share
+        : impact.cliff_impact.reform.cliff_gap;
     const change = reform / baseline - 1;
     const formatter = x === "Cliff rate" ? formatPer : formatCur;
     const tolerance = 0.0001;
@@ -181,11 +183,17 @@ export default function cliffImpact(props) {
   // and one for the relative change in the cliff gap.
   const cliffShareChange =
     Math.round(
-      (impact.reform.cliff_share / impact.baseline.cliff_share - 1) * 10000,
+      (impact.cliff_impact.reform.cliff_share /
+        impact.cliff_impact.baseline.cliff_share -
+        1) *
+        10000,
     ) / 10000;
   const cliffGapChange =
     Math.round(
-      (impact.reform.cliff_gap / impact.baseline.cliff_gap - 1) * 1000,
+      (impact.cliff_impact.reform.cliff_gap /
+        impact.cliff_impact.baseline.cliff_gap -
+        1) *
+        1000,
     ) / 1000;
   const chart = (
     <ImpactChart
@@ -212,14 +220,14 @@ export default function cliffImpact(props) {
       ...[
         {
           Metric: "Cliff rate",
-          Baseline: impact.baseline.cliff_share,
-          Reform: impact.reform.cliff_share,
+          Baseline: impact.cliff_impact.baseline.cliff_share,
+          Reform: impact.cliff_impact.reform.cliff_share,
           Change: cliffShareChange,
         },
         {
           Metric: "Cliff gap",
-          Baseline: impact.baseline.cliff_gap,
-          Reform: impact.reform.cliff_gap,
+          Baseline: impact.cliff_impact.baseline.cliff_gap,
+          Reform: impact.cliff_impact.reform.cliff_gap,
           Change: cliffGapChange,
         },
       ].map((row) => [row.Metric, row.Baseline, row.Reform, row.Change]),


### PR DESCRIPTION
## Description

Fixes #2620. 
Fixes #2518.
This doesn't require https://github.com/PolicyEngine/policyengine-api/pull/2606 per se, but the cliff impacts feature will remain broken until it and this PR are fully merged.

## Changes

This PR modifies the `CliffImpact.jsx` component to use the proper `impact` schema, introduced as part of the simulation API.

## Screenshots

This screenshot shows the changes from both this PR and https://github.com/PolicyEngine/policyengine-api/pull/2606.
<img width="1440" alt="Screen Shot 2025-06-23 at 5 29 21 PM" src="https://github.com/user-attachments/assets/d2b541be-2d46-427c-8066-7870102e4e6c" />

## Tests

N/A
