### PR TITLE
Update officewarming date to October 22

### DIFF
--- a/src/posts/articles/dc-office-ai-coding.md
+++ b/src/posts/articles/dc-office-ai-coding.md
@@ -25,9 +25,9 @@ We moved into the [Open Gov Hub](https://www.opengovhub.org/). The [microsite](h
 
 ## Join us
 
-This Wednesday, our DC team (Max, Daphne, Pavel, and David) is hosting an officewarming with bites and drinks. This one's just for fun.
+Our DC team (Max, Daphne, Pavel, and David) is hosting an officewarming with bites and drinks. This one's just for fun.
 
-**When:** Wednesday, October 9, 5:30-7:30 PM
+**When:** Wednesday, October 22, 5:30-7:30 PM
 
 **Where:** Open Gov Hub, 1100 13th St NW, Washington, DC 20005
 

--- a/src/posts/posts.json
+++ b/src/posts/posts.json
@@ -10,7 +10,7 @@
   },
   {
     "title": "How we used Claude Code to choose our DC office",
-    "description": "We used Claude Code to build an interactive comparison tool for choosing our DC office. The winner: Open Gov Hub. Join us Wednesday to celebrate!",
+    "description": "We used Claude Code to build an interactive comparison tool for choosing our DC office. The winner: Open Gov Hub. Join us Oct 22 to celebrate!",
     "date": "2025-10-05",
     "tags": ["us", "org", "ai"],
     "authors": ["max-ghenis", "daphne-hansell"],


### PR DESCRIPTION
Pushes back the DC officewarming event from October 8 to October 22.

Changes:
- Blog post date updated
- Description updated to mention Oct 22

The event is now scheduled for:
**Wednesday, October 22, 5:30-7:30 PM**
Open Gov Hub, 1100 13th St NW, Washington, DC 20005