### PR TITLE
Fix #2845: emit certified populace-us URI in Reproduce-in-Python snippets

### DIFF
--- a/src/__tests__/data/reformDefinitionCode.test.js
+++ b/src/__tests__/data/reformDefinitionCode.test.js
@@ -7,6 +7,7 @@ import {
   getImplementationCode,
   sanitizeStringToPython,
 } from "data/reformDefinitionCode";
+import { POPULACE_US_DEFAULT_DATASET_URI } from "data/countries";
 import {
   baselinePolicyUS,
   baselinePolicyUK,
@@ -262,7 +263,7 @@ describe("Test getImplementationCode", () => {
     expect(output).toBeInstanceOf(Array);
     expect(output).toContain("baseline = Microsimulation(reform=baseline)");
   });
-  test("If US state, return lines with pooled 3-year CPS dataset", () => {
+  test("If US state, return lines with the certified populace-us dataset", () => {
     let testPolicy = JSON.parse(JSON.stringify(baselinePolicyUS));
     testPolicy = {
       ...testPolicy,
@@ -286,10 +287,10 @@ describe("Test getImplementationCode", () => {
     );
     expect(output).toBeInstanceOf(Array);
     expect(output).toContain(
-      'baseline = Microsimulation(dataset="hf://policyengine/policyengine-us-data/pooled_3_year_cps_2023.h5")',
+      `baseline = Microsimulation(dataset="${POPULACE_US_DEFAULT_DATASET_URI}")`,
     );
     expect(output).toContain(
-      'reformed = Microsimulation(reform=reform, dataset="hf://policyengine/policyengine-us-data/pooled_3_year_cps_2023.h5")',
+      `reformed = Microsimulation(reform=reform, dataset="${POPULACE_US_DEFAULT_DATASET_URI}")`,
     );
   });
   test("If dataset provided, return lines with dataset", () => {
@@ -303,10 +304,10 @@ describe("Test getImplementationCode", () => {
     );
     expect(output).toBeInstanceOf(Array);
     expect(output).toContain(
-      'baseline = Microsimulation(dataset="hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5")',
+      `baseline = Microsimulation(dataset="${POPULACE_US_DEFAULT_DATASET_URI}")`,
     );
   });
-  test("If dataset provided alongside US state, return lines with dataset, not Pooled 3-Year CPS", () => {
+  test("If dataset provided alongside US state, return lines with dataset, not the state fallback", () => {
     const output = getImplementationCode(
       "policy",
       "ks",
@@ -317,7 +318,7 @@ describe("Test getImplementationCode", () => {
     );
     expect(output).toBeInstanceOf(Array);
     expect(output).toContain(
-      'baseline = Microsimulation(dataset="hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5")',
+      `baseline = Microsimulation(dataset="${POPULACE_US_DEFAULT_DATASET_URI}")`,
     );
   });
 });

--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -53,12 +53,21 @@ export const STATUS_TEXT_COLORS = {
   Pending: colors.BLACK,
 };
 
+// The certified populace-us dataset that policyengine.py resolves as its
+// default US microdata (see src/policyengine/data/bundle/manifest.json's
+// data_releases.us.default_dataset_uri in PolicyEngine/policyengine.py).
+// This pins the certified revision so "Reproduce in Python" snippets stay
+// byte-reproducible; bump the revision suffix when populace-us is
+// re-certified (see PolicyEngine/populace#204 for the migration history).
+export const POPULACE_US_DEFAULT_DATASET_URI =
+  "hf://policyengine/populace-us/populace_us_2024.h5@populace-us-2024-sparse-l0-refit-57k-71a0887-national-only-20260701";
+
 // Map dataset keywords to their equivalents
 // in the actual US package; at the moment,
 // this only applies to the "enhanced_cps"
 // dataset selection
 export const DEFAULT_DATASETS = {
-  enhanced_cps: "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5",
+  enhanced_cps: POPULACE_US_DEFAULT_DATASET_URI,
 };
 
 const DEFAULT_US_HOUSEHOLD = {

--- a/src/data/reformDefinitionCode.js
+++ b/src/data/reformDefinitionCode.js
@@ -1,6 +1,6 @@
 import { optimiseHousehold } from "../api/variables";
 import { defaultYear } from "./constants";
-import { DEFAULT_DATASETS } from "./countries";
+import { DEFAULT_DATASETS, POPULACE_US_DEFAULT_DATASET_URI } from "./countries";
 import { wrappedJsonStringify } from "./wrappedJson";
 
 export function getReproducibilityCodeBlock(
@@ -184,8 +184,10 @@ export function getImplementationCode(
   if (hasDatasetSpecified) {
     datasetText = DEFAULT_DATASETS[dataset];
   } else if (isState) {
-    datasetText =
-      "hf://policyengine/policyengine-us-data/pooled_3_year_cps_2023.h5";
+    // State-level runs use the same certified populace-us national dataset;
+    // state regions scope it by state_fips rather than shipping a separate
+    // state-level file (see PolicyEngine/populace#204).
+    datasetText = POPULACE_US_DEFAULT_DATASET_URI;
   }
 
   const datasetSpecifier = datasetText ? `dataset="${datasetText}"` : "";


### PR DESCRIPTION
## Summary

Fixes #2845. The live "Reproduce in Python" code generator (`src/data/reformDefinitionCode.js`) hardcoded archived `hf://policyengine/policyengine-us-data/...` Hugging Face URIs for US state-level and `enhanced_cps` runs. `policyengine-us-data` is deprecated/archived — users copying these snippets from policyengine.org were pointed at an uncertified dataset that `policyengine.py` no longer resolves as its default.

This swaps both hardcoded URIs for the certified `populace-us` dataset that `policyengine.py`'s bundle manifest (`src/policyengine/data/bundle/manifest.json`, `data_releases.us.default_dataset_uri`) actually resolves today, and centralizes the URI as a single named export (`POPULACE_US_DEFAULT_DATASET_URI` in `src/data/countries.js`) so both call sites and the test suite share one source of truth.

Found during the [populace#204 artifact-replacement audit](https://github.com/PolicyEngine/populace/issues/204#issuecomment-4895964656), which named `src/data/reformDefinitionCode.js:188` and `src/data/countries.js:61` explicitly as live production hardcodes. The prior tracking issue (#2828) was closed as "moved to policyengine-app-v2" without a v1 fix ever being filed — that's what #2845 re-opens for this repo.

## Before / after

**US state-level policy run** (e.g. California), previously fell back to a pooled-CPS file that no longer represents the certified default:

```diff
- baseline = Microsimulation(dataset="hf://policyengine/policyengine-us-data/pooled_3_year_cps_2023.h5")
- reformed = Microsimulation(reform=reform, dataset="hf://policyengine/policyengine-us-data/pooled_3_year_cps_2023.h5")
+ baseline = Microsimulation(dataset="hf://policyengine/populace-us/populace_us_2024.h5@populace-us-2024-sparse-l0-refit-57k-71a0887-national-only-20260701")
+ reformed = Microsimulation(reform=reform, dataset="hf://policyengine/populace-us/populace_us_2024.h5@populace-us-2024-sparse-l0-refit-57k-71a0887-national-only-20260701")
```

**National run with the "enhanced_cps" dataset selected**:

```diff
- baseline = Microsimulation(dataset="hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5")
+ baseline = Microsimulation(dataset="hf://policyengine/populace-us/populace_us_2024.h5@populace-us-2024-sparse-l0-refit-57k-71a0887-national-only-20260701")
```

## URI-form decision: pinned to the certified revision, not tracking `main`

The replacement URI includes an `@populace-us-2024-sparse-l0-refit-57k-71a0887-national-only-20260701` revision suffix rather than a bare `hf://policyengine/populace-us/populace_us_2024.h5`. This is a deliberate choice, not an oversight:

- **This is what `policyengine.py` itself resolves.** `CountryReleaseManifest.default_dataset_uri` (`src/policyengine/provenance/manifest.py`) returns `certified_data_artifact.uri` when the certified artifact matches the default dataset — and that URI is always the pinned `@revision` form, verified against both `policyengine.py`'s checked-in `manifest.json` and its own test suite (`tests/test_us_regions.py`, `tests/test_models.py`), which assert the full pinned string as the resolved value. There is no "unpinned/latest-tracking" form anywhere in `policyengine.py`'s actual resolution path — pinning is what "the populace default that policyengine.py actually resolves" means concretely.
- **The feature's own purpose demands it.** `PolicyReproducibility.jsx`/`HouseholdReproducibility.jsx` render this snippet under the heading "Reproduce these results," generated fresh on every page view for the results the user is looking at *right now*. A revision-pinned URI gives byte-identical reproduction of that specific dataset; a bare/tracking URI would silently resolve to whatever HF's `main` branch holds by the time the user runs the copied snippet, which could be a different (or not-yet-existing) file.
- **It matches the existing maintenance model.** The code being replaced was already a hardcoded literal string (`enhanced_cps_2024.h5`, `pooled_3_year_cps_2023.h5`), bumped manually as datasets changed — this PR keeps that same pattern, just pointing at the current certified value. A follow-up PR bumping `POPULACE_US_DEFAULT_DATASET_URI` when populace-us is re-certified to a new revision is the same maintenance cost as before, now centralized in one constant instead of duplicated across two files.

One discrepancy surfaced during this investigation, flagged for visibility but out of scope here: `policyengine-us`'s own `system.py:49` `DEFAULT_DATASET` constant is still pinned to an older revision (`c86a631-6e1bcd0271a5-20260619T002242Z`, 2026-06-19) than `policyengine.py`'s bundle manifest (`sparse-l0-refit-57k-71a0887-national-only-20260701`, 2026-07-01) — both point at the same repo/file, just different certified builds. This PR follows the `policyengine.py` manifest value since that's the client this app's generated code targets.

## Scope

Swept all of `src/` (excluding `src/posts/`, which is historical blog content covered separately by #2659) for other `policyengine-us-data` references. Found and fixed exactly two call sites, both now covered by the shared constant:

- `src/data/reformDefinitionCode.js` — `getImplementationCode()`'s US-state fallback branch
- `src/data/countries.js` — `DEFAULT_DATASETS.enhanced_cps`

No other live code path references the archived repo after this change (verified with a repo-wide grep).

## Changelog

This repo's `changelog_entry.yaml` is no longer wired into any CI workflow or Makefile target (checked `.github/workflows/`, `Makefile`) — the last several merged PRs (#2842, #2841, #2821, #2820, #2817) didn't touch it either, and the file at HEAD still carries a stale entry from an already-merged, already-released PR. Following current repo practice, this PR does not add a changelog entry.

## Test plan

- [x] Lint with zero-warnings tolerance (ESLint `--max-warnings 0` + Prettier check, matching CI) — exit 0, zero warnings repo-wide
- [x] Prettier write pass — all touched files already Prettier-compliant, no changes needed
- [x] Jest run of `src/__tests__/data/reformDefinitionCode.test.js` with `--verbose` — 23/23 tests passed, exit 0, including the 3 tests updated to assert the new URI
- [x] Jest run scoped to `data` test paths — 24/24 tests passed across `countries.test.js` + `reformDefinitionCode.test.js`, exit 0
- [x] Repo-wide grep confirms zero remaining `policyengine-us-data` references outside `src/posts/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
