### PR TITLE
replaced hardcoded API URL with environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_POLICYENGINE_API=https://api.policyengine.org

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ REACT_APP_DEBUG ?= false
 
 install:
 	npm ci
+	cp .env.example .env
 	pip3 install -U black
 
 build:

--- a/src/__tests__/api/call.test.js
+++ b/src/__tests__/api/call.test.js
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { useAuthenticatedApiCall } from "../../api/call";
 import * as authenticatedFetch from "../../hooks/useAuthenticatedFetch";
+import { POLICYENGINE_API } from "../../constants";
 
 jest.mock("../../hooks/useAuthenticatedFetch");
 let mock_authenticated_fetch;
@@ -36,7 +37,7 @@ describe("useAuthenticatedApiCall", () => {
 
     expect(response).toEqual(DEFAULT_FETCH_RESULT);
     expect(mock_authenticated_fetch.mock.calls[0]).toEqual([
-      "https://api.policyengine.org/test/path",
+      POLICYENGINE_API + "/test/path",
       {
         body: JSON.stringify(SOME_REQUEST_BODY),
         headers: {

--- a/src/api/call.js
+++ b/src/api/call.js
@@ -3,8 +3,7 @@ import { buildParameterTree } from "./parameters";
 import { buildVariableTree, getTreeLeavesInOrder } from "./variables";
 import { wrappedJsonStringify, wrappedResponseJson } from "../data/wrappedJson";
 import { useAuthenticatedFetch } from "../hooks/useAuthenticatedFetch";
-
-const POLICYENGINE_API = "https://api.policyengine.org";
+import { POLICYENGINE_API } from "../constants";
 
 /**
  * returns an api call function that can be used to make requests

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,2 @@
+export const POLICYENGINE_API =
+  process.env.REACT_APP_POLICYENGINE_API || "https://api.policyengine.org";


### PR DESCRIPTION
Fixes #2493 

## Description
Added environment configuration template, centralized API URL in constants, updated apiCall with fallback, and aligned tests with new constants setup

## Changes
- Created .env.example file as a template for environment configuration
- Created a constants.js file under src/api to pull the API URL through the process.env, if not it will fallback to the hardcoded URL mentioned.
- Added a Makefile command to automatically copy .env.example to .env
- Imported API URL from constants to use be used as a constant in call.js .
- Modified the apiCall function to use API URL constant

## Tests
- Updated the call.test.js to use the API URL from constants
