### PR TITLE
Updating PR workflow to use Node v20

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
         # by our package.json.
         # Hopefully this allows us to catch problems
         # with differing versions ahead of time.
-        node-version: [19.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #2203 
## Description
Updated PR Workflow to use Node v20

## Changes
Node v19 was deployed off in the latest workflow, updated the node to v20

## Screenshots
Workflow of this PR
<img width="1302" height="791" alt="Screenshot 2025-07-14 at 12 37 18 AM" src="https://github.com/user-attachments/assets/a607ca9e-a23f-4f78-95dd-df2f9b0b5d64" />

