### PR TITLE
Fixed issue 1936: brackets sorting

### DIFF
--- a/src/api/parameters.js
+++ b/src/api/parameters.js
@@ -31,8 +31,10 @@ export function buildParameterTree(parameters) {
         (cumulativePath in parameters && parameters[cumulativePath].label) ||
         key;
       // Transform e.g. "0]" -> 1
+      let bracketIndex = 0;
       if (key.endsWith("]")) {
-        label = `Bracket ${parseInt(key.slice(0, -1)) + 1}`;
+        bracketIndex = parseInt(key.slice(0, -1));
+        label = `Bracket ${bracketIndex + 1}`;
       }
       label = label.replaceAll("_", " ");
       if (!currentNode.children) {
@@ -46,7 +48,7 @@ export function buildParameterTree(parameters) {
         currentNode.children.push({
           label: label,
           name: cumulativePath,
-          index: 0,
+          index: bracketIndex,
           children: [],
         });
       }

--- a/src/pages/PolicyPage.jsx
+++ b/src/pages/PolicyPage.jsx
@@ -75,7 +75,14 @@ function PolicyLeftSidebar(props) {
   const sortTreeInPlace = (tree) => {
     if (!Array.isArray(tree)) return [];
 
-    tree.sort((a, b) => a.label.localeCompare(b.label));
+    // Check if all nodes are bracket nodes
+    const allBrackets = tree.every((item) => /^Bracket \d+$/.test(item.label));
+    // If all nodes are bracket nodes, sort numerically by index else sort alphabetically by label
+    if (allBrackets) {
+      tree.sort((a, b) => a.index - b.index);
+    } else {
+      tree.sort((a, b) => a.label.localeCompare(b.label));
+    }
 
     tree.forEach((item) => {
       if (Array.isArray(item.children)) {


### PR DESCRIPTION
Fixes #1936 

## Description

This PR fixes the incorrect ordering of bracketed parameter nodes (e.g., "Bracket 10" appearing before "Bracket 2") in the parameter tree sidebar. The issue was caused by missing index assignments for bracket nodes in the parameter tree construction, and by sorting logic that did not distinguish between bracket and non-bracket nodes. This change ensures bracket nodes are always sorted numerically, while all other nodes are sorted alphabetically.

## Changes

_Parameter Tree Construction (parameters.js)_

Assigns a numeric index to bracket nodes during tree construction, based on their bracket number.
Non-bracket nodes retain their default or module-based index.

_Tree Sorting Logic (PolicyPage.jsx):_

Updates the sortTreeInPlace function to:
Detect if all nodes at a given tree level are bracket nodes (using a regex on the label).
Sort bracket nodes numerically by their index property.
Sort all other nodes alphabetically by their label.

## Screenshots

https://www.loom.com/share/cec71fa84dae43e6b58b7e08b49782d1?sid=3d6c2f5a-b909-4bdf-9dbd-790bf173b26d

## Tests

Manually verified in the UI that bracketed parameters are now always sorted numerically, even for double-digit brackets. Confirmed that non-bracket nodes remain sorted alphabetically.
