### PR TITLE
Add 2025 Year in Review app embedding

### DIFF
--- a/src/apps/apps.json
+++ b/src/apps/apps.json
@@ -33,5 +33,12 @@
     "url": "https://frontend-neon-seven.vercel.app/",
     "slug": "rhode-island-ctc-calculator",
     "tags": ["us", "policy"]
+  },
+  {
+    "title": "2025 Year in Review",
+    "description": "Interactive exploration of PolicyEngine's 2025 achievements, impact, and milestones",
+    "url": "https://policyengine.github.io/2025-year-in-review",
+    "slug": "2025-year-in-review",
+    "tags": ["us", "uk", "featured"]
   }
 ]

--- a/src/pages/AppPage.jsx
+++ b/src/pages/AppPage.jsx
@@ -6,7 +6,7 @@ import { Helmet } from "react-helmet";
 import { useEffect, useRef, useState } from "react";
 
 export default function AppPage() {
-  const { appName } = useParams();
+  const { appName, countryId } = useParams();
   const location = useLocation();
   const navigate = useNavigate();
   const iframeRef = useRef(null);
@@ -15,6 +15,8 @@ export default function AppPage() {
 
   // Check if this is an OBBBA app that needs special handling
   const isOBBBAApp = app?.slug === "obbba-household-by-household";
+  // Check if this is the year-in-review app that needs country context
+  const isYearInReviewApp = app?.slug === "2025-year-in-review";
   const [initialUrl, setInitialUrl] = useState(null);
 
   // Construct iframe URL with parameters (for OBBBA app only on initial load)
@@ -31,11 +33,22 @@ export default function AppPage() {
         : baseUrl;
 
       setInitialUrl(url);
-    } else if (!isOBBBAApp) {
-      // For non-OBBBA apps, just use the app URL
+    } else if (isYearInReviewApp && !initialUrl) {
+      // Year-in-review app uses path-based routing for country (e.g., /uk or /us)
+      const country = countryId || "us";
+      setInitialUrl(`${app.url}/${country}`);
+    } else if (!isOBBBAApp && !isYearInReviewApp) {
+      // For other apps, just use the app URL
       setInitialUrl(app.url);
     }
-  }, [app, location.search, initialUrl, isOBBBAApp]);
+  }, [
+    app,
+    location.search,
+    initialUrl,
+    isOBBBAApp,
+    isYearInReviewApp,
+    countryId,
+  ]);
 
   // Listen for messages from OBBBA iframe
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add year-in-review entry to apps.json with slug "2025-year-in-review"
- Modify AppPage to pass country context to year-in-review app
- Enables policyengine.org/uk/2025-year-in-review and /us/2025-year-in-review routes

The 2025 Year in Review interactive is deployed to GitHub Pages at policyengine.github.io/2025-year-in-review. This PR embeds it into the main PolicyEngine app so it's accessible at policyengine.org/uk/2025-year-in-review and /us/2025-year-in-review.

## Test plan
- [ ] Verify /uk/2025-year-in-review loads UK content
- [ ] Verify /us/2025-year-in-review loads US content
- [ ] Verify existing apps still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)