### PR TITLE
Update Node.js from 22 to 24 LTS

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
         # by our package.json.
         # Hopefully this allows us to catch problems
         # with differing versions ahead of time.
-        node-version: [22.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
       - name: Install repository
         run: npm ci
       - name: Run tests


### PR DESCRIPTION
## Summary

Update Node.js from 22.x to 24.x in CI workflows (pr.yml and push.yml).

- Node.js 24 is now the Active LTS version (Krypton)
- Node.js 22 moved to Maintenance LTS

## Test plan

- [ ] CI passes with Node.js 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)