### PR TITLE
Allow clipboard access for OBBBA iframe

### DIFF
--- a/src/applets/OBBBAHouseholdExplorer.jsx
+++ b/src/applets/OBBBAHouseholdExplorer.jsx
@@ -56,6 +56,7 @@ export default function OBBBAHouseholdExplorer() {
           height={`calc(100vh - ${style.spacing.HEADER_HEIGHT})`}
           width="100%"
           style={{ overflow: "hidden" }}
+          allow="clipboard-write"
         />
       </div>
     </>


### PR DESCRIPTION
## Description

Fixes #2684

This PR adds the `allow="clipboard-write"` permission to the OBBBA iframe, enabling the embedded app to copy URLs to the clipboard.

## Problem

When users click the 🔗 (copy link) button in the OBBBA Household Explorer at https://policyengine.org/us/obbba-household-explorer, they get a permissions error:

```
[Violation] Permissions policy violation: The Clipboard API has been blocked because of a permissions policy applied to the current document.
```

## Solution

Added `allow="clipboard-write"` attribute to the iframe element. This explicitly grants the embedded content permission to use the Clipboard API.

## Changes

```diff
<iframe
  ref={iframeRef}
  src={iframeUrl}
  title="OBBBA Household Explorer"
  height={`calc(100vh - ${style.spacing.HEADER_HEIGHT})`}
  width="100%"
  style={{ overflow: "hidden" }}
+ allow="clipboard-write"
/>
```

## Testing

1. Visit https://policyengine.org/us/obbba-household-explorer
2. Navigate to any household view
3. Click the 🔗 button
4. The URL should be copied to clipboard without errors
5. Check browser console - should not show permissions policy violations

## Note

The OBBBA app already has robust fallback mechanisms if clipboard access fails, but with this permission, the primary Clipboard API method should work correctly.