### PR TITLE
Use conditional chaining to prevent MarkdownFormatter breakage

### DIFF
--- a/src/layout/MarkdownFormatter.jsx
+++ b/src/layout/MarkdownFormatter.jsx
@@ -369,7 +369,7 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict, pSize }) {
           // If href=#user-content-fn-1, id should be user-content-fnref-1 and vice versa
           if (href.startsWith("#user-content-fn-")) {
             id = href.replace("#user-content-fn-", "user-content-fnref-");
-            footnoteNumber = parseInt(id?.split("-").pop());
+            footnoteNumber = parseInt(id?.split("-").pop() || "0");
           } else if (href.startsWith("#user-content-fnref-")) {
             id = href.replace("#user-content-fnref-", "user-content-fn-");
           } else {

--- a/src/layout/MarkdownFormatter.jsx
+++ b/src/layout/MarkdownFormatter.jsx
@@ -319,7 +319,7 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict, pSize }) {
               .props.children.find(
                 (child) => child?.props?.node.tagName === "a",
               ).props.node.properties.href;
-            value = footnoteLinkBack?.split("-").pop();
+            value = footnoteLinkBack?.split("-").pop() || "";
             validValue = /^-?\d+$/.test(value);
           } catch (e) {
             // Do nothing

--- a/src/layout/MarkdownFormatter.jsx
+++ b/src/layout/MarkdownFormatter.jsx
@@ -319,7 +319,7 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict, pSize }) {
               .props.children.find(
                 (child) => child?.props?.node.tagName === "a",
               ).props.node.properties.href;
-            value = footnoteLinkBack.split("-").pop();
+            value = footnoteLinkBack?.split("-").pop();
             validValue = /^-?\d+$/.test(value);
           } catch (e) {
             // Do nothing
@@ -369,7 +369,7 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict, pSize }) {
           // If href=#user-content-fn-1, id should be user-content-fnref-1 and vice versa
           if (href.startsWith("#user-content-fn-")) {
             id = href.replace("#user-content-fn-", "user-content-fnref-");
-            footnoteNumber = parseInt(id.split("-").pop());
+            footnoteNumber = parseInt(id?.split("-").pop());
           } else if (href.startsWith("#user-content-fnref-")) {
             id = href.replace("#user-content-fnref-", "user-content-fn-");
           } else {
@@ -475,7 +475,7 @@ export function MarkdownFormatter({ markdown, backgroundColor, dict, pSize }) {
           }
         },
         h2: ({ children: headerText }) => {
-          if (!headerText.split) {
+          if (!headerText?.split) {
             headerText = "";
           }
           // Remove slashes and commas, and replace spaces with dashes to create a


### PR DESCRIPTION
## Description

Fixes #2664.

## Changes

In a couple spots, the `MarkdownFormatter` attempts to access attributes or methods that may not be present if a given input is `undefined`. This includes the header formatting function, which attempts to take a string and use `String.split()` to divide the header into segments before styling, but if a given input is not a string, `MarkdownFormatter` crashes.

This PR uses optional chaining to prevent this error in a few locations that use `String.split()`. It leaves out the line reading:
```
    [leftContent, rightContent] = content.split("&&&");
```
As this will actually resolve to `undefined` if optional chaining is employed due to the array spread operator.

These changes do not remove `MarkdownFormatter`. Removing `MarkdownFormatter` would first require minor API-side changes, as the prompt we employ instructs Claude to return code in markdown. @MaxGhenis if you'd still prefer that we remove `MarkdownFormatter`, I can do so, but would recommend first pushing this to re-enable the feature.

## Screenshots

https://github.com/user-attachments/assets/ec02098b-7f10-4ac8-ae78-29906cd3b2ac

## Tests

N/A
