### PR TITLE
Updated styling for the display card to match result cards

### DIFF
--- a/src/pages/learn/APIGeneralContent.jsx
+++ b/src/pages/learn/APIGeneralContent.jsx
@@ -509,7 +509,7 @@ export function VariableParameterExplorer(props) {
       </div>
 
       {totalPages > 1 && (
-        <div style={{ marginTop: 20, textAlign: "center" }}>
+        <div style={{ marginTop: 20, marginBottom: 20, textAlign: "center" }}>
           <div
             style={{ display: "inline-flex", alignItems: "center", gap: "8px" }}
           >
@@ -674,11 +674,22 @@ function CardDrawer(props) {
   const type = metadata.type;
   return (
     <>
-      {type === "parameter" ? (
-        <APIParameterCard metadata={metadata} />
-      ) : (
-        <APIVariableCard metadata={metadata} />
-      )}
+      <Card
+        bordered={true}
+        style={{
+          width: "100%",
+          backgroundColor: "white",
+          overflow: "hidden",
+          cursor: "pointer",
+          transition: "transform 0.2s",
+        }}
+      >
+        {type === "parameter" ? (
+          <APIParameterCard metadata={metadata} />
+        ) : (
+          <APIVariableCard metadata={metadata} />
+        )}
+      </Card>
     </>
   );
 }


### PR DESCRIPTION
Fixes #2587  
## Description
Fixing design for the selected display card

## Changes
- Updating the design to be more inline with rest of the cards
- Stretching the display card and its content to full width of the window 

## Screenshots
<img width="1268" height="337" alt="Screenshot 2025-07-13 at 11 57 42 PM" src="https://github.com/user-attachments/assets/97a40370-3363-4d8a-8a72-c6aa2be6575a" />
