### PR TITLE
Fix OBBBA URL sync 'one behind' issue

### DIFF
--- a/src/pages/AppPage.jsx
+++ b/src/pages/AppPage.jsx
@@ -17,11 +17,11 @@ export default function AppPage() {
   const isOBBBAApp = app?.slug === "obbba-household-by-household";
   const [initialUrl, setInitialUrl] = useState(null);
 
-  // Construct iframe URL with parameters (for OBBBA app only on initial load)
+  // Construct initial iframe URL with parameters
   useEffect(() => {
-    if (!app) return;
+    if (!app || initialUrl) return;
 
-    if (isOBBBAApp && !initialUrl) {
+    if (isOBBBAApp) {
       const baseUrl = app.url;
       const separator = baseUrl.includes("?") ? "&" : "?";
       const urlParams = new URLSearchParams(location.search);
@@ -31,11 +31,11 @@ export default function AppPage() {
         : baseUrl;
 
       setInitialUrl(url);
-    } else if (!isOBBBAApp) {
+    } else {
       // For non-OBBBA apps, just use the app URL
       setInitialUrl(app.url);
     }
-  }, [app, location.search, initialUrl, isOBBBAApp]);
+  }, [app, location.search, isOBBBAApp, initialUrl]);
 
   // Listen for messages from OBBBA iframe
   useEffect(() => {
@@ -48,8 +48,15 @@ export default function AppPage() {
 
         // Handle URL update messages from the iframe
         if (event.data?.type === "urlUpdate" && event.data?.params) {
+          console.log("Received urlUpdate from iframe:", event.data.params);
           const newParams = new URLSearchParams(event.data.params);
-          navigate(`${location.pathname}?${newParams.toString()}`, {
+          const newParamsString = newParams.toString();
+          console.log(
+            "Navigating to:",
+            `${location.pathname}?${newParamsString}`,
+          );
+
+          navigate(`${location.pathname}?${newParamsString}`, {
             replace: true,
           });
         }


### PR DESCRIPTION
## Summary
Added debugging to diagnose the "one behind" issue where the parent app URL lags behind the iframe's displayed household ID.

## Problem
After the initial OBBBA deep linking fix was merged, there's still an issue where:
- The URL parameter in the parent app is one step behind the actual displayed household in the iframe
- This doesn't occur when accessing the obbba-scatter app directly

## Changes
- Added console logging to trace when the iframe sends URL updates
- This will help identify if the iframe is sending outdated parameters

## Next Steps
Once we see the debug output, we can determine if:
1. The iframe is sending the old URL before updating its own state
2. There's a timing issue in how we handle the message
3. We need to coordinate with the obbba-scatter app to fix the message timing

🤖 Generated with [Claude Code](https://claude.ai/code)