### PR TITLE
Use British spelling for UK LSR parameter paths

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,3 +2,4 @@
   changes:
     changed:
       - Added household-level impact analysis by pension contributions to UK income tax and NI reforms blog post
+      - Updated UK LSR parameter paths to use British spelling (`labour_supply_responses`) to match policyengine-uk rename.

--- a/src/pages/policy/PolicyRightSidebar.jsx
+++ b/src/pages/policy/PolicyRightSidebar.jsx
@@ -111,10 +111,10 @@ function BehavioralResponseToggle(props) {
   const behavioralResponseReforms = useMemo(
     () => ({
       uk: {
-        "gov.simulation.labor_supply_responses.income_elasticity": {
+        "gov.simulation.labour_supply_responses.income_elasticity": {
           [dateString]: -0.05,
         },
-        "gov.simulation.labor_supply_responses.substitution_elasticity": {
+        "gov.simulation.labour_supply_responses.substitution_elasticity": {
           [dateString]: 0.25,
         },
       },


### PR DESCRIPTION
## Summary
- Companion to PolicyEngine/policyengine-uk#1607, which renames `gov.simulation.labor_supply_responses.*` → `gov.simulation.labour_supply_responses.*` in the UK repo.
- Updates the two UK-only path strings in `PolicyRightSidebar.jsx` (`income_elasticity`, `substitution_elasticity`) so the LSR sliders keep resolving after the UK rename lands.
- US paths (`elasticities.*`) are untouched — those live in `policyengine-us` and aren't being renamed.

## Coordination
Merge order matters: this PR should land **immediately before or after** policyengine-uk#1607 to minimize the window where one side disagrees with the other. Safer sequence:
1. Merge this PR first so the app expects the new paths.
2. Merge policyengine-uk#1607, then bump `policyengine-uk` in the app.

## Test plan
- [ ] Run the app against a policyengine-uk build with the rename applied and confirm the LSR toggle still adds both elasticity parameters to the policy.
- [ ] Confirm no regressions to the US LSR flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)