### PR TITLE
Fix duplicate path in OBBBA iframe URL

### DIFF
--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -10,15 +10,8 @@ function getOBBBAIframeUrl() {
   // GitHub Pages deployment uses base path /obbba-scatter
   const githubPagesUrl = "https://policyengine.github.io/obbba-scatter";
 
-  // In production, we need to account for the base path
-  // The actual app is served from /obbba-scatter/ subdirectory
-  if (process.env.NODE_ENV === "production") {
-    // Check if the base URL is accessible (this would be done at build time)
-    // For now, we use the correct URL with base path
-    return `${githubPagesUrl}/obbba-scatter`;
-  }
-
-  // In development, use the base URL
+  // Always use the base GitHub Pages URL
+  // The obbba-scatter app is already served from the /obbba-scatter path
   return githubPagesUrl;
 }
 

--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -11,7 +11,8 @@ function getOBBBAIframeUrl() {
   const githubPagesUrl = "https://policyengine.github.io/obbba-scatter";
 
   // Always use the base GitHub Pages URL
-  // The obbba-scatter app is already served from the /obbba-scatter path
+  // GitHub Pages automatically serves the repository content from the /obbba-scatter base path.
+  // No additional path concatenation is needed.
   return githubPagesUrl;
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a critical bug that's preventing deep links from working on the OBBBA household explorer.

## The Problem

After the previous PR (#2688) was merged and deployed, deep links like https://policyengine.org/us/obbba-household-explorer?household=46067&baseline=tcja-expiration still don't work.

The issue is that the environment.js file was constructing an incorrect URL in production:
- **Wrong**: `https://policyengine.github.io/obbba-scatter/obbba-scatter` (404 error)
- **Correct**: `https://policyengine.github.io/obbba-scatter`

## The Fix

This PR simplifies the URL logic. The GitHub Pages app already handles the `/obbba-scatter` base path internally, so we don't need to add it again.

## Testing

After this fix is deployed:
1. Deep links will work: https://policyengine.org/us/obbba-household-explorer?household=46067&baseline=tcja-expiration
2. The iframe will load from the correct URL
3. URL parameters will be properly passed to the embedded app

## Related Issues

- Follows up on PR #2688 which added the initial iframe URL configuration
- The issue was discovered when testing the production deployment