### PR TITLE
Add stable to GCP handlers

### DIFF
--- a/gcp/app.yaml
+++ b/gcp/app.yaml
@@ -3,6 +3,7 @@ runtime: python311
 handlers:
   - url: /.*
     script: app.app
+    secure: always
 
 env_variables:
   FLASK_APP: app.py


### PR DESCRIPTION
Fixes #2802. Adds "stable: always" to GCP handlers to force redirect to SSL.