### PR TITLE
Add plugin auto-install and improve blog workflow documentation

### DIFF
--- a/.claude/agents/blog-post-reviewer.md
+++ b/.claude/agents/blog-post-reviewer.md
@@ -30,12 +30,14 @@ You review PolicyEngine blog posts to ensure they follow formatting standards, a
 - **Images**: Reference `/images/posts/filename.jpg` (served from public directory)
 - **Links**: Use descriptive link text, not bare URLs
 
-### Image Requirements
+### Image and Chart Requirements
 
 - **Cover image**: Must exist in `src/images/posts/` (loaded via require() at build time)
-- **Naming convention**: Cover image filename should match post slug (e.g., `dc-office-ai-coding.md` → `dc-office-ai-coding.png`)
+- **Naming convention**: Cover image filename MUST match post slug exactly (e.g., `california-billionaire-tax-marginal-rates.md` → `california-billionaire-tax-marginal-rates.jpg`)
 - **In-post images**: Must exist in `public/images/posts/` (served at runtime via /images/posts/ URL)
-- **Format**: PNG or JPG, optimized for web
+- **Interactive charts**: Organized in `public/charts/[post-slug]/` with simple names (phase-in.html, liability.html, mtr.html)
+- **Chart references**: `<iframe src="/charts/[post-slug]/chart-name.html" width="100%" height="650" frameborder="0"></iframe>`
+- **Format**: PNG or JPG for images, HTML for interactive Plotly charts
 
 ### Writing Style
 

--- a/.claude/commands/add-blog-post.md
+++ b/.claude/commands/add-blog-post.md
@@ -72,19 +72,33 @@ echo "Description length: ${#DESC} characters"
 [RSVP link](https://example.com)
 ```
 
-## Step 4: Handle Images
+## Step 4: Handle Images and Charts
 
 ### Cover Image
 
 ```bash
-# IMPORTANT: Cover image filename MUST match post slug
-# Example: dc-office-ai-coding.md → dc-office-ai-coding.png
+# IMPORTANT: Cover image filename MUST match post slug exactly
+# Example: california-billionaire-tax-marginal-rates.md → california-billionaire-tax-marginal-rates.jpg
 
 # Cover images go in src/images/posts/ (loaded via require() at build time)
-mv [source-path] src/images/posts/[post-slug].png
+mv [source-path] src/images/posts/[post-slug].jpg
 
 # Verify it exists
-ls -lh src/images/posts/[post-slug].png
+ls -lh src/images/posts/[post-slug].jpg
+```
+
+### Interactive Charts (Plotly HTML)
+
+```bash
+# Charts organized in subfolder matching post slug
+mkdir -p public/charts/[post-slug]
+
+# Simple names: phase-in.html, liability.html, mtr.html, etc.
+cp chart1.html public/charts/[post-slug]/phase-in.html
+cp chart2.html public/charts/[post-slug]/liability.html
+
+# Reference in markdown as:
+# <iframe src="/charts/[post-slug]/phase-in.html" width="100%" height="650" frameborder="0"></iframe>
 ```
 
 ### In-Post Images
@@ -97,10 +111,11 @@ cp [source-path] public/images/posts/[image-name].jpg
 # ![Alt text](/images/posts/[image-name].jpg)
 ```
 
-**Image Location Summary**:
+**File Location Summary**:
 
-- **Cover images**: `src/images/posts/` (webpack require())
-- **In-post images**: `public/images/posts/` (runtime URL serving)
+- **Cover image**: `src/images/posts/[post-slug].jpg` (webpack require(), must match slug)
+- **Interactive charts**: `public/charts/[post-slug]/simple-name.html` (organized by post)
+- **In-post images**: `public/images/posts/[image-name].jpg` (runtime URL serving)
 
 ## Step 5: Update posts.json
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "plugins": {
+    "autoInstall": {
+      "PolicyEngine/policyengine-claude": {
+        "source": "github",
+        "ref": "master"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds PolicyEngine Claude plugin auto-install configuration and enhances local .claude with blog post workflow improvements.

## Changes

**Plugin configuration:**
- Add `.claude/settings.json` to auto-install `PolicyEngine/policyengine-claude`
- Team members get all skills, agents, and commands automatically on repo open

**Blog workflow improvements:**
- Document chart organization: `public/charts/[post-slug]/simple-name.html`
- Cover image must match slug exactly
- Interactive chart iframe embedding guidance
- Update blog-post-reviewer with chart requirements

## Benefits

**For team:**
- Auto-access to 14 skills (design, writing, analysis, etc.)
- Auto-access to 18 agents (rules-engineer, test-creator, etc.)
- No manual plugin installation needed

**For blog posts:**
- Clear chart organization pattern
- Consistent file naming
- Better documentation of image/chart locations

These improvements emerged from creating the California billionaire tax blog post with 3 interactive Plotly charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)