### PR TITLE
Add critical CI check requirement to documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Before merging ANY PR:
 1. Run `gh pr checks [PR_NUMBER] --repo PolicyEngine/policyengine-app`
 2. Verify EVERY check shows "pass" (not "pending" or "fail")
 3. Wait if any checks are still "pending"
-4. Only merge when you see: `CI (22.x)	pass`, `Lint	pass`, `Vercel	pass`
+4. Only merge when you see: `CI pass`, `Lint pass`, `Vercel pass` (the CI check name may include a Node version like `CI (22.x)`)
 
 **If you merge before CI completes, you risk breaking production.**
 


### PR DESCRIPTION
## Summary

Adds prominent warnings to CLAUDE.md about NEVER merging PRs before CI checks complete.

## Changes

Added critical section at top of `CLAUDE.md`:
- Step-by-step verification process before merge
- Examples of correct vs incorrect merge workflow  
- Warning about production breakage risk

## Context

After merging PR #2786 before CI completed, adding explicit documentation to prevent this critical error in future AI-assisted workflows.

## Required Checks

The documentation specifies all required checks must show "pass":
- `CI (22.x) pass`
- `Lint pass`
- `Vercel pass`