### PR TITLE
Fix KeyError in social_card_tags by skipping posts without filename

### DIFF
--- a/gcp/social_card_tags.py
+++ b/gcp/social_card_tags.py
@@ -7,8 +7,11 @@ CUSTOM_TITLES = {"2024-manifestos": "UK 2024 Election Manifestos"}
 # Load src/posts/posts.json
 with open("src/posts/posts.json") as f:
     posts: list = json.load(f)
-    post_by_slug = {post["filename"].split(".")[0]: post for post in posts}
-
+    post_by_slug = {
+    post["filename"].split(".")[0]: post
+    for post in posts
+    if "filename" in post
+}
 
 def get_title(path: str, query_params: dict):
     # /{country}/page => 'PolicyEngine COUNTRY | Page'


### PR DESCRIPTION
## Description

This PR fixes a KeyError in gcp/social_card_tags.py that occurred when a post did not have a filename key. Previously, the script crashed if at least one post was missing this field.

The change ensures that posts without filename are safely skipped, preventing the social card tagging process from failing. This resolves issue [#2727](https://github.com/N-Yashwitha/policyengine-app_2nd_issue/issues/2727)

## Changes

Modified the dictionary comprehension in gcp/social_card_tags.py:

post_by_slug = {
    post["filename"].split(".")[0]: post
    for post in posts
    if "filename" in post
}
Only posts with a filename key are now processed.
No other functionality was modified.

## Screenshots

<img width="692" height="351" alt="Screenshot from 2025-10-26 19-55-32" src="https://github.com/user-attachments/assets/dbe48f8a-e33b-43b4-84a5-d01a7319e919" />

Previously, running python gcp/social_card_tags.py raised KeyError: 'filename'.
After this fix, the script runs successfully without crashing.

## Tests

Tested locally in Python virtual environment:
Activated venv: source venv/bin/activate
Installed dependencies: pip install beautifulsoup4 requests pyyaml
Ran script: python gcp/social_card_tags.py
Verified that posts missing filename are skipped.
Verified that posts with valid filename are processed correctly.
