### PR TITLE
Revert OBBBA household explorer to use Streamlit URL

### DIFF
--- a/src/PolicyEngine.jsx
+++ b/src/PolicyEngine.jsx
@@ -44,7 +44,6 @@ import style from "./style";
 import RedirectToCountry from "./routing/RedirectToCountry";
 import CountryIdLayout from "./routing/CountryIdLayout";
 import RedirectBlogPost from "./routing/RedirectBlogPost";
-import RedirectOBBBAHouseholdExplorer from "./routing/RedirectOBBBAHouseholdExplorer";
 import { StatusPage } from "./pages/StatusPage";
 import ManifestosComparison from "./applets/ManifestosComparison";
 import DeveloperLayout from "./pages/DeveloperLayout";
@@ -387,11 +386,6 @@ export default function PolicyEngine() {
           />
           {/* redirect from /countryId/blog/slug to /countryId/research/slug */}
           <Route path="blog/:postName" element={<RedirectBlogPost />} />
-          {/* redirect from old obbba-household-explorer to obbba-household-by-household */}
-          <Route
-            path="obbba-household-explorer"
-            element={<RedirectOBBBAHouseholdExplorer />}
-          />
         </Route>
         <Route path="/uk/cec" element={<CitizensEconomicCouncil />} />
         <Route path="/uk/2024-manifestos" element={<ManifestosComparison />} />

--- a/src/apps/apps.json
+++ b/src/apps/apps.json
@@ -2,8 +2,8 @@
   {
     "title": "OBBBA household impact explorer",
     "description": "Interactive tool to explore household-level impacts of the One Big Beautiful Bill Act",
-    "url": "https://policyengine.github.io/obbba-scatter",
-    "slug": "obbba-household-by-household",
+    "url": "https://obbba-household-explorer.streamlit.app/",
+    "slug": "obbba-household-explorer",
     "tags": ["us", "featured", "policy"]
   }
 ]

--- a/src/routing/RedirectOBBBAHouseholdExplorer.jsx
+++ b/src/routing/RedirectOBBBAHouseholdExplorer.jsx
@@ -1,7 +1,0 @@
-import { Navigate, useParams } from "react-router-dom";
-
-export default function RedirectOBBBAHouseholdExplorer() {
-  const { countryId } = useParams();
-
-  return <Navigate to={`/${countryId}/obbba-household-by-household`} replace />;
-}


### PR DESCRIPTION
## Summary
- Reverts the app back to its original configuration
- Uses the original slug: `obbba-household-explorer`
- Points to the Streamlit app: https://obbba-household-explorer.streamlit.app/
- Removes the redirect component and route

## Context
Based on user feedback, we're reverting the OBBBA household explorer to point to its original Streamlit URL instead of using a redirect to a new slug.

## Test plan
- [ ] Verify the app loads at `/us/obbba-household-explorer`
- [ ] Confirm it displays the Streamlit app in an iframe
- [ ] Ensure build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)