### PR TITLE
Fix: the menu items are highlighted when the input values changes from default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ yarn-error.log*
 .idea
 
 venv/*
+
+.early.coverage

--- a/src/controls/SearchOptions.jsx
+++ b/src/controls/SearchOptions.jsx
@@ -24,7 +24,6 @@ export default function SearchOptions(props) {
       showSearch
       options={filteredOptions}
       optionFilterProp="children"
-      selectorBg={"red"}
       onSelect={(value) => {
         if (options.find((option) => option.value === value)) {
           setValue(value);
@@ -39,9 +38,12 @@ export default function SearchOptions(props) {
           onSearch(text);
         }
       }}
-      filterOption={(input, option) =>
-        (option?.label ?? "").toLowerCase().includes(input.toLowerCase())
-      }
+      filterOption={(input, option) => {
+        const label = option?.searchLabel ?? option?.label ?? "";
+        return (typeof label === "string" ? label : "")
+          .toLowerCase()
+          .includes(input.toLowerCase());
+      }}
       style={style || { width: 200, marginLeft: 10, marginRight: 10 }}
       placeholder={
         value

--- a/src/layout/Menu.jsx
+++ b/src/layout/Menu.jsx
@@ -34,6 +34,7 @@ function MenuItem(props) {
         style={{
           fontSize: 16,
           color: disabled && style.colors.DARK_GRAY,
+          fontWeight: props.modified ? "bold" : "normal",
           fontFamily: "Roboto Serif",
           margin: 5,
         }}
@@ -54,13 +55,17 @@ function MenuItem(props) {
         )}
         {selected === name ? "" : adjustedLabel || name.split(".").pop()}
         {isBeta && betaBadge}
+        {props.modified && (
+          <span style={{ marginLeft: 5, color: style.colors.BLUE }}>•</span>
+        )}
       </p>
     </motion.div>
   );
 }
 
 function MenuItemGroup(props) {
-  const { name, label, selected, children, onSelect, disabled } = props;
+  const { name, label, selected, children, onSelect, disabled, modified } =
+    props;
   const betaBadge = <Tag color={style.colors.TEAL_ACCENT}>BETA</Tag>;
   const isBeta = label.includes(" (experimental)");
   const adjustedLabel = isBeta ? label.slice(0, -14) : label;
@@ -97,6 +102,7 @@ function MenuItemGroup(props) {
             label={capitalize(child.label)}
             selected={selected}
             onSelect={onSelect}
+            modified={child.modified}
           >
             {child.children}
           </MenuItemGroup>,
@@ -110,6 +116,7 @@ function MenuItemGroup(props) {
             label={capitalize(child.label)}
             selected={selected}
             onSelect={onSelect}
+            modified={child.modified}
           />,
         );
       }
@@ -144,7 +151,14 @@ function MenuItemGroup(props) {
         }}
         whileHover={!disabled && { backgroundColor: "white" }}
       >
-        <p style={{ fontSize: 16, fontFamily: "Roboto Serif", margin: 5 }}>
+        <p
+          style={{
+            fontSize: 16,
+            fontFamily: "Roboto Serif",
+            margin: 5,
+            fontWeight: modified ? "bold" : "normal",
+          }}
+        >
           {selected === name && (
             <span
               style={{
@@ -159,6 +173,9 @@ function MenuItemGroup(props) {
           )}
           {selected === name ? "" : adjustedLabel || name.split(".").pop()}
           {isBeta && betaBadge}
+          {modified && (
+            <span style={{ marginLeft: 5, color: style.colors.BLUE }}>•</span>
+          )}
         </p>
       </motion.div>
       {expandedComponentSpace}
@@ -180,6 +197,7 @@ export default function Menu(props) {
           label={capitalize(item.label)}
           selected={selected || ""}
           onSelect={onSelect}
+          modified={item.modified}
         >
           {item.children}
         </MenuItemGroup>,
@@ -193,6 +211,7 @@ export default function Menu(props) {
           label={item.label}
           selected={selected || ""}
           onSelect={onSelect}
+          modified={item.modified}
         />,
       );
     }

--- a/src/pages/HouseholdPage.jsx
+++ b/src/pages/HouseholdPage.jsx
@@ -399,7 +399,12 @@ export default function HouseholdPage(props) {
             ? "Household impact"
             : "Household variables"
         }
-        middle={<HouseholdLeftSidebar metadata={metadata} />}
+        middle={
+          <HouseholdLeftSidebar
+            metadata={metadata}
+            householdInput={householdInput}
+          />
+        }
         right={middle}
         left={
           <HouseholdRightSidebar
@@ -443,15 +448,21 @@ function HouseholdLeftSidebar(props) {
     metadata.countryId,
   );
 
+  const modifiedNames = getModifiedVariableNames(
+    props.householdInput,
+    metadata,
+  );
+  const modifiedTree = markTreeModified(displayTree, modifiedNames);
+
   return (
     <div>
       {!isOnOutput && (
         <div style={{ padding: 10 }}>
-          <VariableSearch metadata={metadata} />
+          <VariableSearch metadata={metadata} modifiedNames={modifiedNames} />
         </div>
       )}
       <StackedMenu
-        firstTree={displayTree}
+        firstTree={modifiedTree}
         selected={selected}
         onSelect={onSelect}
         secondTree={HOUSEHOLD_OUTPUT_TREE[0].children}
@@ -596,4 +607,103 @@ export function getHouseholdYear(householdInput) {
     return householdYearArr[0];
   }
   return defaultYear;
+}
+
+function getModifiedVariableNames(householdInput, metadata) {
+  if (!householdInput) return new Set();
+  const modified = new Set();
+  const variables = metadata.variables;
+  const householdYear = getHouseholdYear(householdInput);
+
+  for (const entityPlural in householdInput) {
+    for (const entity in householdInput[entityPlural]) {
+      for (const variable in householdInput[entityPlural][entity]) {
+        if (!(variable in variables)) continue;
+        const currentVal =
+          householdInput[entityPlural][entity][variable][householdYear];
+        const defaultVal = variables[variable].defaultValue;
+
+        if (currentVal !== defaultVal) {
+          if (currentVal === null && defaultVal !== null) {
+            continue;
+          }
+          if (currentVal !== null) {
+            // Suppress "modified" status for default values of added entities (spouse/children)
+            if (variable === "age") {
+              if (entity === "your partner" && Number(currentVal) === 40) {
+                continue;
+              }
+              // Child defaults are 10
+              if (
+                entity !== "you" &&
+                entity !== "your partner" &&
+                Number(currentVal) === 10
+              ) {
+                continue;
+              }
+            }
+
+            modified.add(variable);
+          }
+        }
+      }
+    }
+  }
+
+  // Special Handling due to structural changes not captured by variable logic alone
+
+  // Tax Year: menu item 'input.household.taxYear' -> 'taxYear'
+  if (Number(householdYear) !== Number(defaultYear)) {
+    modified.add("taxYear");
+  }
+
+  // Marital Status
+  // Logic: If 'marital_status' variable changed (captured above), OR if 'your partner' exists in people
+  if (householdInput.people && householdInput.people["your partner"]) {
+    modified.add("maritalStatus");
+  }
+  // Map 'marital_status' (variable) to 'maritalStatus' (menu item)
+  if (modified.has("marital_status")) {
+    modified.add("maritalStatus");
+  }
+
+  // Children
+  // Logic: If there are people other than 'you' and 'your partner'
+  if (householdInput.people) {
+    const hasChildren = Object.keys(householdInput.people).some(
+      (key) => key !== "you" && key !== "your partner",
+    );
+    if (hasChildren) {
+      modified.add("children");
+    }
+  }
+
+  // County
+  // Map 'county' (variable) to 'countyName' (menu item)
+  if (modified.has("county")) {
+    modified.add("countyName");
+  }
+
+  return modified;
+}
+
+function markTreeModified(tree, modifiedNames) {
+  return tree.map((node) => {
+    let isModified = false;
+    let children = null;
+
+    if (node.children) {
+      children = markTreeModified(node.children, modifiedNames);
+      isModified = children.some((child) => child.modified);
+    } else {
+      const varName = node.name.split(".").pop();
+      isModified = modifiedNames.has(varName);
+    }
+
+    return {
+      ...node,
+      children,
+      modified: isModified,
+    };
+  });
 }

--- a/src/pages/household/VariableSearch.jsx
+++ b/src/pages/household/VariableSearch.jsx
@@ -3,20 +3,39 @@ import { copySearchParams } from "../../api/call";
 import SearchOptions from "../../controls/SearchOptions";
 
 export default function VariableSearch(props) {
-  const { metadata, callback } = props;
+  const { metadata, callback, modifiedNames } = props;
   const [searchParams, setSearchParams] = useSearchParams();
   const showComputed = searchParams.get("showComputedVariables") === "true";
   const options = Object.values(metadata.variables)
     .filter((variable) => !variable.hidden_input)
     .filter((variable) => showComputed || variable.isInputVariable)
-    .map((variable) => ({
-      value: variable.moduleName + "." + variable.name,
-      label: variable.label,
-    }))
-    .filter((option) => !!option.label && !!option.value);
+    .map((variable) => {
+      const isModified = modifiedNames && modifiedNames.has(variable.name);
+      return {
+        value: variable.moduleName + "." + variable.name,
+        label: isModified ? (
+          <span style={{ fontWeight: "bold" }}>
+            {variable.label} <span style={{ color: "#1890ff" }}>•</span>
+          </span>
+        ) : (
+          variable.label
+        ),
+        searchLabel: variable.label,
+      };
+    })
+    .filter((option) => !!option.searchLabel && !!option.value);
+
+  const countyModified = modifiedNames && modifiedNames.has("countyName");
   options.push({
     value: "input.household.countyName",
-    label: "County name",
+    label: countyModified ? (
+      <span style={{ fontWeight: "bold" }}>
+        County name <span style={{ color: "#1890ff" }}>•</span>
+      </span>
+    ) : (
+      "County name"
+    ),
+    searchLabel: "County name",
   });
   return (
     <SearchOptions


### PR DESCRIPTION
## Description : Highlight modified parameters in menu and search

Adds visual indicators for household variables that differ from defaults. Modified items are now highlighted in the menu with bold text and a blue dot.

Fixes #50

## Changes:

- Detect modified variables by comparing inputs with defaults and propagating state through the navigation tree.
- Update menu rendering to visually mark modified items.

## Video for changes made
[highlighted_menus](https://drive.google.com/file/d/1PazETXf2AROJ_ZA7fNt71doxIZLtrNxO/view?usp=sharing)

## Tests

![WhatsApp Image 2025-12-16 at 3 54 38 PM](https://github.com/user-attachments/assets/2b165788-b1e6-4757-839b-5bdcbce763d5)

passed all the existing test cases. UI works properly, tested manually as shown in video
