### PR TITLE
Filter household outputs

### DIFF
--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -438,6 +438,11 @@ function HouseholdLeftSidebar(props) {
     metadata.countryId,
   );
 
+  const displayTree = filterTreeForDisplay(
+    metadata.variableTree.children,
+    metadata.countryId,
+  );
+
   return (
     <div>
       {!isOnOutput && (
@@ -446,7 +451,7 @@ function HouseholdLeftSidebar(props) {
         </div>
       )}
       <StackedMenu
-        firstTree={metadata.variableTree.children}
+        firstTree={displayTree}
         selected={selected}
         onSelect={onSelect}
         secondTree={HOUSEHOLD_OUTPUT_TREE[0].children}
@@ -488,6 +493,22 @@ export function addCustomInputs(displayTree, countryId) {
   }
 
   return displayTree;
+}
+
+export function filterTreeForDisplay(tree, countryId) {
+  // US household calculator will temporarily display input.geography
+  // until the county name input is made searchable, then it will be removed
+  const US_CATEGORIES_TO_DISPLAY = ["input.household", "input.geography"];
+
+  if (countryId === "us") {
+    return tree.filter((node) =>
+      US_CATEGORIES_TO_DISPLAY.some((category) =>
+        node.name.startsWith(category),
+      ),
+    );
+  }
+
+  return tree.filter((node) => node.name.startsWith("input.household"));
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #2590 

## Changes

Adds a function to filter all variables for the inputs we specifically want to display. Temporarily leaves "Geography" as an input for the US until we can make the "County name" component searchable as part of #2604.

## Screenshots

US:
<img width="1440" height="673" alt="Screen Shot 2025-07-14 at 12 41 11 AM" src="https://github.com/user-attachments/assets/fb5e9dd0-08d8-4252-9970-5f0a377c5adb" />

UK:
<img width="1440" height="673" alt="Screen Shot 2025-07-14 at 12 41 25 AM" src="https://github.com/user-attachments/assets/1192005e-6097-43cc-8a42-64f637ecfd5c" />

## Tests

None added, just confirmed visually.
