### PR TITLE
Fix Node version mismatch causing deployment failures

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
         # by our package.json.
         # Hopefully this allows us to catch problems
         # with differing versions ahead of time.
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
       - name: Install repository
         run: npm ci
       - name: Run tests

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: "22.x"
       - name: Install repository
         run: npm ci
       - name: Run tests

--- a/jest.config.js
+++ b/jest.config.js
@@ -70,7 +70,7 @@ module.exports = {
   transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
   testMatch: ["**/__tests__/**/*.test.js"],
   moduleNameMapper: {
-    "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|md)$":
+    "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|md|ipynb)$":
       "<rootDir>/src/__tests__/__setup__/fileMock.js",
     "\\.(css|less)$": "<rootDir>/src/__tests__/__setup__/fileMock.js",
   },


### PR DESCRIPTION
## Summary
- Updates GitHub Actions workflows to use Node 22.x
- Fixes deployment failures that started after PR #2667

## Problem
The package.json requires Node >=22.0.0, but PR #2667 changed the PR workflow to use Node 20.x. This version mismatch caused all deployments to fail starting with commit 115dd1d0.

## Solution
- Update PR workflow from Node 20.x to 22.x
- Add Node.js setup step to push workflow with version 22.x (it was using default version)
- Both workflows now properly match the package.json requirement

## Test plan
- [ ] PR checks should pass with Node 22.x
- [ ] Deployment should succeed after merge

Fixes the deployment failures from:
- https://github.com/PolicyEngine/policyengine-app/actions/runs/16486648107
- https://github.com/PolicyEngine/policyengine-app/actions/runs/16485694458
- https://github.com/PolicyEngine/policyengine-app/actions/runs/16484538920