### PR TITLE
Fix OBBBA household-by-household tool URL

### DIFF
--- a/src/apps/apps.json
+++ b/src/apps/apps.json
@@ -9,7 +9,7 @@
   {
     "title": "OBBBA household-by-household analysis",
     "description": "Detailed household-by-household impact analysis of the One Big Beautiful Bill Act",
-    "url": "https://policyengine.github.io/obbba-scatter",
+    "url": "https://policyengine.github.io/obbba-household-by-household",
     "slug": "obbba-household-by-household",
     "tags": ["us", "featured", "policy"]
   }


### PR DESCRIPTION
## Summary
Simple fix to update the URL for the OBBBA household-by-household tool from the old repository name to the new one.

## Changes
- Update URL in `src/apps/apps.json` from `obbba-scatter` to `obbba-household-by-household`

This matches the renamed GitHub Pages deployment at https://policyengine.github.io/obbba-household-by-household

🤖 Generated with [Claude Code](https://claude.ai/code)