### PR TITLE
Add checkboxes to toggle parameters and variables in explorer

### DIFF
--- a/src/pages/learn/APIGeneralContent.jsx
+++ b/src/pages/learn/APIGeneralContent.jsx
@@ -400,7 +400,10 @@ export function VariableParameterExplorer(props) {
   const { metadata } = props;
   const [query, setQuery] = useState("");
   const [selectedCardData, setSelectedCardData] = useState(null);
+
   const [showAbolitions, setShowAbolitions] = useState(false);
+  const [showParameters, setShowParameters] = useState(true);
+  const [showVariables, setShowVariables] = useState(true);
 
   const [page, setPage] = useState(0);
 
@@ -444,11 +447,17 @@ export function VariableParameterExplorer(props) {
     .filter(filterByQuery)
     .map((v) => ({ ...v, type: "variable" }));
 
-  const allCards = [...parameterCards, ...variableCards].sort((a, b) => {
+  const filteredCards = [
+    ...(showParameters ? parameterCards : []),
+    ...(showVariables ? variableCards : []),
+  ];
+
+  const allCards = filteredCards.sort((a, b) => {
     const labelA = (a.label || a.name || "").toLowerCase();
     const labelB = (b.label || b.name || "").toLowerCase();
     return labelA.localeCompare(labelB);
   });
+
   const totalPages = Math.ceil(allCards.length / CARDS_PER_PAGE);
   const currentCards = allCards.slice(
     page * CARDS_PER_PAGE,
@@ -471,7 +480,7 @@ export function VariableParameterExplorer(props) {
           padding: "8px",
         }}
       />
-      <div style={{ marginBottom: 10 }}>
+      <div style={{ marginBottom: 10, display: "flex", gap: "20px" }}>
         <label style={{ fontSize: "14px", cursor: "pointer" }}>
           <input
             type="checkbox"
@@ -493,6 +502,32 @@ export function VariableParameterExplorer(props) {
               }}
             />
           </Tooltip>
+        </label>
+
+        <label style={{ fontSize: "14px", cursor: "pointer" }}>
+          <input
+            type="checkbox"
+            checked={showParameters}
+            onChange={() => {
+              setShowParameters((prev) => !prev);
+              setPage(0);
+            }}
+            style={{ marginRight: 8 }}
+          />
+          Show parameters
+        </label>
+
+        <label style={{ fontSize: "14px", cursor: "pointer" }}>
+          <input
+            type="checkbox"
+            checked={showVariables}
+            onChange={() => {
+              setShowVariables((prev) => !prev);
+              setPage(0);
+            }}
+            style={{ marginRight: 8 }}
+          />
+          Show variables
         </label>
       </div>
       <div


### PR DESCRIPTION
## Description
This PR adds separate checkboxes to toggle visibility of parameters and variables in the VariableParameterExplorer. It improves user control over the types of data shown in the result cards.

## Changes
- Added two new checkboxes: "Show parameters" and "Show variables"
- Introduced showParameters and showVariables state hooks
- Updated filtering logic to conditionally include cards based on checkbox state

## Screenshots
<img width="1512" height="795" alt="Screenshot 2025-07-27 at 10 37 51 PM" src="https://github.com/user-attachments/assets/c61f0e98-9e7f-4d7f-89f4-bd351dcb08e8" />
