### PR TITLE
Feature multi-agent workflows post in US

### DIFF
--- a/src/posts/posts.json
+++ b/src/posts/posts.json
@@ -1500,7 +1500,7 @@
     "title": "Testing multi-agent AI workflows for policy research",
     "description": "A multi-agent Claude Code system fared better on distributional analysis than benefit interactions; insights inform our forthcoming plugin.",
     "date": "2025-10-28",
-    "tags": ["uk", "featured", "technology", "ai"],
+    "tags": ["uk", "us", "featured", "technology", "ai"],
     "authors": ["vahid-ahmadi"],
     "filename": "multi-agent-workflows-policy-research.md",
     "image": "multi-agent-workflows-policy-research.png"


### PR DESCRIPTION
## Summary
- Added "us" tag to the "Testing multi-agent AI workflows for policy research" blog post to feature it on the US site in addition to the UK site

## Test plan
- [ ] Verify the post appears in the featured posts section on policyengine.org (US site)
- [ ] Verify the post still appears in the featured posts section on policyengine.org/uk (UK site)
- [ ] Confirm the post metadata is correctly displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)