### PR TITLE
Fix: Ensure data.json is generated before tests run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ debug:
 	REACT_APP_DEBUG=true npm start
 
 test:
-	node metadata_fetch.mjs
 	npm run test
 
 deploy-setup:

--- a/metadata_fetch.mjs
+++ b/metadata_fetch.mjs
@@ -6,8 +6,10 @@ let metadataUS = null;
 let metadataUK = null;
 let metadataCA = null;
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
+// Fix for Windows path issues
+const normalizedDirname = __dirname.startsWith('/') ? __dirname.slice(1) : __dirname;
 const filePath = path.join(
-  __dirname,
+  normalizedDirname,
   "src",
   "__tests__",
   "__setup__",

--- a/metadata_fetch.mjs
+++ b/metadata_fetch.mjs
@@ -7,7 +7,9 @@ let metadataUK = null;
 let metadataCA = null;
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 // Fix for Windows path issues
-const normalizedDirname = __dirname.startsWith('/') ? __dirname.slice(1) : __dirname;
+const normalizedDirname = __dirname.startsWith("/")
+  ? __dirname.slice(1)
+  : __dirname;
 const filePath = path.join(
   normalizedDirname,
   "src",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "pretest": "node metadata_fetch.mjs",
     "test": "jest",
     "eject": "react-scripts eject",
     "fix": "eslint --fix --ext js,jsx . && prettier -w .",


### PR DESCRIPTION
- Fix Windows path issue in metadata_fetch.mjs
- Add pretest script to package.json for automatic data generation
- Simplify Makefile by removing manual metadata fetch call
- Resolves issue #2711

## Description

Please provide a summary of the changes and which issue is fixed. Please include relevant motivation and context.

## Changes

Please describe the changes in detail.

## Screenshots

Please include concise visuals (videos, screenshots, etc.) demonstrating the code in action and the impact of changes. Many on the team use a free tool called [Loom](https://www.loom.com/) to capture and share short clips, but feel free to utilize any tool you'd like. Screenshots of the code itself can also be helpful, but are usually not necessary.

## Tests

Please describe how the change has been tested.
