### PR TITLE
Fix UK behavioral response calculations returning zero FTE impacts

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,4 +2,3 @@
   changes:
     fixed:
       - Fixed UK behavioral response calculations returning zero FTE impacts by updating parameter names to match UK API expectations
-

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,5 @@
-- bump: minor
+- bump: patch
   changes:
-    added:
-      - Add detailed childcare policy analysis report
+    fixed:
+      - Fixed UK behavioral response calculations returning zero FTE impacts by updating parameter names to match UK API expectations
+

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -111,10 +111,10 @@ function BehavioralResponseToggle(props) {
   const behavioralResponseReforms = useMemo(
     () => ({
       uk: {
-        "gov.simulation.labor_supply_responses.income_elasticity": {
+        "gov.behavioral_responses.labor_supply_income_elasticity": {
           [dateString]: -0.05,
         },
-        "gov.simulation.labor_supply_responses.substitution_elasticity": {
+        "gov.behavioral_responses.labor_supply_substitution_elasticity": {
           [dateString]: 0.25,
         },
       },


### PR DESCRIPTION
Fixes #2741

**Problem**

The behavioral response implementation for the UK was systematically returning zero FTE (Full-Time Equivalent) impacts despite valid policy reforms with significant income effects. This affected the accuracy of dynamic scoring for tax and benefit policy changes on the UK site.

**Root Cause**

The web application was using outdated parameter names that don't match what the UK backend API expects for behavioral response elasticities. While the US parameters were correctly configured, the UK parameters were using an old naming convention (gov.simulation.labor_supply_responses.*) instead of the correct API parameters.

**Solution**

Updated the behavioral response parameter names in PolicyRightSidebar.jsx to match the UK API expectations:
- Changed gov.simulation.labor_supply_responses.income_elasticity → gov.behavioral_responses.labor_supply_income_elasticity
- Changed gov.simulation.labor_supply_responses.substitution_elasticity → gov.behavioral_responses.labor_supply_substitution_elasticity
